### PR TITLE
Fixed exception caused by canceling robot export

### DIFF
--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/LiteExporterForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/LiteExporterForm.cs
@@ -152,7 +152,7 @@ public partial class LiteExporterForm : Form
     {
         if (ExporterWorker.IsBusy)
             ExporterWorker.CancelAsync();
-        Close();
+        
         if (ExporterWorker.CancellationPending)
             Dispose();
     }
@@ -176,6 +176,7 @@ public partial class LiteExporterForm : Form
         #endregion
         else
         {
+            DialogResult = DialogResult.OK;
             Close();
         }
     }

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
@@ -251,14 +251,20 @@ public partial class SynthesisGUI : Form
             return false;
         }
 
-        List<RigidNode_Base> nodes = SkeletonBase.ListAllNodes();
-        for (int i = 0; i < Meshes.Count; i++)
+        // Exporter completed successfully
+        if (liteExporter.DialogResult == DialogResult.OK)
         {
-            ((OGL_RigidNode)nodes[i]).loadMeshes(Meshes[i]);
+            List<RigidNode_Base> nodes = SkeletonBase.ListAllNodes();
+            for (int i = 0; i < Meshes.Count; i++)
+            {
+                ((OGL_RigidNode)nodes[i]).loadMeshes(Meshes[i]);
+            }
+            
+            return true;
         }
-
-        //ReloadPanels();
-        return true;
+        // Exporter failed
+        else
+            return false;
     }
 
     /// <summary>


### PR DESCRIPTION
Added a dialog result to the exporter window so that the function opening the exporter can tell whether or not it completed successfully, and stops the rest of the process accordingly. This resolves AARD-526.