### PR TITLE
reset spawn point sets camera to overview

### DIFF
--- a/engine/unity5/Assets/Scripts/GUI/SimUI.cs
+++ b/engine/unity5/Assets/Scripts/GUI/SimUI.cs
@@ -569,7 +569,15 @@ public class SimUI : MonoBehaviour
                 break;
             case 2:
                 EndOtherProcesses();
+                camera.SwitchCameraState(new DynamicCamera.OrbitState(camera));
+                DynamicCamera.MovingEnabled = true;
                 main.BeginRobotReset();
+                resetDropdown.GetComponent<Dropdown>().value = 0;
+                break;
+            case 3:
+                AuxFunctions.FindObject(GameObject.Find("Reset Robot Dropdown"), "Dropdown List").SetActive(false);
+                AuxFunctions.FindObject(GameObject.Find("Canvas"), "LoadingPanel").SetActive(true);
+                SceneManager.LoadScene("Scene");
                 resetDropdown.GetComponent<Dropdown>().value = 0;
                 break;
         }


### PR DESCRIPTION
Sets camera to overview when trying to reset spawn point to correct WASD directions when rotating camera.

Jira Issue: https://jira.autodesk.com/browse/AARD-520