### PR TITLE
Fixed some replay mode bugs

### DIFF
--- a/engine/unity5/Assets/Scripts/States/LoadReplayState.cs
+++ b/engine/unity5/Assets/Scripts/States/LoadReplayState.cs
@@ -58,6 +58,7 @@ namespace Synthesis.States
             if (entry != null)
             {
                 splashScreen.SetActive(true);
+                replayList.SetActive(false);
                 PlayerPrefs.SetString("simSelectedReplay", entry);
                 PlayerPrefs.Save();
                 Application.LoadLevel("Scene");

--- a/engine/unity5/Assets/Scripts/States/MainState.cs
+++ b/engine/unity5/Assets/Scripts/States/MainState.cs
@@ -535,7 +535,8 @@ namespace Synthesis.States
             lastFrameCount = physicsWorld.frameCount;
             Tracking = true;
 
-            CollisionTracker.Reset();
+            if (!awaitingReplay)
+                CollisionTracker.Reset();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed a bug where the replay list would remain visible as the replay was loading. Also fixed an issue where collisions would not show up in a loaded replay.

Testing should involve recording a replay, saving it, returning to the main menu, loading the replay, and ensuring that the issues described above are fixed.