### PR TITLE
Export directory

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Properties/Settings.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace BxDRobotExporter.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -68,6 +68,18 @@ namespace BxDRobotExporter.Properties {
             }
             set {
                 this["FancyColors"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int ConfigVersion {
+            get {
+                return ((int)(this["ConfigVersion"]));
+            }
+            set {
+                this["ConfigVersion"] = value;
             }
         }
     }

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Properties/Settings.settings
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Properties/Settings.settings
@@ -14,5 +14,8 @@
     <Setting Name="FancyColors" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ConfigVersion" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
@@ -648,6 +648,7 @@ namespace BxDRobotExporter
             Properties.Settings.Default.ChildColor = Child;
             Properties.Settings.Default.FancyColors = UseFancyColors;
             Properties.Settings.Default.SaveLocation = SaveLocation;
+            Properties.Settings.Default.ConfigVersion = 1; // Update this config version number when changes are made to the exporter which require settings to be reset or changed when the exporter starts
             Properties.Settings.Default.Save();
         } 
         #endregion

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Utilities.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Utilities.cs
@@ -128,7 +128,7 @@ namespace BxDRobotExporter
         public static void LoadSettings()
         {
             if (Properties.Settings.Default.SaveLocation == "" || Properties.Settings.Default.SaveLocation == "firstRun")
-                Properties.Settings.Default.SaveLocation = System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments) + @"\Synthesis\Robots";
+                Properties.Settings.Default.SaveLocation = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData) + @"\Synthesis\Robots";
             SynthesisGUI.PluginSettings = EditorsLibrary.PluginSettingsForm.Values = new EditorsLibrary.PluginSettingsForm.PluginSettingsValues
             {
                 InventorChildColor = Properties.Settings.Default.ChildColor,

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Utilities.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Utilities.cs
@@ -127,8 +127,10 @@ namespace BxDRobotExporter
         /// </summary>
         public static void LoadSettings()
         {
-            if (Properties.Settings.Default.SaveLocation == "" || Properties.Settings.Default.SaveLocation == "firstRun")
+            // Old configurations get overriden (version numbers below 1)
+            if (Properties.Settings.Default.SaveLocation == "" || Properties.Settings.Default.SaveLocation == "firstRun" || Properties.Settings.Default.ConfigVersion < 1 )
                 Properties.Settings.Default.SaveLocation = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData) + @"\Synthesis\Robots";
+
             SynthesisGUI.PluginSettings = EditorsLibrary.PluginSettingsForm.Values = new EditorsLibrary.PluginSettingsForm.PluginSettingsValues
             {
                 InventorChildColor = Properties.Settings.Default.ChildColor,

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/OneClickExport/OneClickExportForm.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/OneClickExport/OneClickExportForm.cs
@@ -55,7 +55,7 @@ namespace BxDRobotExporter.Wizard
         /// <param name="e"></param>
         private void OneClickExportForm_Load(object sender, EventArgs e)
         {
-            var dirs = Directory.GetDirectories(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + @"\synthesis\fields");
+            var dirs = Directory.GetDirectories(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Synthesis\Fields");
             foreach (var dir in dirs)
             {
                 fields.Add(dir.Split(new char[] { '\\' }, StringSplitOptions.RemoveEmptyEntries).Last(), dir);

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ReviewAndFinishPage.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ReviewAndFinishPage.cs
@@ -58,7 +58,7 @@ namespace BxDRobotExporter.Wizard
         /// </summary>
         public void Initialize()
         {
-            var dirs = Directory.GetDirectories(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + @"\synthesis\fields");
+            var dirs = Directory.GetDirectories(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Synthesis\Fields");
 
             foreach (var dir in dirs)
             {

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/ExporterSettingsForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/ExporterSettingsForm.cs
@@ -70,7 +70,7 @@ namespace EditorsLibrary
             {
                 InventorChildColor = Color.FromArgb(255, 0, 125, 255),
                 GeneralUseFancyColors = false,
-                GeneralSaveLocation = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + @"\Synthesis\Robots"
+                GeneralSaveLocation = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Synthesis\Robots"
             };
         }
 


### PR DESCRIPTION
Changed the default directory for exporting robots to "User\AppData\Roaming\Synthesis\Robots" instead of "User\Documents\Synthesis\Robots". This way it matches the default directory that Synthesis checks.

Stores a version number is settings so that users that are updating the plugin will automatically have the export directory overridden to the new folder.