### PR TITLE
overview state for spawn point camera

### DIFF
--- a/engine/unity5/Assets/Scripts/GUI/SimUI.cs
+++ b/engine/unity5/Assets/Scripts/GUI/SimUI.cs
@@ -638,7 +638,7 @@ public class SimUI : MonoBehaviour
                 break;
             case 2:
                 EndOtherProcesses();
-                camera.SwitchCameraState(new DynamicCamera.OrbitState(camera));
+                camera.SwitchCameraState(new DynamicCamera.OverviewState(camera));
                 DynamicCamera.MovingEnabled = true;
                 main.BeginRobotReset();
                 resetDropdown.GetComponent<Dropdown>().value = 0;


### PR DESCRIPTION
Sets camera to overview when trying to reset spawn point to correct WASD directions when rotating camera.

Jira Issue: https://jira.autodesk.com/browse/AARD-520