### PR TITLE
Improved Clarity of Node Names in Wizard

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.cs
@@ -191,8 +191,10 @@ namespace BxDRobotExporter.Wizard
                 {
                     if (node.GetSkeletalJoint() != null && node.GetSkeletalJoint().GetJointType() == SkeletalJointType.ROTATIONAL)
                     {
-                        NodeListBox.Items.Add(node.ModelFileName);
-                        listItems.Add(node.ModelFileName, node);
+                        string readableName = node.ModelFileName.Replace('_', ' ').Replace(".bxda", "");
+                        readableName = readableName.Substring(0, 1).ToUpperInvariant() + readableName.Substring(1); // Capitalize first character
+                        NodeListBox.Items.Add(readableName);
+                        listItems.Add(readableName, node);
                     }
                 }
             }
@@ -202,8 +204,10 @@ namespace BxDRobotExporter.Wizard
                 {
                     if (node.GetParent().GetParent() != null)
                     {
-                        NodeListBox.Items.Add(node.ModelFileName);
-                        listItems.Add(node.ModelFileName, node);
+                        string readableName = node.ModelFileName.Replace('_', ' ').Replace(".bxda", "");
+                        readableName = readableName.Substring(0, 1).ToUpperInvariant() + readableName.Substring(1); // Capitalize first character
+                        NodeListBox.Items.Add(readableName);
+                        listItems.Add(readableName, node);
                     }
                 }
             }

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/WizardForm.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/WizardForm.cs
@@ -18,7 +18,7 @@ namespace BxDRobotExporter.Wizard
         {
             InitializeComponent();
 
-            BXDJSkeleton.SetupFileNames(Utilities.GUI.SkeletonBase, true);
+            BXDJSkeleton.SetupFileNames(Utilities.GUI.SkeletonBase);
             
             this.Resize += WizardForm_Resize;
 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/JointEditorPane.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/JointEditorPane.cs
@@ -233,8 +233,8 @@ namespace EditorsLibrary
 
                         ListViewItem item = new ListViewItem(new string[] {
                         Utilities.CapitalizeFirstLetter(Enum.GetName(typeof(SkeletalJointType),joint.GetJointType()), true),
-                        Utilities.CapitalizeFirstLetter(node.GetParent().ModelFileName.Replace('_', ' ').Replace(".bxda", " ")),
-                        Utilities.CapitalizeFirstLetter(node.ModelFileName.Replace('_', ' ').Replace(".bxda", " ")),
+                        Utilities.CapitalizeFirstLetter(node.GetParent().ModelFileName.Replace('_', ' ').Replace(".bxda", "")),
+                        Utilities.CapitalizeFirstLetter(node.ModelFileName.Replace('_', ' ').Replace(".bxda", "")),
                         joint.cDriver != null ? joint.cDriver.ToString() : "No Driver",
                         wheelData!=null ? wheelData.GetTypeString() : "No Wheel",
                         joint.attachedSensors.Count.ToString()})


### PR DESCRIPTION
Moved file name prepping to the end of the process. This means that nodes maintain their part names throughout the exporter process so that the user can tell which node corresponds to which part more easily. This resolves AARD-569.