### PR TITLE
Fixed robot not falling when wizard is not finished

### DIFF
--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
@@ -66,7 +66,7 @@ public partial class SynthesisGUI : Form
     public RigidNode_Base SkeletonBase = null;
     public List<BXDAMesh> Meshes = null;
     public bool MeshesAreColored = false;
-    public float TotalMass = 0;
+    public float TotalMass = 120;
 
     private SkeletonExporterForm skeletonExporter;
     private LiteExporterForm liteExporter;


### PR DESCRIPTION
Changed the default mass value from 0 to 120, so that if it is not overridden by the wizard, it still has some mass so that it will fall.
This resolves AARD-532.