### PR TITLE
Removal of Old Buttons for Non-Wheel Joints in Wizard

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.Designer.cs
@@ -50,6 +50,8 @@
             this.PortOneUpDown = new System.Windows.Forms.NumericUpDown();
             this.DriverComboBox = new System.Windows.Forms.ComboBox();
             this.SelectDriverLabel = new System.Windows.Forms.Label();
+            this.MainTableLayout = new System.Windows.Forms.TableLayoutPanel();
+            this.DriverLayout = new System.Windows.Forms.TableLayoutPanel();
             this.NodeGroupBox.SuspendLayout();
             this.JointLimitGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.UpperLimitUpDown)).BeginInit();
@@ -59,6 +61,8 @@
             this.PortsGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.PortTwoUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.PortOneUpDown)).BeginInit();
+            this.MainTableLayout.SuspendLayout();
+            this.DriverLayout.SuspendLayout();
             this.SuspendLayout();
             // 
             // NodeGroupBox
@@ -66,14 +70,10 @@
             this.NodeGroupBox.AutoSize = true;
             this.NodeGroupBox.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.NodeGroupBox.BackColor = System.Drawing.SystemColors.Control;
-            this.NodeGroupBox.Controls.Add(this.JointLimitGroupBox);
-            this.NodeGroupBox.Controls.Add(this.MetaTabControl);
-            this.NodeGroupBox.Controls.Add(this.PortsGroupBox);
-            this.NodeGroupBox.Controls.Add(this.DriverComboBox);
-            this.NodeGroupBox.Controls.Add(this.SelectDriverLabel);
+            this.NodeGroupBox.Controls.Add(this.MainTableLayout);
             this.NodeGroupBox.Location = new System.Drawing.Point(0, 0);
             this.NodeGroupBox.Name = "NodeGroupBox";
-            this.NodeGroupBox.Size = new System.Drawing.Size(440, 202);
+            this.NodeGroupBox.Size = new System.Drawing.Size(374, 252);
             this.NodeGroupBox.TabIndex = 0;
             this.NodeGroupBox.TabStop = false;
             this.NodeGroupBox.Text = "Empty";
@@ -86,9 +86,10 @@
             this.JointLimitGroupBox.Controls.Add(this.UpperLimitLabel);
             this.JointLimitGroupBox.Controls.Add(this.LowerLimitLabel);
             this.JointLimitGroupBox.Controls.Add(this.LowerLimitUpDown);
-            this.JointLimitGroupBox.Location = new System.Drawing.Point(226, 101);
+            this.JointLimitGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
+            this.JointLimitGroupBox.Location = new System.Drawing.Point(3, 87);
             this.JointLimitGroupBox.Name = "JointLimitGroupBox";
-            this.JointLimitGroupBox.Size = new System.Drawing.Size(208, 79);
+            this.JointLimitGroupBox.Size = new System.Drawing.Size(175, 83);
             this.JointLimitGroupBox.TabIndex = 13;
             this.JointLimitGroupBox.TabStop = false;
             this.JointLimitGroupBox.Text = "Joint Limits";
@@ -96,7 +97,7 @@
             // TotalFreedomLabel
             // 
             this.TotalFreedomLabel.AutoSize = true;
-            this.TotalFreedomLabel.Location = new System.Drawing.Point(128, 34);
+            this.TotalFreedomLabel.Location = new System.Drawing.Point(118, 28);
             this.TotalFreedomLabel.Name = "TotalFreedomLabel";
             this.TotalFreedomLabel.Size = new System.Drawing.Size(47, 13);
             this.TotalFreedomLabel.TabIndex = 5;
@@ -105,7 +106,7 @@
             // FreedomFactorLabel
             // 
             this.FreedomFactorLabel.AutoSize = true;
-            this.FreedomFactorLabel.Location = new System.Drawing.Point(128, 19);
+            this.FreedomFactorLabel.Location = new System.Drawing.Point(118, 16);
             this.FreedomFactorLabel.Name = "FreedomFactorLabel";
             this.FreedomFactorLabel.Size = new System.Drawing.Size(51, 13);
             this.FreedomFactorLabel.TabIndex = 4;
@@ -148,11 +149,12 @@
             // MetaTabControl
             // 
             this.MetaTabControl.Controls.Add(this.PneumaticTab);
-            this.MetaTabControl.Location = new System.Drawing.Point(10, 98);
+            this.MetaTabControl.Dock = System.Windows.Forms.DockStyle.Top;
+            this.MetaTabControl.Location = new System.Drawing.Point(183, 86);
             this.MetaTabControl.Margin = new System.Windows.Forms.Padding(2);
             this.MetaTabControl.Name = "MetaTabControl";
             this.MetaTabControl.SelectedIndex = 0;
-            this.MetaTabControl.Size = new System.Drawing.Size(211, 86);
+            this.MetaTabControl.Size = new System.Drawing.Size(177, 126);
             this.MetaTabControl.TabIndex = 12;
             this.MetaTabControl.Visible = false;
             // 
@@ -165,7 +167,7 @@
             this.PneumaticTab.Location = new System.Drawing.Point(4, 22);
             this.PneumaticTab.Margin = new System.Windows.Forms.Padding(2);
             this.PneumaticTab.Name = "PneumaticTab";
-            this.PneumaticTab.Size = new System.Drawing.Size(203, 60);
+            this.PneumaticTab.Size = new System.Drawing.Size(169, 100);
             this.PneumaticTab.TabIndex = 1;
             this.PneumaticTab.Text = "Pneumatic";
             this.PneumaticTab.UseVisualStyleBackColor = true;
@@ -173,7 +175,7 @@
             // PressureLabel
             // 
             this.PressureLabel.AutoSize = true;
-            this.PressureLabel.Location = new System.Drawing.Point(100, 9);
+            this.PressureLabel.Location = new System.Drawing.Point(2, 59);
             this.PressureLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.PressureLabel.Name = "PressureLabel";
             this.PressureLabel.Size = new System.Drawing.Size(48, 13);
@@ -189,10 +191,10 @@
             "60 psi",
             "20 psi",
             "10 psi"});
-            this.PneumaticPressureComboBox.Location = new System.Drawing.Point(102, 26);
+            this.PneumaticPressureComboBox.Location = new System.Drawing.Point(4, 74);
             this.PneumaticPressureComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.PneumaticPressureComboBox.Name = "PneumaticPressureComboBox";
-            this.PneumaticPressureComboBox.Size = new System.Drawing.Size(91, 21);
+            this.PneumaticPressureComboBox.Size = new System.Drawing.Size(94, 21);
             this.PneumaticPressureComboBox.TabIndex = 6;
             // 
             // PneumaticDiameterComboBox
@@ -221,14 +223,16 @@
             // 
             // PortsGroupBox
             // 
+            this.MainTableLayout.SetColumnSpan(this.PortsGroupBox, 2);
             this.PortsGroupBox.Controls.Add(this.AutoAssignCheckBox);
             this.PortsGroupBox.Controls.Add(this.PortTwoUpDown);
             this.PortsGroupBox.Controls.Add(this.PortTwoLabel);
             this.PortsGroupBox.Controls.Add(this.PortOneLabel);
             this.PortsGroupBox.Controls.Add(this.PortOneUpDown);
-            this.PortsGroupBox.Location = new System.Drawing.Point(10, 44);
+            this.PortsGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
+            this.PortsGroupBox.Location = new System.Drawing.Point(3, 30);
             this.PortsGroupBox.Name = "PortsGroupBox";
-            this.PortsGroupBox.Size = new System.Drawing.Size(424, 51);
+            this.PortsGroupBox.Size = new System.Drawing.Size(356, 51);
             this.PortsGroupBox.TabIndex = 6;
             this.PortsGroupBox.TabStop = false;
             this.PortsGroupBox.Text = "Ports";
@@ -308,6 +312,7 @@
             // 
             // DriverComboBox
             // 
+            this.DriverComboBox.Dock = System.Windows.Forms.DockStyle.Top;
             this.DriverComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.DriverComboBox.FormattingEnabled = true;
             this.DriverComboBox.Items.AddRange(new object[] {
@@ -317,20 +322,62 @@
             "Bumper Pneumatic",
             "Relay Pneumatic",
             "Dual Motor"});
-            this.DriverComboBox.Location = new System.Drawing.Point(84, 17);
+            this.DriverComboBox.Location = new System.Drawing.Point(80, 3);
             this.DriverComboBox.Name = "DriverComboBox";
-            this.DriverComboBox.Size = new System.Drawing.Size(350, 21);
+            this.DriverComboBox.Size = new System.Drawing.Size(279, 21);
             this.DriverComboBox.TabIndex = 2;
             this.DriverComboBox.SelectedIndexChanged += new System.EventHandler(this.DriverComboBox_SelectedIndexChanged);
             // 
             // SelectDriverLabel
             // 
             this.SelectDriverLabel.AutoSize = true;
-            this.SelectDriverLabel.Location = new System.Drawing.Point(7, 20);
+            this.SelectDriverLabel.Dock = System.Windows.Forms.DockStyle.Right;
+            this.SelectDriverLabel.Location = new System.Drawing.Point(3, 3);
+            this.SelectDriverLabel.Margin = new System.Windows.Forms.Padding(3);
             this.SelectDriverLabel.Name = "SelectDriverLabel";
-            this.SelectDriverLabel.Size = new System.Drawing.Size(71, 13);
+            this.SelectDriverLabel.Size = new System.Drawing.Size(71, 21);
             this.SelectDriverLabel.TabIndex = 1;
             this.SelectDriverLabel.Text = "Select Driver:";
+            this.SelectDriverLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // MainTableLayout
+            // 
+            this.MainTableLayout.AutoSize = true;
+            this.MainTableLayout.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.MainTableLayout.ColumnCount = 2;
+            this.MainTableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.MainTableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.MainTableLayout.Controls.Add(this.DriverLayout, 0, 0);
+            this.MainTableLayout.Controls.Add(this.JointLimitGroupBox, 0, 2);
+            this.MainTableLayout.Controls.Add(this.PortsGroupBox, 0, 1);
+            this.MainTableLayout.Controls.Add(this.MetaTabControl, 1, 2);
+            this.MainTableLayout.Location = new System.Drawing.Point(6, 19);
+            this.MainTableLayout.Name = "MainTableLayout";
+            this.MainTableLayout.RowCount = 3;
+            this.MainTableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.MainTableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.MainTableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.MainTableLayout.Size = new System.Drawing.Size(362, 214);
+            this.MainTableLayout.TabIndex = 14;
+            // 
+            // DriverLayout
+            // 
+            this.DriverLayout.AutoSize = true;
+            this.DriverLayout.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.DriverLayout.ColumnCount = 2;
+            this.MainTableLayout.SetColumnSpan(this.DriverLayout, 2);
+            this.DriverLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.DriverLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.DriverLayout.Controls.Add(this.SelectDriverLabel, 0, 0);
+            this.DriverLayout.Controls.Add(this.DriverComboBox, 1, 0);
+            this.DriverLayout.Dock = System.Windows.Forms.DockStyle.Top;
+            this.DriverLayout.Location = new System.Drawing.Point(0, 0);
+            this.DriverLayout.Margin = new System.Windows.Forms.Padding(0);
+            this.DriverLayout.Name = "DriverLayout";
+            this.DriverLayout.RowCount = 1;
+            this.DriverLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.DriverLayout.Size = new System.Drawing.Size(362, 27);
+            this.DriverLayout.TabIndex = 0;
             // 
             // DefinePartPanel
             // 
@@ -341,7 +388,7 @@
             this.BackColor = System.Drawing.Color.Transparent;
             this.Controls.Add(this.NodeGroupBox);
             this.Name = "DefinePartPanel";
-            this.Size = new System.Drawing.Size(443, 205);
+            this.Size = new System.Drawing.Size(377, 255);
             this.NodeGroupBox.ResumeLayout(false);
             this.NodeGroupBox.PerformLayout();
             this.JointLimitGroupBox.ResumeLayout(false);
@@ -355,6 +402,10 @@
             this.PortsGroupBox.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.PortTwoUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.PortOneUpDown)).EndInit();
+            this.MainTableLayout.ResumeLayout(false);
+            this.MainTableLayout.PerformLayout();
+            this.DriverLayout.ResumeLayout(false);
+            this.DriverLayout.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -384,5 +435,7 @@
         private System.Windows.Forms.NumericUpDown LowerLimitUpDown;
         private System.Windows.Forms.Label TotalFreedomLabel;
         private System.Windows.Forms.Label FreedomFactorLabel;
+        private System.Windows.Forms.TableLayoutPanel MainTableLayout;
+        private System.Windows.Forms.TableLayoutPanel DriverLayout;
     }
 }

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.Designer.cs
@@ -50,8 +50,6 @@
             this.PortOneUpDown = new System.Windows.Forms.NumericUpDown();
             this.DriverComboBox = new System.Windows.Forms.ComboBox();
             this.SelectDriverLabel = new System.Windows.Forms.Label();
-            this.MergeNodeButton = new System.Windows.Forms.Button();
-            this.InventorHighlightButton = new System.Windows.Forms.Button();
             this.NodeGroupBox.SuspendLayout();
             this.JointLimitGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.UpperLimitUpDown)).BeginInit();
@@ -65,16 +63,16 @@
             // 
             // NodeGroupBox
             // 
+            this.NodeGroupBox.AutoSize = true;
+            this.NodeGroupBox.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.NodeGroupBox.Controls.Add(this.JointLimitGroupBox);
             this.NodeGroupBox.Controls.Add(this.MetaTabControl);
             this.NodeGroupBox.Controls.Add(this.PortsGroupBox);
             this.NodeGroupBox.Controls.Add(this.DriverComboBox);
             this.NodeGroupBox.Controls.Add(this.SelectDriverLabel);
             this.NodeGroupBox.Location = new System.Drawing.Point(0, 0);
-            this.NodeGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NodeGroupBox.Name = "NodeGroupBox";
-            this.NodeGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.NodeGroupBox.Size = new System.Drawing.Size(583, 233);
+            this.NodeGroupBox.Size = new System.Drawing.Size(440, 202);
             this.NodeGroupBox.TabIndex = 0;
             this.NodeGroupBox.TabStop = false;
             this.NodeGroupBox.Text = "Empty";
@@ -87,11 +85,9 @@
             this.JointLimitGroupBox.Controls.Add(this.UpperLimitLabel);
             this.JointLimitGroupBox.Controls.Add(this.LowerLimitLabel);
             this.JointLimitGroupBox.Controls.Add(this.LowerLimitUpDown);
-            this.JointLimitGroupBox.Location = new System.Drawing.Point(301, 124);
-            this.JointLimitGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.JointLimitGroupBox.Location = new System.Drawing.Point(226, 101);
             this.JointLimitGroupBox.Name = "JointLimitGroupBox";
-            this.JointLimitGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.JointLimitGroupBox.Size = new System.Drawing.Size(277, 97);
+            this.JointLimitGroupBox.Size = new System.Drawing.Size(208, 79);
             this.JointLimitGroupBox.TabIndex = 13;
             this.JointLimitGroupBox.TabStop = false;
             this.JointLimitGroupBox.Text = "Joint Limits";
@@ -99,69 +95,63 @@
             // TotalFreedomLabel
             // 
             this.TotalFreedomLabel.AutoSize = true;
-            this.TotalFreedomLabel.Location = new System.Drawing.Point(171, 42);
-            this.TotalFreedomLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.TotalFreedomLabel.Location = new System.Drawing.Point(128, 34);
             this.TotalFreedomLabel.Name = "TotalFreedomLabel";
-            this.TotalFreedomLabel.Size = new System.Drawing.Size(62, 17);
+            this.TotalFreedomLabel.Size = new System.Drawing.Size(47, 13);
             this.TotalFreedomLabel.TabIndex = 5;
             this.TotalFreedomLabel.Text = "0.0 units";
             // 
             // FreedomFactorLabel
             // 
             this.FreedomFactorLabel.AutoSize = true;
-            this.FreedomFactorLabel.Location = new System.Drawing.Point(171, 23);
-            this.FreedomFactorLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.FreedomFactorLabel.Location = new System.Drawing.Point(128, 19);
             this.FreedomFactorLabel.Name = "FreedomFactorLabel";
-            this.FreedomFactorLabel.Size = new System.Drawing.Size(68, 17);
+            this.FreedomFactorLabel.Size = new System.Drawing.Size(51, 13);
             this.FreedomFactorLabel.TabIndex = 4;
             this.FreedomFactorLabel.Text = "Freedom:";
             // 
             // UpperLimitUpDown
             // 
-            this.UpperLimitUpDown.Location = new System.Drawing.Point(96, 32);
-            this.UpperLimitUpDown.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.UpperLimitUpDown.Location = new System.Drawing.Point(72, 26);
             this.UpperLimitUpDown.Name = "UpperLimitUpDown";
-            this.UpperLimitUpDown.Size = new System.Drawing.Size(61, 22);
+            this.UpperLimitUpDown.Size = new System.Drawing.Size(46, 20);
             this.UpperLimitUpDown.TabIndex = 3;
             this.UpperLimitUpDown.ValueChanged += new System.EventHandler(this.UpperLimitUpDown_ValueChanged);
             // 
             // UpperLimitLabel
             // 
             this.UpperLimitLabel.AutoSize = true;
-            this.UpperLimitLabel.Location = new System.Drawing.Point(8, 34);
-            this.UpperLimitLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.UpperLimitLabel.Location = new System.Drawing.Point(6, 28);
             this.UpperLimitLabel.Name = "UpperLimitLabel";
-            this.UpperLimitLabel.Size = new System.Drawing.Size(80, 17);
+            this.UpperLimitLabel.Size = new System.Drawing.Size(60, 13);
             this.UpperLimitLabel.TabIndex = 2;
             this.UpperLimitLabel.Text = "Upper Limit";
             // 
             // LowerLimitLabel
             // 
             this.LowerLimitLabel.AutoSize = true;
-            this.LowerLimitLabel.Location = new System.Drawing.Point(8, 68);
-            this.LowerLimitLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LowerLimitLabel.Location = new System.Drawing.Point(6, 55);
             this.LowerLimitLabel.Name = "LowerLimitLabel";
-            this.LowerLimitLabel.Size = new System.Drawing.Size(79, 17);
+            this.LowerLimitLabel.Size = new System.Drawing.Size(60, 13);
             this.LowerLimitLabel.TabIndex = 1;
             this.LowerLimitLabel.Text = "Lower Limit";
             // 
             // LowerLimitUpDown
             // 
-            this.LowerLimitUpDown.Location = new System.Drawing.Point(96, 65);
-            this.LowerLimitUpDown.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.LowerLimitUpDown.Location = new System.Drawing.Point(72, 53);
             this.LowerLimitUpDown.Name = "LowerLimitUpDown";
-            this.LowerLimitUpDown.Size = new System.Drawing.Size(60, 22);
+            this.LowerLimitUpDown.Size = new System.Drawing.Size(45, 20);
             this.LowerLimitUpDown.TabIndex = 0;
             this.LowerLimitUpDown.ValueChanged += new System.EventHandler(this.LowerLimitUpDown_ValueChanged);
             // 
             // MetaTabControl
             // 
             this.MetaTabControl.Controls.Add(this.PneumaticTab);
-            this.MetaTabControl.Location = new System.Drawing.Point(13, 121);
-            this.MetaTabControl.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.MetaTabControl.Location = new System.Drawing.Point(10, 98);
+            this.MetaTabControl.Margin = new System.Windows.Forms.Padding(2);
             this.MetaTabControl.Name = "MetaTabControl";
             this.MetaTabControl.SelectedIndex = 0;
-            this.MetaTabControl.Size = new System.Drawing.Size(281, 106);
+            this.MetaTabControl.Size = new System.Drawing.Size(211, 86);
             this.MetaTabControl.TabIndex = 12;
             this.MetaTabControl.Visible = false;
             // 
@@ -171,10 +161,10 @@
             this.PneumaticTab.Controls.Add(this.PneumaticPressureComboBox);
             this.PneumaticTab.Controls.Add(this.PneumaticDiameterComboBox);
             this.PneumaticTab.Controls.Add(this.DiameterLabel);
-            this.PneumaticTab.Location = new System.Drawing.Point(4, 25);
-            this.PneumaticTab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.PneumaticTab.Location = new System.Drawing.Point(4, 22);
+            this.PneumaticTab.Margin = new System.Windows.Forms.Padding(2);
             this.PneumaticTab.Name = "PneumaticTab";
-            this.PneumaticTab.Size = new System.Drawing.Size(273, 77);
+            this.PneumaticTab.Size = new System.Drawing.Size(203, 60);
             this.PneumaticTab.TabIndex = 1;
             this.PneumaticTab.Text = "Pneumatic";
             this.PneumaticTab.UseVisualStyleBackColor = true;
@@ -182,9 +172,10 @@
             // PressureLabel
             // 
             this.PressureLabel.AutoSize = true;
-            this.PressureLabel.Location = new System.Drawing.Point(133, 11);
+            this.PressureLabel.Location = new System.Drawing.Point(100, 9);
+            this.PressureLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.PressureLabel.Name = "PressureLabel";
-            this.PressureLabel.Size = new System.Drawing.Size(65, 17);
+            this.PressureLabel.Size = new System.Drawing.Size(48, 13);
             this.PressureLabel.TabIndex = 13;
             this.PressureLabel.Text = "Pressure";
             // 
@@ -197,10 +188,10 @@
             "60 psi",
             "20 psi",
             "10 psi"});
-            this.PneumaticPressureComboBox.Location = new System.Drawing.Point(136, 32);
-            this.PneumaticPressureComboBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.PneumaticPressureComboBox.Location = new System.Drawing.Point(102, 26);
+            this.PneumaticPressureComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.PneumaticPressureComboBox.Name = "PneumaticPressureComboBox";
-            this.PneumaticPressureComboBox.Size = new System.Drawing.Size(120, 24);
+            this.PneumaticPressureComboBox.Size = new System.Drawing.Size(91, 21);
             this.PneumaticPressureComboBox.TabIndex = 6;
             // 
             // PneumaticDiameterComboBox
@@ -211,18 +202,19 @@
             "1 in",
             ".5 in",
             ".25 in"});
-            this.PneumaticDiameterComboBox.Location = new System.Drawing.Point(5, 32);
-            this.PneumaticDiameterComboBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.PneumaticDiameterComboBox.Location = new System.Drawing.Point(4, 26);
+            this.PneumaticDiameterComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.PneumaticDiameterComboBox.Name = "PneumaticDiameterComboBox";
-            this.PneumaticDiameterComboBox.Size = new System.Drawing.Size(124, 24);
+            this.PneumaticDiameterComboBox.Size = new System.Drawing.Size(94, 21);
             this.PneumaticDiameterComboBox.TabIndex = 12;
             // 
             // DiameterLabel
             // 
             this.DiameterLabel.AutoSize = true;
-            this.DiameterLabel.Location = new System.Drawing.Point(3, 11);
+            this.DiameterLabel.Location = new System.Drawing.Point(2, 9);
+            this.DiameterLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.DiameterLabel.Name = "DiameterLabel";
-            this.DiameterLabel.Size = new System.Drawing.Size(116, 17);
+            this.DiameterLabel.Size = new System.Drawing.Size(87, 13);
             this.DiameterLabel.TabIndex = 9;
             this.DiameterLabel.Text = "Internal Diameter";
             // 
@@ -233,11 +225,9 @@
             this.PortsGroupBox.Controls.Add(this.PortTwoLabel);
             this.PortsGroupBox.Controls.Add(this.PortOneLabel);
             this.PortsGroupBox.Controls.Add(this.PortOneUpDown);
-            this.PortsGroupBox.Location = new System.Drawing.Point(13, 54);
-            this.PortsGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.PortsGroupBox.Location = new System.Drawing.Point(10, 44);
             this.PortsGroupBox.Name = "PortsGroupBox";
-            this.PortsGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.PortsGroupBox.Size = new System.Drawing.Size(565, 63);
+            this.PortsGroupBox.Size = new System.Drawing.Size(424, 51);
             this.PortsGroupBox.TabIndex = 6;
             this.PortsGroupBox.TabStop = false;
             this.PortsGroupBox.Text = "Ports";
@@ -245,10 +235,9 @@
             // AutoAssignCheckBox
             // 
             this.AutoAssignCheckBox.AutoSize = true;
-            this.AutoAssignCheckBox.Location = new System.Drawing.Point(328, 25);
-            this.AutoAssignCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.AutoAssignCheckBox.Location = new System.Drawing.Point(246, 20);
             this.AutoAssignCheckBox.Name = "AutoAssignCheckBox";
-            this.AutoAssignCheckBox.Size = new System.Drawing.Size(106, 21);
+            this.AutoAssignCheckBox.Size = new System.Drawing.Size(82, 17);
             this.AutoAssignCheckBox.TabIndex = 4;
             this.AutoAssignCheckBox.Text = "Auto-Assign";
             this.AutoAssignCheckBox.UseVisualStyleBackColor = true;
@@ -256,8 +245,7 @@
             // 
             // PortTwoUpDown
             // 
-            this.PortTwoUpDown.Location = new System.Drawing.Point(196, 23);
-            this.PortTwoUpDown.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.PortTwoUpDown.Location = new System.Drawing.Point(147, 19);
             this.PortTwoUpDown.Maximum = new decimal(new int[] {
             20,
             0,
@@ -269,7 +257,7 @@
             0,
             0});
             this.PortTwoUpDown.Name = "PortTwoUpDown";
-            this.PortTwoUpDown.Size = new System.Drawing.Size(63, 22);
+            this.PortTwoUpDown.Size = new System.Drawing.Size(47, 20);
             this.PortTwoUpDown.TabIndex = 3;
             this.PortTwoUpDown.Value = new decimal(new int[] {
             3,
@@ -280,27 +268,24 @@
             // PortTwoLabel
             // 
             this.PortTwoLabel.AutoSize = true;
-            this.PortTwoLabel.Location = new System.Drawing.Point(137, 26);
-            this.PortTwoLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.PortTwoLabel.Location = new System.Drawing.Point(103, 21);
             this.PortTwoLabel.Name = "PortTwoLabel";
-            this.PortTwoLabel.Size = new System.Drawing.Size(50, 17);
+            this.PortTwoLabel.Size = new System.Drawing.Size(38, 13);
             this.PortTwoLabel.TabIndex = 2;
             this.PortTwoLabel.Text = "Port 2:";
             // 
             // PortOneLabel
             // 
             this.PortOneLabel.AutoSize = true;
-            this.PortOneLabel.Location = new System.Drawing.Point(8, 26);
-            this.PortOneLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.PortOneLabel.Location = new System.Drawing.Point(6, 21);
             this.PortOneLabel.Name = "PortOneLabel";
-            this.PortOneLabel.Size = new System.Drawing.Size(50, 17);
+            this.PortOneLabel.Size = new System.Drawing.Size(38, 13);
             this.PortOneLabel.TabIndex = 1;
             this.PortOneLabel.Text = "Port 1:";
             // 
             // PortOneUpDown
             // 
-            this.PortOneUpDown.Location = new System.Drawing.Point(67, 23);
-            this.PortOneUpDown.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.PortOneUpDown.Location = new System.Drawing.Point(50, 19);
             this.PortOneUpDown.Maximum = new decimal(new int[] {
             20,
             0,
@@ -312,7 +297,7 @@
             0,
             0});
             this.PortOneUpDown.Name = "PortOneUpDown";
-            this.PortOneUpDown.Size = new System.Drawing.Size(63, 22);
+            this.PortOneUpDown.Size = new System.Drawing.Size(47, 20);
             this.PortOneUpDown.TabIndex = 0;
             this.PortOneUpDown.Value = new decimal(new int[] {
             2,
@@ -331,55 +316,31 @@
             "Bumper Pneumatic",
             "Relay Pneumatic",
             "Dual Motor"});
-            this.DriverComboBox.Location = new System.Drawing.Point(112, 21);
-            this.DriverComboBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.DriverComboBox.Location = new System.Drawing.Point(84, 17);
             this.DriverComboBox.Name = "DriverComboBox";
-            this.DriverComboBox.Size = new System.Drawing.Size(465, 24);
+            this.DriverComboBox.Size = new System.Drawing.Size(350, 21);
             this.DriverComboBox.TabIndex = 2;
             this.DriverComboBox.SelectedIndexChanged += new System.EventHandler(this.DriverComboBox_SelectedIndexChanged);
             // 
             // SelectDriverLabel
             // 
             this.SelectDriverLabel.AutoSize = true;
-            this.SelectDriverLabel.Location = new System.Drawing.Point(9, 25);
-            this.SelectDriverLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.SelectDriverLabel.Location = new System.Drawing.Point(7, 20);
             this.SelectDriverLabel.Name = "SelectDriverLabel";
-            this.SelectDriverLabel.Size = new System.Drawing.Size(93, 17);
+            this.SelectDriverLabel.Size = new System.Drawing.Size(71, 13);
             this.SelectDriverLabel.TabIndex = 1;
             this.SelectDriverLabel.Text = "Select Driver:";
             // 
-            // MergeNodeButton
-            // 
-            this.MergeNodeButton.Location = new System.Drawing.Point(5, 239);
-            this.MergeNodeButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.MergeNodeButton.Name = "MergeNodeButton";
-            this.MergeNodeButton.Size = new System.Drawing.Size(283, 28);
-            this.MergeNodeButton.TabIndex = 1;
-            this.MergeNodeButton.Text = "Merge Node Into Parent";
-            this.MergeNodeButton.UseVisualStyleBackColor = true;
-            this.MergeNodeButton.Click += new System.EventHandler(this.MergeNodeButton_Click);
-            // 
-            // InventorHighlightButton
-            // 
-            this.InventorHighlightButton.Location = new System.Drawing.Point(296, 239);
-            this.InventorHighlightButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.InventorHighlightButton.Name = "InventorHighlightButton";
-            this.InventorHighlightButton.Size = new System.Drawing.Size(283, 28);
-            this.InventorHighlightButton.TabIndex = 2;
-            this.InventorHighlightButton.Text = "View Node in Inventor";
-            this.InventorHighlightButton.UseVisualStyleBackColor = true;
-            this.InventorHighlightButton.Click += new System.EventHandler(this.InventorHighlightButton_Click);
-            // 
             // DefinePartPanel
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.InventorHighlightButton);
-            this.Controls.Add(this.MergeNodeButton);
+            this.AutoSize = true;
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.Controls.Add(this.NodeGroupBox);
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "DefinePartPanel";
-            this.Size = new System.Drawing.Size(583, 271);
+            this.Size = new System.Drawing.Size(443, 205);
+            this.MouseHover += new System.EventHandler(this.HighlightNode);
             this.NodeGroupBox.ResumeLayout(false);
             this.NodeGroupBox.PerformLayout();
             this.JointLimitGroupBox.ResumeLayout(false);
@@ -394,6 +355,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.PortTwoUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.PortOneUpDown)).EndInit();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -421,7 +383,5 @@
         private System.Windows.Forms.NumericUpDown LowerLimitUpDown;
         private System.Windows.Forms.Label TotalFreedomLabel;
         private System.Windows.Forms.Label FreedomFactorLabel;
-        private System.Windows.Forms.Button MergeNodeButton;
-        private System.Windows.Forms.Button InventorHighlightButton;
     }
 }

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.Designer.cs
@@ -52,6 +52,7 @@
             this.SelectDriverLabel = new System.Windows.Forms.Label();
             this.MainTableLayout = new System.Windows.Forms.TableLayoutPanel();
             this.DriverLayout = new System.Windows.Forms.TableLayoutPanel();
+            this.PneumaticLayout = new System.Windows.Forms.TableLayoutPanel();
             this.NodeGroupBox.SuspendLayout();
             this.JointLimitGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.UpperLimitUpDown)).BeginInit();
@@ -63,6 +64,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.PortOneUpDown)).BeginInit();
             this.MainTableLayout.SuspendLayout();
             this.DriverLayout.SuspendLayout();
+            this.PneumaticLayout.SuspendLayout();
             this.SuspendLayout();
             // 
             // NodeGroupBox
@@ -73,7 +75,7 @@
             this.NodeGroupBox.Controls.Add(this.MainTableLayout);
             this.NodeGroupBox.Location = new System.Drawing.Point(0, 0);
             this.NodeGroupBox.Name = "NodeGroupBox";
-            this.NodeGroupBox.Size = new System.Drawing.Size(374, 252);
+            this.NodeGroupBox.Size = new System.Drawing.Size(374, 254);
             this.NodeGroupBox.TabIndex = 0;
             this.NodeGroupBox.TabStop = false;
             this.NodeGroupBox.Text = "Empty";
@@ -154,20 +156,17 @@
             this.MetaTabControl.Margin = new System.Windows.Forms.Padding(2);
             this.MetaTabControl.Name = "MetaTabControl";
             this.MetaTabControl.SelectedIndex = 0;
-            this.MetaTabControl.Size = new System.Drawing.Size(177, 126);
+            this.MetaTabControl.Size = new System.Drawing.Size(177, 128);
             this.MetaTabControl.TabIndex = 12;
             this.MetaTabControl.Visible = false;
             // 
             // PneumaticTab
             // 
-            this.PneumaticTab.Controls.Add(this.PressureLabel);
-            this.PneumaticTab.Controls.Add(this.PneumaticPressureComboBox);
-            this.PneumaticTab.Controls.Add(this.PneumaticDiameterComboBox);
-            this.PneumaticTab.Controls.Add(this.DiameterLabel);
+            this.PneumaticTab.Controls.Add(this.PneumaticLayout);
             this.PneumaticTab.Location = new System.Drawing.Point(4, 22);
             this.PneumaticTab.Margin = new System.Windows.Forms.Padding(2);
             this.PneumaticTab.Name = "PneumaticTab";
-            this.PneumaticTab.Size = new System.Drawing.Size(169, 100);
+            this.PneumaticTab.Size = new System.Drawing.Size(169, 102);
             this.PneumaticTab.TabIndex = 1;
             this.PneumaticTab.Text = "Pneumatic";
             this.PneumaticTab.UseVisualStyleBackColor = true;
@@ -175,8 +174,8 @@
             // PressureLabel
             // 
             this.PressureLabel.AutoSize = true;
-            this.PressureLabel.Location = new System.Drawing.Point(2, 59);
-            this.PressureLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.PressureLabel.Location = new System.Drawing.Point(3, 47);
+            this.PressureLabel.Margin = new System.Windows.Forms.Padding(3);
             this.PressureLabel.Name = "PressureLabel";
             this.PressureLabel.Size = new System.Drawing.Size(48, 13);
             this.PressureLabel.TabIndex = 13;
@@ -184,6 +183,7 @@
             // 
             // PneumaticPressureComboBox
             // 
+            this.PneumaticPressureComboBox.Dock = System.Windows.Forms.DockStyle.Top;
             this.PneumaticPressureComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.PneumaticPressureComboBox.FormattingEnabled = true;
             this.PneumaticPressureComboBox.ImeMode = System.Windows.Forms.ImeMode.NoControl;
@@ -191,31 +191,32 @@
             "60 psi",
             "20 psi",
             "10 psi"});
-            this.PneumaticPressureComboBox.Location = new System.Drawing.Point(4, 74);
+            this.PneumaticPressureComboBox.Location = new System.Drawing.Point(2, 65);
             this.PneumaticPressureComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.PneumaticPressureComboBox.Name = "PneumaticPressureComboBox";
-            this.PneumaticPressureComboBox.Size = new System.Drawing.Size(94, 21);
+            this.PneumaticPressureComboBox.Size = new System.Drawing.Size(165, 21);
             this.PneumaticPressureComboBox.TabIndex = 6;
             // 
             // PneumaticDiameterComboBox
             // 
+            this.PneumaticDiameterComboBox.Dock = System.Windows.Forms.DockStyle.Top;
             this.PneumaticDiameterComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.PneumaticDiameterComboBox.FormattingEnabled = true;
             this.PneumaticDiameterComboBox.Items.AddRange(new object[] {
             "1 in",
             ".5 in",
             ".25 in"});
-            this.PneumaticDiameterComboBox.Location = new System.Drawing.Point(4, 26);
+            this.PneumaticDiameterComboBox.Location = new System.Drawing.Point(2, 21);
             this.PneumaticDiameterComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.PneumaticDiameterComboBox.Name = "PneumaticDiameterComboBox";
-            this.PneumaticDiameterComboBox.Size = new System.Drawing.Size(94, 21);
+            this.PneumaticDiameterComboBox.Size = new System.Drawing.Size(165, 21);
             this.PneumaticDiameterComboBox.TabIndex = 12;
             // 
             // DiameterLabel
             // 
             this.DiameterLabel.AutoSize = true;
-            this.DiameterLabel.Location = new System.Drawing.Point(2, 9);
-            this.DiameterLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.DiameterLabel.Location = new System.Drawing.Point(3, 3);
+            this.DiameterLabel.Margin = new System.Windows.Forms.Padding(3);
             this.DiameterLabel.Name = "DiameterLabel";
             this.DiameterLabel.Size = new System.Drawing.Size(87, 13);
             this.DiameterLabel.TabIndex = 9;
@@ -357,7 +358,7 @@
             this.MainTableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.MainTableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.MainTableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.MainTableLayout.Size = new System.Drawing.Size(362, 214);
+            this.MainTableLayout.Size = new System.Drawing.Size(362, 216);
             this.MainTableLayout.TabIndex = 14;
             // 
             // DriverLayout
@@ -379,6 +380,27 @@
             this.DriverLayout.Size = new System.Drawing.Size(362, 27);
             this.DriverLayout.TabIndex = 0;
             // 
+            // PneumaticLayout
+            // 
+            this.PneumaticLayout.AutoSize = true;
+            this.PneumaticLayout.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.PneumaticLayout.ColumnCount = 1;
+            this.PneumaticLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.PneumaticLayout.Controls.Add(this.PressureLabel, 0, 2);
+            this.PneumaticLayout.Controls.Add(this.DiameterLabel, 0, 0);
+            this.PneumaticLayout.Controls.Add(this.PneumaticPressureComboBox, 0, 3);
+            this.PneumaticLayout.Controls.Add(this.PneumaticDiameterComboBox, 0, 1);
+            this.PneumaticLayout.Dock = System.Windows.Forms.DockStyle.Top;
+            this.PneumaticLayout.Location = new System.Drawing.Point(0, 0);
+            this.PneumaticLayout.Name = "PneumaticLayout";
+            this.PneumaticLayout.RowCount = 4;
+            this.PneumaticLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.PneumaticLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.PneumaticLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.PneumaticLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.PneumaticLayout.Size = new System.Drawing.Size(169, 88);
+            this.PneumaticLayout.TabIndex = 15;
+            // 
             // DefinePartPanel
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -388,7 +410,7 @@
             this.BackColor = System.Drawing.Color.Transparent;
             this.Controls.Add(this.NodeGroupBox);
             this.Name = "DefinePartPanel";
-            this.Size = new System.Drawing.Size(377, 255);
+            this.Size = new System.Drawing.Size(377, 257);
             this.NodeGroupBox.ResumeLayout(false);
             this.NodeGroupBox.PerformLayout();
             this.JointLimitGroupBox.ResumeLayout(false);
@@ -406,6 +428,8 @@
             this.MainTableLayout.PerformLayout();
             this.DriverLayout.ResumeLayout(false);
             this.DriverLayout.PerformLayout();
+            this.PneumaticLayout.ResumeLayout(false);
+            this.PneumaticLayout.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -437,5 +461,6 @@
         private System.Windows.Forms.Label FreedomFactorLabel;
         private System.Windows.Forms.TableLayoutPanel MainTableLayout;
         private System.Windows.Forms.TableLayoutPanel DriverLayout;
+        private System.Windows.Forms.TableLayoutPanel PneumaticLayout;
     }
 }

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.Designer.cs
@@ -65,6 +65,7 @@
             // 
             this.NodeGroupBox.AutoSize = true;
             this.NodeGroupBox.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.NodeGroupBox.BackColor = System.Drawing.SystemColors.Control;
             this.NodeGroupBox.Controls.Add(this.JointLimitGroupBox);
             this.NodeGroupBox.Controls.Add(this.MetaTabControl);
             this.NodeGroupBox.Controls.Add(this.PortsGroupBox);
@@ -337,10 +338,10 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.BackColor = System.Drawing.Color.Transparent;
             this.Controls.Add(this.NodeGroupBox);
             this.Name = "DefinePartPanel";
             this.Size = new System.Drawing.Size(443, 205);
-            this.MouseHover += new System.EventHandler(this.HighlightNode);
             this.NodeGroupBox.ResumeLayout(false);
             this.NodeGroupBox.PerformLayout();
             this.JointLimitGroupBox.ResumeLayout(false);

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
@@ -133,42 +133,11 @@ namespace BxDRobotExporter.Wizard
         }
 
         /// <summary>
-        /// Warns the user and then merges the node into its parent node.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void MergeNodeButton_Click(object sender, EventArgs e)
-        {
-            if(MessageBox.Show("Are you sure you want to merge this node into the parent node? (Use this only if you don't want this part of the robot to move in the simulation)\n This cannot be undone.", "Merge Node", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
-            {
-                foreach(Control control in this.Controls)
-                {
-                    if (!(control is Button))
-                        control.Enabled = false;
-                }
-                Label mergedLabel = new Label
-                {
-                    Text = "Merged " + node.ModelFileName + " into " + node.GetParent().ModelFileName,
-                    Font = new Font(DefaultFont.FontFamily, 12.0f),
-                    BackColor = System.Windows.Forms.Control.DefaultBackColor,
-                    ForeColor = Color.DarkGray,
-                    AutoSize = false,
-                    Dock = DockStyle.Fill,
-                    TextAlign = ContentAlignment.MiddleCenter
-                };
-                this.Controls.Add(mergedLabel);
-                mergedLabel.BringToFront();
-
-                WizardData.Instance.MergeQueue.Add(node);
-            }
-        }
-
-        /// <summary>
         /// Highlights the node in inventor.
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void InventorHighlightButton_Click(object sender, EventArgs e)
+        private void HighlightNode(object sender, EventArgs e)
         {
             StandardAddInServer.Instance.WizardSelect(node);
         }

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
@@ -35,18 +35,21 @@ namespace BxDRobotExporter.Wizard
         {
             InitializeComponent();
         }
-        
+
         public DefinePartPanel(RigidNode_Base node)
         {
             InitializeComponent();
             BackColor = DefaultBackColor;
             this.node = node;
-            this.NodeGroupBox.Text = node.ModelFileName;
+            NodeGroupBox.Text = node.ModelFileName;
 
             DriverComboBox.SelectedIndex = 0;
             DriverComboBox_SelectedIndexChanged(null, null);
             PortTwoUpDown.Minimum = WizardData.Instance.nextFreePort;
             PortOneUpDown.Minimum = WizardData.Instance.nextFreePort;
+
+            // Add a highlight component action to all children. This is simpler than manually adding the hover event to each control.
+            AddHighlightAction(this);
         }
 
         private void AutoAssignCheckBox_CheckedChanged(object sender, EventArgs e)
@@ -140,6 +143,14 @@ namespace BxDRobotExporter.Wizard
         private void HighlightNode(object sender, EventArgs e)
         {
             StandardAddInServer.Instance.WizardSelect(node);
+        }
+
+        private void AddHighlightAction(Control baseControl)
+        {
+            baseControl.MouseHover += HighlightNode;
+
+            foreach (Control control in baseControl.Controls)
+                AddHighlightAction(control);
         }
 
         /// <summary>


### PR DESCRIPTION
This branch affects the non-wheel driver configuration in the exporter wizard. Removed the "view in inventor" and "merge node" buttons. Viewing joints in inventor can now be achieved by hovering your mouse over the joint in the wizard. This resolves AARD-580.