### PR TITLE
Disabled LiteExporterForm Resizability

### DIFF
--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/LiteExporterForm.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/LiteExporterForm.Designer.cs
@@ -59,7 +59,7 @@
             this.ProgressLabel.AutoSize = true;
             this.ProgressLabel.Location = new System.Drawing.Point(13, 373);
             this.ProgressLabel.Name = "ProgressLabel";
-            this.ProgressLabel.Size = new System.Drawing.Size(54, 13);
+            this.ProgressLabel.Size = new System.Drawing.Size(73, 17);
             this.ProgressLabel.TabIndex = 2;
             this.ProgressLabel.Text = "Progress: ";
             // 
@@ -89,7 +89,9 @@
             this.Controls.Add(this.ProgressLabel);
             this.Controls.Add(this.ProgressBar);
             this.Controls.Add(this.LoadingAnimation);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MaximizeBox = false;
             this.Name = "LiteExporterForm";
             this.Text = "Exporting Meshes...";
             ((System.ComponentModel.ISupportInitialize)(this.LoadingAnimation)).EndInit();


### PR DESCRIPTION
This disables the resizability of the exporter loading form as requested in AARD-474.

Ensure you're running Visual Studio as Administrator.

Theoretically speaking, this should work...