### PR TITLE
increased speed of mix and match scroll function

### DIFF
--- a/engine/unity5/Assets/Scripts/MixAndMatch/MixAndMatchScroll.cs
+++ b/engine/unity5/Assets/Scripts/MixAndMatch/MixAndMatchScroll.cs
@@ -28,10 +28,11 @@ using UnityEngine.UI;
     void Update()
         {
             float distance = gameObject.GetComponent<RectTransform>().anchoredPosition.x - TargetPosition.x;
-
+            float speed = 15.4f; //max
+        
             if (gameObject.activeSelf == true && Math.Abs(distance) > 6)
             {
-                gameObject.GetComponent<RectTransform>().anchoredPosition = (gameObject.GetComponent<RectTransform>().anchoredPosition.x - TargetPosition.x > 0) ? (Vector3)gameObject.GetComponent<RectTransform>().anchoredPosition + new Vector3(-6f, 0f, 0f) : (Vector3)gameObject.GetComponent<RectTransform>().anchoredPosition + new Vector3(6f, 0f, 0f);
+                gameObject.GetComponent<RectTransform>().anchoredPosition = (gameObject.GetComponent<RectTransform>().anchoredPosition.x - TargetPosition.x > 0) ? (Vector3)gameObject.GetComponent<RectTransform>().anchoredPosition + new Vector3(-speed, 0f, 0f) : (Vector3)gameObject.GetComponent<RectTransform>().anchoredPosition + new Vector3(speed, 0f, 0f);
             } else
             {
             Destroy(this);


### PR DESCRIPTION
Increased horizontal scroll speed by 2.5 times when choosing parts in mix and match mode.

Jira issue: https://jira.autodesk.com/browse/AARD-374