### PR TITLE
Added keybind and button for resetting the field

### DIFF
--- a/engine/unity5/Assets/Scene.unity
+++ b/engine/unity5/Assets/Scene.unity
@@ -11889,6 +11889,8 @@ MonoBehaviour:
       m_Image: {fileID: 21300000, guid: 0b46a02922478d04d856febaaee26ec7, type: 3}
     - m_Text: Reset Spawn Point
       m_Image: {fileID: 21300000, guid: 0b46a02922478d04d856febaaee26ec7, type: 3}
+    - m_Text: Reset Field
+      m_Image: {fileID: 21300000, guid: 0b46a02922478d04d856febaaee26ec7, type: 3}
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
@@ -37613,7 +37615,9 @@ MonoBehaviour:
 
     Long hold R or other RESET key: configure spawnpoint and robot orientation
 
-    ALT + LEFT MOUSE: Click and drag gamepieces around (God Mode)
+    F: reset field
+
+    ALT + LEFT MOUSE: click and drag gamepieces around (God Mode)
 
     U: Spawn a new robot
 
@@ -37625,7 +37629,7 @@ MonoBehaviour:
 
     ] : Spawn secondary gamepiece
 
-    ESCAPE: Exit to main menu'
+    ESCAPE: exit to main menu'
 --- !u!222 &1102676361
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -63418,7 +63422,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
   m_AnchoredPosition: {x: -23, y: -24.099998}
-  m_SizeDelta: {x: 153.9, y: 66.3}
+  m_SizeDelta: {x: 153.9, y: 96.15}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &1941047082
 MonoBehaviour:
@@ -65092,7 +65096,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Reset Robot
+  m_Text: Reset
 --- !u!222 &2002520315
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/engine/unity5/Assets/Scripts/GUI/SimUI.cs
+++ b/engine/unity5/Assets/Scripts/GUI/SimUI.cs
@@ -572,6 +572,12 @@ public class SimUI : MonoBehaviour
                 main.BeginRobotReset();
                 resetDropdown.GetComponent<Dropdown>().value = 0;
                 break;
+            case 3:
+                AuxFunctions.FindObject(GameObject.Find("Reset Robot Dropdown"), "Dropdown List").SetActive(false);
+                AuxFunctions.FindObject(GameObject.Find("Canvas"), "LoadingPanel").SetActive(true);
+                SceneManager.LoadScene("Scene");
+                resetDropdown.GetComponent<Dropdown>().value = 0;
+                break;
         }
     }
     #endregion

--- a/engine/unity5/Assets/Scripts/InputControl/Controls.cs
+++ b/engine/unity5/Assets/Scripts/InputControl/Controls.cs
@@ -70,6 +70,7 @@ public class Controls
 
         //Other controls
         public KeyMapping resetRobot;
+        public KeyMapping resetField;
         public KeyMapping cameraToggle;
         //public KeyMapping replayMode;
         public KeyMapping pickupPrimary;
@@ -345,6 +346,7 @@ public class Controls
 
         //Other Controls
         buttons[0].resetRobot = InputControl.setKey("1: Reset Robot", PlayerOneIndex, KeyCode.R, new JoystickInput(JoystickButton.Button8, Joystick.Joystick1), false);
+        buttons[0].resetField = InputControl.setKey("1: Reset Field", PlayerOneIndex, KeyCode.F, new JoystickInput(JoystickButton.Button9, Joystick.Joystick1), false);
         buttons[0].cameraToggle = InputControl.setKey("1: Camera Toggle", PlayerOneIndex, KeyCode.C, new JoystickInput(JoystickButton.Button7, Joystick.Joystick1), false);
         //buttons[0].replayMode = InputControl.setKey("1: Replay Mode", PlayerOneIndex, KeyCode.Tab, new JoystickInput(JoystickButton.Button6, Joystick.Joystick1), false);
         buttons[0].pickupPrimary = InputControl.setKey("1: Pick Up Primary Gamepiece", PlayerOneIndex, KeyCode.LeftControl, new JoystickInput(JoystickButton.Button3, Joystick.Joystick1), false);
@@ -396,6 +398,7 @@ public class Controls
         
         //Other Controls
         buttons[1].resetRobot = InputControl.setKey("2: Reset Robot", PlayerTwoIndex, new JoystickInput(JoystickButton.Button8, Joystick.Joystick2), false);
+        buttons[1].resetField = InputControl.setKey("2: Reset Field", PlayerTwoIndex, new JoystickInput(JoystickButton.Button9, Joystick.Joystick2), false);
         buttons[1].cameraToggle = InputControl.setKey("2: Camera Toggle", PlayerTwoIndex, new JoystickInput(JoystickButton.Button7, Joystick.Joystick2), false);
         //buttons[1].replayMode = InputControl.setKey("2: Replay Mode", PlayerTwoIndex, KeyCode.Tab, new JoystickInput(JoystickButton.Button6, Joystick.Joystick1), false);
         buttons[1].pickupPrimary = InputControl.setKey("2: Pick Up Primary Gamepiece", PlayerTwoIndex, new JoystickInput(JoystickButton.Button3, Joystick.Joystick2), false);
@@ -447,6 +450,7 @@ public class Controls
 
         //Other Controls
         buttons[2].resetRobot = InputControl.setKey("3: Reset Robot", PlayerThreeIndex, new JoystickInput(JoystickButton.Button8, Joystick.Joystick3), false);
+        buttons[2].resetField = InputControl.setKey("3: Reset Field", PlayerThreeIndex, new JoystickInput(JoystickButton.Button9, Joystick.Joystick3), false);
         buttons[2].cameraToggle = InputControl.setKey("3: Camera Toggle", PlayerThreeIndex, new JoystickInput(JoystickButton.Button7, Joystick.Joystick3), false);
         //buttons[2].replayMode = InputControl.setKey("3: Replay Mode", PlayerThreeIndex, KeyCode.Tab, new JoystickInput(JoystickButton.Button6, Joystick.Joystick1), false);
         buttons[2].pickupPrimary = InputControl.setKey("3: Pick Up Primary Gamepiece", PlayerThreeIndex, new JoystickInput(JoystickButton.Button3, Joystick.Joystick3), false);
@@ -498,6 +502,7 @@ public class Controls
 
         //Other Controls
         buttons[3].resetRobot = InputControl.setKey("4: Reset Robot", PlayerFourIndex, new JoystickInput(JoystickButton.Button8, Joystick.Joystick4), false);
+        buttons[3].resetField = InputControl.setKey("4: Reset Field", PlayerFourIndex, new JoystickInput(JoystickButton.Button9, Joystick.Joystick4), false);
         buttons[3].cameraToggle = InputControl.setKey("4: Camera Toggle", PlayerFourIndex, new JoystickInput(JoystickButton.Button7, Joystick.Joystick4), false);
         //buttons[3].replayMode = InputControl.setKey("4: Replay Mode", PlayerFourIndex, KeyCode.Tab, new JoystickInput(JoystickButton.Button6, Joystick.Joystick1), false);
         buttons[3].pickupPrimary = InputControl.setKey("4: Pick Up Primary Gamepiece", PlayerFourIndex, new JoystickInput(JoystickButton.Button3, Joystick.Joystick4), false);
@@ -549,6 +554,7 @@ public class Controls
 
         //Other Controls
         buttons[4].resetRobot = InputControl.setKey("5: Reset Robot", PlayerFiveIndex, new JoystickInput(JoystickButton.Button8, Joystick.Joystick5), false);
+        buttons[4].resetField = InputControl.setKey("5: Reset Field", PlayerFiveIndex, new JoystickInput(JoystickButton.Button9, Joystick.Joystick5), false);
         buttons[4].cameraToggle = InputControl.setKey("5: Camera Toggle", PlayerFiveIndex, new JoystickInput(JoystickButton.Button7, Joystick.Joystick5), false);
         //buttons[4].replayMode = InputControl.setKey("5: Replay Mode", PlayerFiveIndex, KeyCode.Tab, new JoystickInput(JoystickButton.Button6, Joystick.Joystick1), false);
         buttons[4].pickupPrimary = InputControl.setKey("5: Pick Up Primary Gamepiece", PlayerFiveIndex, new JoystickInput(JoystickButton.Button3, Joystick.Joystick5), false);
@@ -600,6 +606,7 @@ public class Controls
 
         //Other Controls
         buttons[5].resetRobot = InputControl.setKey("6: Reset Robot", PlayerSixIndex, new JoystickInput(JoystickButton.Button8, Joystick.Joystick6), false);
+        buttons[5].resetField = InputControl.setKey("6: Reset Field", PlayerSixIndex, new JoystickInput(JoystickButton.Button9, Joystick.Joystick6), false);
         buttons[5].cameraToggle = InputControl.setKey("6: Camera Toggle", PlayerSixIndex, new JoystickInput(JoystickButton.Button7, Joystick.Joystick6), false);
         //buttons[5].replayMode = InputControl.setKey("6: Replay Mode", PlayerSixIndex, KeyCode.Tab, new JoystickInput(JoystickButton.Button6, Joystick.Joystick1), false);
         buttons[5].pickupPrimary = InputControl.setKey("6: Pick Up Primary Gamepiece", PlayerSixIndex, new JoystickInput(JoystickButton.Button3, Joystick.Joystick6), false);
@@ -658,6 +665,7 @@ public class Controls
 
         //Other Controls
         buttons[0].resetRobot = InputControl.setKey("1: Reset Robot", PlayerOneIndex, KeyCode.R, new JoystickInput(JoystickButton.Button8, Joystick.Joystick1), true);
+        buttons[0].resetField = InputControl.setKey("1: Reset Field", PlayerOneIndex, KeyCode.F, new JoystickInput(JoystickButton.Button9, Joystick.Joystick1), true);
         buttons[0].cameraToggle = InputControl.setKey("1: Camera Toggle", PlayerOneIndex, KeyCode.C, new JoystickInput(JoystickButton.Button7, Joystick.Joystick1), true);
         //buttons[0].replayMode = InputControl.setKey("1: Replay Mode", PlayerOneIndex, KeyCode.Tab, new JoystickInput(JoystickButton.Button6, Joystick.Joystick1), true);
         buttons[0].pickupPrimary = InputControl.setKey("1: Pick Up Primary Gamepiece", PlayerOneIndex, KeyCode.LeftControl, new JoystickInput(JoystickButton.Button3, Joystick.Joystick1), true);
@@ -709,6 +717,7 @@ public class Controls
 
         //Other Controls
         buttons[1].resetRobot = InputControl.setKey("2: Reset Robot", PlayerTwoIndex, new JoystickInput(JoystickButton.Button8, Joystick.Joystick2), true);
+        buttons[1].resetField = InputControl.setKey("2: Reset Field", PlayerTwoIndex, new JoystickInput(JoystickButton.Button9, Joystick.Joystick2), true);
         buttons[1].cameraToggle = InputControl.setKey("2: Camera Toggle", PlayerTwoIndex, new JoystickInput(JoystickButton.Button7, Joystick.Joystick2), true);
         //buttons[1].replayMode = InputControl.setKey("2: Replay Mode", PlayerTwoIndex, KeyCode.Tab, new JoystickInput(JoystickButton.Button6, Joystick.Joystick1), true);
         buttons[1].pickupPrimary = InputControl.setKey("2: Pick Up Primary Gamepiece", PlayerTwoIndex, new JoystickInput(JoystickButton.Button3, Joystick.Joystick2), true);
@@ -760,6 +769,7 @@ public class Controls
 
         //Other Controls
         buttons[2].resetRobot = InputControl.setKey("3: Reset Robot", PlayerThreeIndex, new JoystickInput(JoystickButton.Button8, Joystick.Joystick3), true);
+        buttons[2].resetField = InputControl.setKey("3: Reset Field", PlayerThreeIndex, new JoystickInput(JoystickButton.Button9, Joystick.Joystick3), true);
         buttons[2].cameraToggle = InputControl.setKey("3: Camera Toggle", PlayerThreeIndex, new JoystickInput(JoystickButton.Button7, Joystick.Joystick3), true);
         //buttons[2].replayMode = InputControl.setKey("3: Replay Mode", PlayerThreeIndex, KeyCode.Tab, new JoystickInput(JoystickButton.Button6, Joystick.Joystick1), true);
         buttons[2].pickupPrimary = InputControl.setKey("3: Pick Up Primary Gamepiece", PlayerThreeIndex, new JoystickInput(JoystickButton.Button3, Joystick.Joystick3), true);
@@ -811,6 +821,7 @@ public class Controls
 
         //Other Controls
         buttons[3].resetRobot = InputControl.setKey("4: Reset Robot", PlayerFourIndex, new JoystickInput(JoystickButton.Button8, Joystick.Joystick4), true);
+        buttons[3].resetField = InputControl.setKey("4: Reset Field", PlayerFourIndex, new JoystickInput(JoystickButton.Button9, Joystick.Joystick4), true);
         buttons[3].cameraToggle = InputControl.setKey("4: Camera Toggle", PlayerFourIndex, new JoystickInput(JoystickButton.Button7, Joystick.Joystick4), true);
         //buttons[3].replayMode = InputControl.setKey("4: Replay Mode", PlayerFourIndex, KeyCode.Tab, new JoystickInput(JoystickButton.Button6, Joystick.Joystick1), true);
         buttons[3].pickupPrimary = InputControl.setKey("4: Pick Up Primary Gamepiece", PlayerFourIndex, new JoystickInput(JoystickButton.Button3, Joystick.Joystick4), true);
@@ -862,6 +873,7 @@ public class Controls
 
         //Other Controls
         buttons[4].resetRobot = InputControl.setKey("5: Reset Robot", PlayerFiveIndex, new JoystickInput(JoystickButton.Button8, Joystick.Joystick5), true);
+        buttons[4].resetField = InputControl.setKey("5: Reset Field", PlayerFiveIndex, new JoystickInput(JoystickButton.Button9, Joystick.Joystick5), true);
         buttons[4].cameraToggle = InputControl.setKey("5: Camera Toggle", PlayerFiveIndex, new JoystickInput(JoystickButton.Button7, Joystick.Joystick5), true);
         //buttons[4].replayMode = InputControl.setKey("5: Replay Mode", PlayerFiveIndex, KeyCode.Tab, new JoystickInput(JoystickButton.Button6, Joystick.Joystick1), true);
         buttons[4].pickupPrimary = InputControl.setKey("5: Pick Up Primary Gamepiece", PlayerFiveIndex, new JoystickInput(JoystickButton.Button3, Joystick.Joystick5), true);
@@ -913,6 +925,7 @@ public class Controls
 
         //Other Controls
         buttons[5].resetRobot = InputControl.setKey("6: Reset Robot", PlayerSixIndex, new JoystickInput(JoystickButton.Button8, Joystick.Joystick6), true);
+        buttons[5].resetField = InputControl.setKey("6: Reset Field", PlayerSixIndex, new JoystickInput(JoystickButton.Button9, Joystick.Joystick6), true);
         buttons[5].cameraToggle = InputControl.setKey("6: Camera Toggle", PlayerSixIndex, new JoystickInput(JoystickButton.Button7, Joystick.Joystick6), true);
         //buttons[5].replayMode = InputControl.setKey("6: Replay Mode", PlayerSixIndex, KeyCode.Tab, new JoystickInput(JoystickButton.Button6, Joystick.Joystick1), true);
         buttons[5].pickupPrimary = InputControl.setKey("6: Pick Up Primary Gamepiece", PlayerSixIndex, new JoystickInput(JoystickButton.Button3, Joystick.Joystick6), true);

--- a/engine/unity5/Assets/Scripts/Robot.cs
+++ b/engine/unity5/Assets/Scripts/Robot.cs
@@ -11,6 +11,7 @@ using Assets.Scripts.BUExtensions;
 using Assets.Scripts.FSM;
 using Assets.Scripts;
 using Assets.Scripts.Utils;
+using UnityEngine.SceneManagement;
 
 /// <summary>
 /// To be attached to all robot parent objects.
@@ -106,6 +107,11 @@ public class Robot : MonoBehaviour
             if (InputControl.GetButtonDown(Controls.buttons[ControlIndex].resetRobot) && !MixAndMatchMode.setPresetPanelOpen)
             {
                 keyDownTime = Time.time;
+            }
+            else if (InputControl.GetButtonDown(Controls.buttons[ControlIndex].resetField))
+            {
+                AuxFunctions.FindObject(GameObject.Find("Canvas"), "LoadingPanel").SetActive(true);
+                SceneManager.LoadScene("Scene");
             }
 
             else if (InputControl.GetButton(Controls.buttons[ControlIndex].resetRobot) &&  !MixAndMatchMode.setPresetPanelOpen &&


### PR DESCRIPTION
Clicking the "F" key (Button 9 on Joystick) and the "Reset Field" button in the "Reset" dropdown menu effectively resets the field to its default state (exactly as it would appear on load in or changing scene). Added "F" key to hotkey list and changed toolbar dropdown from "Robot Reset" to "Reset" to encompass field reset too.

JIRA Issue: https://jira.autodesk.com/browse/AARD-443