### PR TITLE
Improved Weight Setting Consistency

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Data/WizardData.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Data/WizardData.cs
@@ -210,7 +210,7 @@ namespace BxDRobotExporter.Wizard
         /// </summary>
         public void Apply()
         {
-            Utilities.GUI.TotalWeightKg = weightKg;
+            Utilities.GUI.RMeta.TotalWeightKg = weightKg;
 
             //WheelSetupPage
             foreach (WheelSetupData data in wheels)

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Data/WizardData.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Data/WizardData.cs
@@ -167,6 +167,11 @@ namespace BxDRobotExporter.Wizard
         /// The total weight of the robot in kilograms
         /// </summary>
         public float weightKg;
+
+        /// <summary>
+        /// Whether weight units should be expressed in kilograms or pounds.
+        /// </summary>
+        public bool preferMetric;
         #endregion
 
         #region DefineWheelsPage
@@ -211,6 +216,7 @@ namespace BxDRobotExporter.Wizard
         public void Apply()
         {
             Utilities.GUI.RMeta.TotalWeightKg = weightKg;
+            Utilities.GUI.RMeta.PreferMetric = preferMetric;
 
             //WheelSetupPage
             foreach (WheelSetupData data in wheels)

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.cs
@@ -247,13 +247,9 @@ namespace BxDRobotExporter.Wizard
         private void UpdateWeight()
         {
             if (WeightUnitSelector.SelectedIndex == 0)
-            {
                 totalWeightKg = (float)WeightBox.Value / 2.20462f;
-            }
             else
-            {
                 totalWeightKg = (float)WeightBox.Value;
-            }
 
             preferMetric = WeightUnitSelector.SelectedIndex == 1;
         }

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.cs
@@ -48,12 +48,7 @@ namespace BxDRobotExporter.Wizard
 
             // Load weight information
             preferMetric = Utilities.GUI.RMeta.PreferMetric;
-
-            if (Utilities.GUI.RMeta.TotalWeightKg * (preferMetric ? 1 : 2.20462f) > (float)WeightBox.Maximum)
-                WeightBox.Value = WeightBox.Maximum;
-            else
-                WeightBox.Value = (decimal)(Utilities.GUI.RMeta.TotalWeightKg * (preferMetric ? 1 : 2.20462f));
-
+            SetWeightBoxValue(Utilities.GUI.RMeta.TotalWeightKg * (preferMetric ? 1 : 2.20462f));
             WeightUnitSelector.SelectedIndex = Utilities.GUI.RMeta.PreferMetric ? 1 : 0;
 
             Initialize();
@@ -261,6 +256,16 @@ namespace BxDRobotExporter.Wizard
             }
 
             preferMetric = WeightUnitSelector.SelectedIndex == 1;
+        }
+
+        private void SetWeightBoxValue(float value)
+        {
+            if ((decimal)value > WeightBox.Maximum)
+                WeightBox.Value = WeightBox.Maximum;
+            else if ((decimal)value >= WeightBox.Minimum)
+                WeightBox.Value = (decimal)value;
+            else
+                WeightBox.Value = 0;
         }
 
         private void NodeListBox_MouseDown(object sender, MouseEventArgs e)

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.cs
@@ -16,7 +16,8 @@ namespace BxDRobotExporter.Wizard
     /// </summary>
     public partial class DefineWheelsPage : UserControl, IWizardPage
     {
-        private int totalWeightKg = 0;
+        private float totalWeightKg = 0;
+        private bool preferMetric = false;
 
         /// <summary>
         /// Dictionary associating node file names with their respective <see cref="RigidNode_Base"/>s
@@ -44,8 +45,18 @@ namespace BxDRobotExporter.Wizard
             leftSlots = new List<WheelSlotPanel>();
 
             NodeListBox.Enabled = false;
+
+            // Load weight information
+            preferMetric = Utilities.GUI.RMeta.PreferMetric;
+
+            if (Utilities.GUI.RMeta.TotalWeightKg * (preferMetric ? 1 : 2.20462f) > (float)WeightBox.Maximum)
+                WeightBox.Value = WeightBox.Maximum;
+            else
+                WeightBox.Value = (decimal)(Utilities.GUI.RMeta.TotalWeightKg * (preferMetric ? 1 : 2.20462f));
+
+            WeightUnitSelector.SelectedIndex = Utilities.GUI.RMeta.PreferMetric ? 1 : 0;
+
             Initialize();
-            
         }
 
         /// <summary>
@@ -108,6 +119,7 @@ namespace BxDRobotExporter.Wizard
         public void OnNext()
         {
             WizardData.Instance.weightKg = totalWeightKg;
+            WizardData.Instance.preferMetric = preferMetric;
             WizardData.Instance.wheels = new List<WizardData.WheelSetupData>();
             foreach(var slot in rightSlots)
             {
@@ -241,12 +253,14 @@ namespace BxDRobotExporter.Wizard
         {
             if (WeightUnitSelector.SelectedIndex == 0)
             {
-                totalWeightKg = (int)Math.Round(Convert.ToDouble(WeightBox.Value) / 2.20462);
+                totalWeightKg = (float)WeightBox.Value / 2.20462f;
             }
             else
             {
-                totalWeightKg = (int)Math.Round(Convert.ToDouble(WeightBox.Value));
+                totalWeightKg = (float)WeightBox.Value;
             }
+
+            preferMetric = WeightUnitSelector.SelectedIndex == 1;
         }
 
         private void NodeListBox_MouseDown(object sender, MouseEventArgs e)

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/LiteExporterForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/LiteExporterForm.cs
@@ -143,7 +143,7 @@ public partial class LiteExporterForm : Form
         if (SynthesisGUI.Instance.SkeletonBase == null)
             return; // Skeleton has not been built
 
-        List<BXDAMesh> Meshes = ExportMeshesLite(SynthesisGUI.Instance.SkeletonBase, SynthesisGUI.Instance.TotalWeightKg);
+        List<BXDAMesh> Meshes = ExportMeshesLite(SynthesisGUI.Instance.SkeletonBase, SynthesisGUI.Instance.RMeta.TotalWeightKg);
 
         SynthesisGUI.Instance.Meshes = Meshes;
     }

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
@@ -32,6 +32,7 @@ public partial class SynthesisGUI : Form
         public bool UseSettingsDir;
         public string ActiveDir;
         public string ActiveRobotName;
+        public float TotalWeightKg;
         public string FieldName;
 
         public static RuntimeMeta CreateRuntimeMeta()
@@ -41,6 +42,7 @@ public partial class SynthesisGUI : Form
                 UseSettingsDir = true,
                 ActiveDir = null,
                 ActiveRobotName = null,
+                TotalWeightKg = -1, // Negative value indicates to use inventor mass
                 FieldName = null
             };
         }
@@ -65,8 +67,6 @@ public partial class SynthesisGUI : Form
     public RigidNode_Base SkeletonBase = null;
     public List<BXDAMesh> Meshes = null;
     public bool MeshesAreColored = false;
-    // TODO: This should be moved to RMeta
-    public float TotalWeightKg = -1; // Negative value indicates default mass should be left alone
 
     private SkeletonExporterForm skeletonExporter;
     private LiteExporterForm liteExporter;
@@ -386,7 +386,7 @@ public partial class SynthesisGUI : Form
             if (propertySet != null)
             {
                 RMeta.ActiveRobotName = Utilities.GetProperty(propertySet, "robot-name", "");
-                TotalWeightKg = Utilities.GetProperty(propertySet, "robot-weight-kg", 0);
+                RMeta.TotalWeightKg = Utilities.GetProperty(propertySet, "robot-weight-kg", 0);
             }
 
             // Load joint data
@@ -504,7 +504,7 @@ public partial class SynthesisGUI : Form
 
             if (RMeta.ActiveRobotName != null)
                 Utilities.SetProperty(propertySet, "robot-name", RMeta.ActiveRobotName);
-            Utilities.SetProperty(propertySet, "robot-weight-kg", TotalWeightKg);
+            Utilities.SetProperty(propertySet, "robot-weight-kg", RMeta.TotalWeightKg);
 
             // Save joint data
             return SaveJointData(propertySets, SkeletonBase);
@@ -682,7 +682,7 @@ public partial class SynthesisGUI : Form
             weightForm.ShowDialog();
 
             if (weightForm.DialogResult == DialogResult.OK)
-                TotalWeightKg = weightForm.TotalWeightKg;
+                RMeta.TotalWeightKg = weightForm.TotalWeightKg;
         }
         catch (Exception ex)
         {

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
@@ -33,6 +33,7 @@ public partial class SynthesisGUI : Form
         public string ActiveDir;
         public string ActiveRobotName;
         public float TotalWeightKg;
+        public bool PreferMetric;
         public string FieldName;
 
         public static RuntimeMeta CreateRuntimeMeta()
@@ -43,6 +44,7 @@ public partial class SynthesisGUI : Form
                 ActiveDir = null,
                 ActiveRobotName = null,
                 TotalWeightKg = -1, // Negative value indicates to use inventor mass
+                PreferMetric = false,
                 FieldName = null
             };
         }
@@ -387,6 +389,7 @@ public partial class SynthesisGUI : Form
             {
                 RMeta.ActiveRobotName = Utilities.GetProperty(propertySet, "robot-name", "");
                 RMeta.TotalWeightKg = Utilities.GetProperty(propertySet, "robot-weight-kg", 0);
+                RMeta.PreferMetric = Utilities.GetProperty(propertySet, "robot-prefer-metric", false);
             }
 
             // Load joint data
@@ -505,6 +508,7 @@ public partial class SynthesisGUI : Form
             if (RMeta.ActiveRobotName != null)
                 Utilities.SetProperty(propertySet, "robot-name", RMeta.ActiveRobotName);
             Utilities.SetProperty(propertySet, "robot-weight-kg", RMeta.TotalWeightKg);
+            Utilities.SetProperty(propertySet, "robot-prefer-metric", RMeta.PreferMetric);
 
             // Save joint data
             return SaveJointData(propertySets, SkeletonBase);

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
@@ -686,7 +686,10 @@ public partial class SynthesisGUI : Form
             weightForm.ShowDialog();
 
             if (weightForm.DialogResult == DialogResult.OK)
+            {
                 RMeta.TotalWeightKg = weightForm.TotalWeightKg;
+                RMeta.PreferMetric = weightForm.PreferMetric;
+            }
         }
         catch (Exception ex)
         {

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
@@ -393,7 +393,7 @@ public partial class SynthesisGUI : Form
             if (propertySet != null)
             {
                 RMeta.ActiveRobotName = Utilities.GetProperty(propertySet, "robot-name", "");
-                RMeta.TotalWeightKg = Utilities.GetProperty(propertySet, "robot-weight-kg", 0);
+                RMeta.TotalWeightKg = Utilities.GetProperty(propertySet, "robot-weight-kg", 0) / 10.0f; // Stored at x10 for better accuracy
                 RMeta.PreferMetric = Utilities.GetProperty(propertySet, "robot-prefer-metric", false);
             }
 
@@ -512,7 +512,7 @@ public partial class SynthesisGUI : Form
 
             if (RMeta.ActiveRobotName != null)
                 Utilities.SetProperty(propertySet, "robot-name", RMeta.ActiveRobotName);
-            Utilities.SetProperty(propertySet, "robot-weight-kg", RMeta.TotalWeightKg);
+            Utilities.SetProperty(propertySet, "robot-weight-kg", RMeta.TotalWeightKg * 10.0f); // x10 for better accuracy
             Utilities.SetProperty(propertySet, "robot-prefer-metric", RMeta.PreferMetric);
 
             // Save joint data

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
@@ -43,7 +43,7 @@ public partial class SynthesisGUI : Form
                 UseSettingsDir = true,
                 ActiveDir = null,
                 ActiveRobotName = null,
-                TotalWeightKg = -1, // Negative value indicates to use inventor mass
+                TotalWeightKg = 0,
                 PreferMetric = false,
                 FieldName = null
             };

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
@@ -32,7 +32,12 @@ public partial class SynthesisGUI : Form
         public bool UseSettingsDir;
         public string ActiveDir;
         public string ActiveRobotName;
-        public float TotalWeightKg;
+        private float _totalWeightKg;
+        public float TotalWeightKg
+        {
+            get => _totalWeightKg;
+            set => _totalWeightKg = (value > 0) ? value : 0; // Prevent negative weight values
+        }
         public bool PreferMetric;
         public string FieldName;
 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.Designer.cs
@@ -34,9 +34,9 @@
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.CancelButton = new System.Windows.Forms.Button();
             this.SaveButton = new System.Windows.Forms.Button();
+            this.CalculatedWeightCheck = new System.Windows.Forms.CheckBox();
             this.WeightLabel = new System.Windows.Forms.Label();
             this.UnitBox = new System.Windows.Forms.ComboBox();
-            this.CalculatedWeightCheck = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.WeightBox)).BeginInit();
             this.tableLayoutPanel1.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
@@ -117,6 +117,18 @@
             this.SaveButton.UseVisualStyleBackColor = true;
             this.SaveButton.Click += new System.EventHandler(this.SaveButton_Click);
             // 
+            // CalculatedWeightCheck
+            // 
+            this.CalculatedWeightCheck.AutoSize = true;
+            this.CalculatedWeightCheck.Dock = System.Windows.Forms.DockStyle.Left;
+            this.CalculatedWeightCheck.Location = new System.Drawing.Point(3, 3);
+            this.CalculatedWeightCheck.Name = "CalculatedWeightCheck";
+            this.CalculatedWeightCheck.Size = new System.Drawing.Size(131, 23);
+            this.CalculatedWeightCheck.TabIndex = 3;
+            this.CalculatedWeightCheck.Text = "Use calculated weight";
+            this.CalculatedWeightCheck.UseVisualStyleBackColor = true;
+            this.CalculatedWeightCheck.CheckedChanged += new System.EventHandler(this.CalculatedWeightCheck_CheckedChanged);
+            // 
             // WeightLabel
             // 
             this.WeightLabel.AutoSize = true;
@@ -139,18 +151,7 @@
             this.UnitBox.Name = "UnitBox";
             this.UnitBox.Size = new System.Drawing.Size(40, 21);
             this.UnitBox.TabIndex = 2;
-            // 
-            // CalculatedWeightCheck
-            // 
-            this.CalculatedWeightCheck.AutoSize = true;
-            this.CalculatedWeightCheck.Dock = System.Windows.Forms.DockStyle.Left;
-            this.CalculatedWeightCheck.Location = new System.Drawing.Point(3, 3);
-            this.CalculatedWeightCheck.Name = "CalculatedWeightCheck";
-            this.CalculatedWeightCheck.Size = new System.Drawing.Size(131, 23);
-            this.CalculatedWeightCheck.TabIndex = 3;
-            this.CalculatedWeightCheck.Text = "Use calculated weight";
-            this.CalculatedWeightCheck.UseVisualStyleBackColor = true;
-            this.CalculatedWeightCheck.CheckedChanged += new System.EventHandler(this.CalculatedWeightCheck_CheckedChanged);
+            this.UnitBox.SelectedIndexChanged += new System.EventHandler(this.UnitBox_SelectedIndexChanged);
             // 
             // SetWeightForm
             // 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.Designer.cs
@@ -44,6 +44,7 @@
             // 
             // WeightBox
             // 
+            this.WeightBox.Dock = System.Windows.Forms.DockStyle.Top;
             this.WeightBox.Location = new System.Drawing.Point(51, 4);
             this.WeightBox.Margin = new System.Windows.Forms.Padding(4);
             this.WeightBox.Maximum = new decimal(new int[] {
@@ -52,7 +53,7 @@
             0,
             0});
             this.WeightBox.Name = "WeightBox";
-            this.WeightBox.Size = new System.Drawing.Size(200, 20);
+            this.WeightBox.Size = new System.Drawing.Size(166, 20);
             this.WeightBox.TabIndex = 0;
             // 
             // tableLayoutPanel1
@@ -72,7 +73,7 @@
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(301, 57);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(302, 57);
             this.tableLayoutPanel1.TabIndex = 1;
             // 
             // tableLayoutPanel2
@@ -94,13 +95,13 @@
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 1;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(301, 29);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(302, 29);
             this.tableLayoutPanel2.TabIndex = 2;
             // 
             // CancelButton
             // 
             this.CancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.CancelButton.Location = new System.Drawing.Point(223, 3);
+            this.CancelButton.Location = new System.Drawing.Point(224, 3);
             this.CancelButton.Name = "CancelButton";
             this.CancelButton.Size = new System.Drawing.Size(75, 23);
             this.CancelButton.TabIndex = 1;
@@ -109,7 +110,7 @@
             // 
             // SaveButton
             // 
-            this.SaveButton.Location = new System.Drawing.Point(142, 3);
+            this.SaveButton.Location = new System.Drawing.Point(143, 3);
             this.SaveButton.Name = "SaveButton";
             this.SaveButton.Size = new System.Drawing.Size(75, 23);
             this.SaveButton.TabIndex = 2;
@@ -145,12 +146,13 @@
             // 
             this.UnitBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.UnitBox.Items.AddRange(new object[] {
-            "lbs",
-            "kg"});
-            this.UnitBox.Location = new System.Drawing.Point(258, 3);
+            "Pounds",
+            "Kilograms"});
+            this.UnitBox.Location = new System.Drawing.Point(224, 3);
             this.UnitBox.Name = "UnitBox";
-            this.UnitBox.Size = new System.Drawing.Size(40, 21);
+            this.UnitBox.Size = new System.Drawing.Size(75, 21);
             this.UnitBox.TabIndex = 2;
+            this.UnitBox.SelectedIndex = 0;
             this.UnitBox.SelectedIndexChanged += new System.EventHandler(this.UnitBox_SelectedIndexChanged);
             // 
             // SetWeightForm

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.Designer.cs
@@ -47,7 +47,7 @@
             this.WeightBox.Location = new System.Drawing.Point(51, 4);
             this.WeightBox.Margin = new System.Windows.Forms.Padding(4);
             this.WeightBox.Maximum = new decimal(new int[] {
-            1000,
+            150,
             0,
             0,
             0});

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.Designer.cs
@@ -153,7 +153,6 @@
             this.UnitBox.Size = new System.Drawing.Size(75, 21);
             this.UnitBox.TabIndex = 2;
             this.UnitBox.SelectedIndex = 0;
-            this.UnitBox.SelectedIndexChanged += new System.EventHandler(this.UnitBox_SelectedIndexChanged);
             // 
             // SetWeightForm
             // 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
@@ -20,7 +20,7 @@ namespace EditorsLibrary
         {
             InitializeComponent();
 
-            TotalWeightKg = SynthesisGUI.Instance.TotalWeightKg;
+            TotalWeightKg = SynthesisGUI.Instance.RMeta.TotalWeightKg;
 
             if (TotalWeightKg > 0)
             {

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
@@ -12,19 +12,21 @@ namespace EditorsLibrary
 {
     public partial class SetWeightForm : Form
     {
-        static bool IsMetric = false;
-
         public float TotalWeightKg = 0;
+        public bool PreferMetric = false;
 
         public SetWeightForm()
         {
             InitializeComponent();
 
             TotalWeightKg = SynthesisGUI.Instance.RMeta.TotalWeightKg;
+            PreferMetric = SynthesisGUI.Instance.RMeta.PreferMetric;
+            
+            UnitBox.SelectedIndex = PreferMetric ? 1 : 0;
 
             if (TotalWeightKg > 0)
             {
-                if (!IsMetric)
+                if (!PreferMetric)
                     WeightBox.Value = (decimal)(TotalWeightKg * 2.20462);
                 else
                     WeightBox.Value = (decimal)TotalWeightKg;
@@ -36,19 +38,17 @@ namespace EditorsLibrary
                 WeightBox.Value = 0;
                 CalculatedWeightCheck.Checked = true;
             }
-
-            UnitBox.SelectedIndex = IsMetric ? 1 : 0;
         }
 
         private void SaveButton_Click(object sender, EventArgs e)
         {
-            IsMetric = UnitBox.SelectedIndex == 1;
+            PreferMetric = UnitBox.SelectedIndex == 1;
 
             if (CalculatedWeightCheck.Checked)
                 TotalWeightKg = -1;
             else
             {
-                if (!IsMetric)
+                if (!PreferMetric)
                     TotalWeightKg = (float)WeightBox.Value / 2.20462f;
                 else
                     TotalWeightKg = (float)WeightBox.Value;
@@ -64,6 +64,14 @@ namespace EditorsLibrary
             WeightBox.Minimum = CalculatedWeightCheck.Checked ? 0 : 1;
             WeightBox.Value = CalculatedWeightCheck.Checked ? 0 : 100;
             UnitBox.Enabled = !CalculatedWeightCheck.Checked;
+        }
+
+        private void UnitBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (UnitBox.SelectedIndex == 0)
+                WeightBox.Value = (decimal)((float)WeightBox.Value / 2.20462f);
+            else
+                WeightBox.Value = (decimal)((float)WeightBox.Value * 2.20462f);
         }
     }
 }

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
@@ -72,6 +72,8 @@ namespace EditorsLibrary
             if (PreferMetric == (UnitBox.SelectedIndex == 1))
                 return;
 
+            PreferMetric = UnitBox.SelectedIndex == 1;
+
             if (UnitBox.SelectedIndex == 0)
                 WeightBox.Value = (decimal)((float)WeightBox.Value / 2.20462f);
             else

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
@@ -74,10 +74,18 @@ namespace EditorsLibrary
 
             PreferMetric = UnitBox.SelectedIndex == 1;
 
+            decimal weightBoxValue;
+
             if (UnitBox.SelectedIndex == 0)
-                WeightBox.Value = (decimal)((float)WeightBox.Value / 2.20462f);
+                weightBoxValue = (decimal)((float)WeightBox.Value / 2.20462f);
             else
-                WeightBox.Value = (decimal)((float)WeightBox.Value * 2.20462f);
+                weightBoxValue = (decimal)((float)WeightBox.Value * 2.20462f);
+
+            // Protection from going over max
+            if (weightBoxValue > WeightBox.Maximum)
+                weightBoxValue = WeightBox.Maximum;
+
+            WeightBox.Value = weightBoxValue;
         }
     }
 }

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
@@ -22,21 +22,8 @@ namespace EditorsLibrary
             TotalWeightKg = SynthesisGUI.Instance.RMeta.TotalWeightKg;
             PreferMetric = SynthesisGUI.Instance.RMeta.PreferMetric;
 
-            if (TotalWeightKg > 0)
-            {
-                if (!PreferMetric)
-                    WeightBox.Value = (decimal)(TotalWeightKg * 2.20462);
-                else
-                    WeightBox.Value = (decimal)TotalWeightKg;
-
-                CalculatedWeightCheck.Checked = false;
-            }
-            else
-            {
-                WeightBox.Value = 0;
-                CalculatedWeightCheck.Checked = true;
-            }
-
+            SetWeightBoxValue(TotalWeightKg * (PreferMetric ? 1 : 2.20462f));
+            CalculatedWeightCheck.Checked = TotalWeightKg <= 0;
             UnitBox.SelectedIndex = PreferMetric ? 1 : 0;
         }
 
@@ -74,18 +61,20 @@ namespace EditorsLibrary
 
             PreferMetric = UnitBox.SelectedIndex == 1;
 
-            decimal weightBoxValue;
-
             if (UnitBox.SelectedIndex == 0)
-                weightBoxValue = (decimal)((float)WeightBox.Value / 2.20462f);
+                SetWeightBoxValue((float)WeightBox.Value / 2.20462f);
             else
-                weightBoxValue = (decimal)((float)WeightBox.Value * 2.20462f);
+                SetWeightBoxValue((float)WeightBox.Value * 2.20462f);
+        }
 
-            // Protection from going over max
-            if (weightBoxValue > WeightBox.Maximum)
-                weightBoxValue = WeightBox.Maximum;
-
-            WeightBox.Value = weightBoxValue;
+        private void SetWeightBoxValue(float value)
+        {
+            if ((decimal)value > WeightBox.Maximum)
+                WeightBox.Value = WeightBox.Maximum;
+            else if ((decimal)value >= WeightBox.Minimum)
+                WeightBox.Value = (decimal)value;
+            else
+                WeightBox.Value = 0;
         }
     }
 }

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
@@ -62,9 +62,9 @@ namespace EditorsLibrary
             PreferMetric = UnitBox.SelectedIndex == 1;
 
             if (UnitBox.SelectedIndex == 0)
-                SetWeightBoxValue((float)WeightBox.Value / 2.20462f);
-            else
                 SetWeightBoxValue((float)WeightBox.Value * 2.20462f);
+            else
+                SetWeightBoxValue((float)WeightBox.Value / 2.20462f);
         }
 
         private void SetWeightBoxValue(float value)

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
@@ -21,8 +21,6 @@ namespace EditorsLibrary
 
             TotalWeightKg = SynthesisGUI.Instance.RMeta.TotalWeightKg;
             PreferMetric = SynthesisGUI.Instance.RMeta.PreferMetric;
-            
-            UnitBox.SelectedIndex = PreferMetric ? 1 : 0;
 
             if (TotalWeightKg > 0)
             {
@@ -38,6 +36,8 @@ namespace EditorsLibrary
                 WeightBox.Value = 0;
                 CalculatedWeightCheck.Checked = true;
             }
+
+            UnitBox.SelectedIndex = PreferMetric ? 1 : 0;
         }
 
         private void SaveButton_Click(object sender, EventArgs e)
@@ -68,6 +68,10 @@ namespace EditorsLibrary
 
         private void UnitBox_SelectedIndexChanged(object sender, EventArgs e)
         {
+            // Value did not change
+            if (PreferMetric == (UnitBox.SelectedIndex == 1))
+                return;
+
             if (UnitBox.SelectedIndex == 0)
                 WeightBox.Value = (decimal)((float)WeightBox.Value / 2.20462f);
             else

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.cs
@@ -53,20 +53,6 @@ namespace EditorsLibrary
             UnitBox.Enabled = !CalculatedWeightCheck.Checked;
         }
 
-        private void UnitBox_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            // Value did not change
-            if (PreferMetric == (UnitBox.SelectedIndex == 1))
-                return;
-
-            PreferMetric = UnitBox.SelectedIndex == 1;
-
-            if (UnitBox.SelectedIndex == 0)
-                SetWeightBoxValue((float)WeightBox.Value * 2.20462f);
-            else
-                SetWeightBoxValue((float)WeightBox.Value / 2.20462f);
-        }
-
         private void SetWeightBoxValue(float value)
         {
             if ((decimal)value > WeightBox.Maximum)


### PR DESCRIPTION
Resolves AARD-586:
- The weight controls in the wizard now more closely resemble those in the set weight form.
- Values for weight and units are synchronized between the wizard and the set weight form.
- Moved the back-end storage of weight from GUI to RMeta to make it more consistent with robot name.
- Chosen weight units are now saved to the assembly file along with the weight of the robot.