### PR TITLE
Fixed initial location of joint editor and other windows

### DIFF
--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/DriveChooser.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/DriveChooser.Designer.cs
@@ -556,6 +556,7 @@ partial class DriveChooser
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "DriveChooser";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "Configure Joint";
             this.Load += new System.EventHandler(this.DriveChooser_Load);
             this.grpChooseDriver.ResumeLayout(false);

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/DriveChooser.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/DriveChooser.cs
@@ -15,7 +15,6 @@ public partial class DriveChooser : Form
     public DriveChooser()
     {
         InitializeComponent();
-        base.Layout += DriveChooser_Layout;
         FormClosing += delegate (object sender, FormClosingEventArgs e) { LegacyInterchange.LegacyEvents.OnRobotModified(); };
     }
 
@@ -139,7 +138,9 @@ public partial class DriveChooser : Form
 
             cmbStages.SelectedIndex = (byte)ElevatorType.NOT_MULTI;
         }
-        PerformLayout();
+        
+        PrepLayout();
+        base.Location = new System.Drawing.Point(Cursor.Position.X - 10, Cursor.Position.Y - base.Height - 10);
         this.ShowDialog(owner);
     }
 
@@ -185,9 +186,7 @@ public partial class DriveChooser : Form
     /// <summary>
     /// Changes the position of window elements based on the type of driver.
     /// </summary>
-    /// <param name="sender"></param>
-    /// <param name="e"></param>
-    void DriveChooser_Layout(object sender, LayoutEventArgs e)
+    void PrepLayout()
     {
         chkBoxDriveWheel.Hide();
         chkBoxHasBrake.Hide();
@@ -250,7 +249,7 @@ public partial class DriveChooser : Form
 
     private void cmbJointDriver_SelectedIndexChanged(object sender, EventArgs e)
     {
-        PerformLayout();
+        PrepLayout();
     }
 
     /// <summary>

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditLimits.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditLimits.Designer.cs
@@ -78,6 +78,7 @@ namespace EditorsLibrary
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.Name = "EditLimits";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "Edit Limits";
             this.ResumeLayout(false);
 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditLimits.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditLimits.cs
@@ -37,6 +37,8 @@ namespace EditorsLibrary
             }
             base.Text = joint.GetType().Name.Replace("_Base", "").Replace("Joint", " Joint");
 
+            base.Location = new System.Drawing.Point(Cursor.Position.X - 10, Cursor.Position.Y - base.Height - 10);
+
             FormClosing += delegate (object sender, FormClosingEventArgs e) { LegacyInterchange.LegacyEvents.OnRobotModified(); };
         }
 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/JointEditorPane.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/JointEditorPane.cs
@@ -56,11 +56,7 @@ namespace EditorsLibrary
                     RigidNode_Base node = nodes[0];
                     if (node != null && node.GetSkeletalJoint() != null)
                     {
-                        EditLimits limitEditor = new EditLimits(node.GetSkeletalJoint())
-                        {
-                            StartPosition = FormStartPosition.Manual,
-                            Location = new System.Drawing.Point(Cursor.Position.X - 10, Cursor.Position.Y - 10)
-                        };
+                        EditLimits limitEditor = new EditLimits(node.GetSkeletalJoint());
                         limitEditor.ShowDialog(ParentForm);
                     }
                 });
@@ -148,11 +144,7 @@ namespace EditorsLibrary
             if (node == null) return;
 
             currentlyEditing = true;
-            SensorListForm listForm = new SensorListForm(node.GetSkeletalJoint())
-            {
-                StartPosition = FormStartPosition.Manual,
-                Location = new System.Drawing.Point(Cursor.Position.X - 10, Cursor.Position.Y - 10)
-            };
+            SensorListForm listForm = new SensorListForm(node.GetSkeletalJoint());
             listForm.ShowDialog(ParentForm);
             ModifiedJoint?.Invoke(nodes);
             this.UpdateJointList();
@@ -169,8 +161,6 @@ namespace EditorsLibrary
 
             currentlyEditing = true;
 
-            driveChooserDialog.StartPosition = FormStartPosition.Manual;
-            driveChooserDialog.Location = new System.Drawing.Point(Cursor.Position.X - 10, Cursor.Position.Y - 10);
             driveChooserDialog.ShowDialog(nodes[0].GetSkeletalJoint(), nodes, ParentForm);
 
             if (ModifiedJoint != null && driveChooserDialog.Saved)

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.Designer.cs
@@ -130,6 +130,7 @@
             this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.MinimumSize = new System.Drawing.Size(416, 251);
             this.Name = "SensorListForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "SensorListForm";
             this.Load += new System.EventHandler(this.SensorListForm_Load);
             this.SizeChanged += new System.EventHandler(this.window_SizeChanged);

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.cs
@@ -21,7 +21,8 @@ namespace EditorsLibrary
             joint = passJoint;
             this.UpdateSensorList();
             FormClosing += delegate (object sender, FormClosingEventArgs e) { LegacyInterchange.LegacyEvents.OnRobotModified(); };
-
+            
+            base.Location = new System.Drawing.Point(Cursor.Position.X - 10, Cursor.Position.Y - base.Height - 10);
         }
 
         private void UpdateSensorList()


### PR DESCRIPTION
In the advanced exporter, the joint editor, limit editor, and sensor editor now appear above the mouse instead of below it, so that they cannot appear off screen. AARD-466