### PR TITLE
Improved the information formatting in the joint editor

### DIFF
--- a/exporters/Aardvark-Libraries/SimulatorFileIO/Joints/Driver/JointDriver.cs
+++ b/exporters/Aardvark-Libraries/SimulatorFileIO/Joints/Driver/JointDriver.cs
@@ -181,13 +181,15 @@ public class JointDriver : BinaryRWObject, IComparable<JointDriver>
 
     public override string ToString()
     {
-        string info = System.Enum.GetName(typeof(JointDriverType), GetDriveType()).Replace('_', ' ').ToLowerInvariant();
-        info += "\nPorts: " + type.GetPortType() + "(" + portA + (type.HasTwoPorts() ? "," + portB : "") + ")";
-        info += "\nMeta: ";
-        foreach (KeyValuePair<System.Type, JointDriverMeta> meta in MetaInfo)
-        {
-            info += "\n\t" + meta.Value.ToString();
-        }
+        string info = "";
+
+        // Joint type
+        string jointType = System.Enum.GetName(typeof(JointDriverType), GetDriveType()).Replace('_', ' ').ToLowerInvariant();
+        info += jointType.Substring(0, 1).ToUpper() + jointType.Substring(1); // Capitalize first letter
+
+        // Port information
+        info += ", Ports: " + type.GetPortType() + " " + portA + (type.HasTwoPorts() ? " and " + portB : "");
+
         return info;
     }
 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/JointEditorPane.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/JointEditorPane.cs
@@ -242,9 +242,10 @@ namespace EditorsLibrary
                         }
 
                         ListViewItem item = new ListViewItem(new string[] {
-                    Enum.GetName(typeof(SkeletalJointType),joint.GetJointType()).ToLowerInvariant(),
-                        node.GetParent().ModelFileName,
-                        node.ModelFileName, joint.cDriver!=null ? joint.cDriver.ToString() : "No driver",
+                        Utilities.CapitalizeFirstLetter(Enum.GetName(typeof(SkeletalJointType),joint.GetJointType()), true),
+                        Utilities.CapitalizeFirstLetter(node.GetParent().ModelFileName.Replace('_', ' ').Replace(".bxda", " ")),
+                        Utilities.CapitalizeFirstLetter(node.ModelFileName.Replace('_', ' ').Replace(".bxda", " ")),
+                        joint.cDriver != null ? joint.cDriver.ToString() : "No Driver",
                         wheelData!=null ? wheelData.GetTypeString() : "No Wheel",
                         joint.attachedSensors.Count.ToString()})
                         {

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/Utilities.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/Utilities.cs
@@ -47,6 +47,16 @@ public class Utilities
         double dz = b.MaxPoint.Z - b.MinPoint.Z;
         return dx * dy * dz;
     }
+
+    public static string CapitalizeFirstLetter(string str, bool onlyFirst = false)
+    {
+        if (str.Length < 2)
+            return str.ToUpperInvariant();
+        else if (onlyFirst)
+            return str.Substring(0, 1).ToUpperInvariant() + str.Substring(1).ToLowerInvariant();
+        else
+            return str.Substring(0, 1).ToUpperInvariant() + str.Substring(1);
+    }
 }
 
 namespace LegacyInterchange


### PR DESCRIPTION
In the joint editor of the advanced exporter, I made some items capitalized to improve appearance to the user, as well as replaced underscores with spaces, and removed ".bxda." I improved the display of joint and motor information as well. This resolves AARD-528.