### PR TITLE
Auto-Assigned Ports for Other Moving Parts

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.Designer.cs
@@ -29,6 +29,15 @@
         private void InitializeComponent()
         {
             this.NodeGroupBox = new System.Windows.Forms.GroupBox();
+            this.MainTableLayout = new System.Windows.Forms.TableLayoutPanel();
+            this.PortsGroupBox = new System.Windows.Forms.GroupBox();
+            this.PortTwoUpDown = new System.Windows.Forms.NumericUpDown();
+            this.PortTwoLabel = new System.Windows.Forms.Label();
+            this.PortOneLabel = new System.Windows.Forms.Label();
+            this.PortOneUpDown = new System.Windows.Forms.NumericUpDown();
+            this.DriverLayout = new System.Windows.Forms.TableLayoutPanel();
+            this.SelectDriverLabel = new System.Windows.Forms.Label();
+            this.DriverComboBox = new System.Windows.Forms.ComboBox();
             this.JointLimitGroupBox = new System.Windows.Forms.GroupBox();
             this.TotalFreedomLabel = new System.Windows.Forms.Label();
             this.FreedomFactorLabel = new System.Windows.Forms.Label();
@@ -38,32 +47,22 @@
             this.LowerLimitUpDown = new System.Windows.Forms.NumericUpDown();
             this.MetaTabControl = new System.Windows.Forms.TabControl();
             this.PneumaticTab = new System.Windows.Forms.TabPage();
+            this.PneumaticLayout = new System.Windows.Forms.TableLayoutPanel();
             this.PressureLabel = new System.Windows.Forms.Label();
+            this.DiameterLabel = new System.Windows.Forms.Label();
             this.PneumaticPressureComboBox = new System.Windows.Forms.ComboBox();
             this.PneumaticDiameterComboBox = new System.Windows.Forms.ComboBox();
-            this.DiameterLabel = new System.Windows.Forms.Label();
-            this.PortsGroupBox = new System.Windows.Forms.GroupBox();
-            this.AutoAssignCheckBox = new System.Windows.Forms.CheckBox();
-            this.PortTwoUpDown = new System.Windows.Forms.NumericUpDown();
-            this.PortTwoLabel = new System.Windows.Forms.Label();
-            this.PortOneLabel = new System.Windows.Forms.Label();
-            this.PortOneUpDown = new System.Windows.Forms.NumericUpDown();
-            this.DriverComboBox = new System.Windows.Forms.ComboBox();
-            this.SelectDriverLabel = new System.Windows.Forms.Label();
-            this.MainTableLayout = new System.Windows.Forms.TableLayoutPanel();
-            this.DriverLayout = new System.Windows.Forms.TableLayoutPanel();
-            this.PneumaticLayout = new System.Windows.Forms.TableLayoutPanel();
             this.NodeGroupBox.SuspendLayout();
+            this.MainTableLayout.SuspendLayout();
+            this.PortsGroupBox.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.PortTwoUpDown)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.PortOneUpDown)).BeginInit();
+            this.DriverLayout.SuspendLayout();
             this.JointLimitGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.UpperLimitUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.LowerLimitUpDown)).BeginInit();
             this.MetaTabControl.SuspendLayout();
             this.PneumaticTab.SuspendLayout();
-            this.PortsGroupBox.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.PortTwoUpDown)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.PortOneUpDown)).BeginInit();
-            this.MainTableLayout.SuspendLayout();
-            this.DriverLayout.SuspendLayout();
             this.PneumaticLayout.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -74,272 +73,13 @@
             this.NodeGroupBox.BackColor = System.Drawing.SystemColors.Control;
             this.NodeGroupBox.Controls.Add(this.MainTableLayout);
             this.NodeGroupBox.Location = new System.Drawing.Point(0, 0);
+            this.NodeGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.NodeGroupBox.Name = "NodeGroupBox";
-            this.NodeGroupBox.Size = new System.Drawing.Size(374, 254);
+            this.NodeGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.NodeGroupBox.Size = new System.Drawing.Size(546, 311);
             this.NodeGroupBox.TabIndex = 0;
             this.NodeGroupBox.TabStop = false;
             this.NodeGroupBox.Text = "Empty";
-            // 
-            // JointLimitGroupBox
-            // 
-            this.JointLimitGroupBox.Controls.Add(this.TotalFreedomLabel);
-            this.JointLimitGroupBox.Controls.Add(this.FreedomFactorLabel);
-            this.JointLimitGroupBox.Controls.Add(this.UpperLimitUpDown);
-            this.JointLimitGroupBox.Controls.Add(this.UpperLimitLabel);
-            this.JointLimitGroupBox.Controls.Add(this.LowerLimitLabel);
-            this.JointLimitGroupBox.Controls.Add(this.LowerLimitUpDown);
-            this.JointLimitGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
-            this.JointLimitGroupBox.Location = new System.Drawing.Point(3, 87);
-            this.JointLimitGroupBox.Name = "JointLimitGroupBox";
-            this.JointLimitGroupBox.Size = new System.Drawing.Size(175, 83);
-            this.JointLimitGroupBox.TabIndex = 13;
-            this.JointLimitGroupBox.TabStop = false;
-            this.JointLimitGroupBox.Text = "Joint Limits";
-            // 
-            // TotalFreedomLabel
-            // 
-            this.TotalFreedomLabel.AutoSize = true;
-            this.TotalFreedomLabel.Location = new System.Drawing.Point(118, 28);
-            this.TotalFreedomLabel.Name = "TotalFreedomLabel";
-            this.TotalFreedomLabel.Size = new System.Drawing.Size(47, 13);
-            this.TotalFreedomLabel.TabIndex = 5;
-            this.TotalFreedomLabel.Text = "0.0 units";
-            // 
-            // FreedomFactorLabel
-            // 
-            this.FreedomFactorLabel.AutoSize = true;
-            this.FreedomFactorLabel.Location = new System.Drawing.Point(118, 16);
-            this.FreedomFactorLabel.Name = "FreedomFactorLabel";
-            this.FreedomFactorLabel.Size = new System.Drawing.Size(51, 13);
-            this.FreedomFactorLabel.TabIndex = 4;
-            this.FreedomFactorLabel.Text = "Freedom:";
-            // 
-            // UpperLimitUpDown
-            // 
-            this.UpperLimitUpDown.Location = new System.Drawing.Point(72, 26);
-            this.UpperLimitUpDown.Name = "UpperLimitUpDown";
-            this.UpperLimitUpDown.Size = new System.Drawing.Size(46, 20);
-            this.UpperLimitUpDown.TabIndex = 3;
-            this.UpperLimitUpDown.ValueChanged += new System.EventHandler(this.UpperLimitUpDown_ValueChanged);
-            // 
-            // UpperLimitLabel
-            // 
-            this.UpperLimitLabel.AutoSize = true;
-            this.UpperLimitLabel.Location = new System.Drawing.Point(6, 28);
-            this.UpperLimitLabel.Name = "UpperLimitLabel";
-            this.UpperLimitLabel.Size = new System.Drawing.Size(60, 13);
-            this.UpperLimitLabel.TabIndex = 2;
-            this.UpperLimitLabel.Text = "Upper Limit";
-            // 
-            // LowerLimitLabel
-            // 
-            this.LowerLimitLabel.AutoSize = true;
-            this.LowerLimitLabel.Location = new System.Drawing.Point(6, 55);
-            this.LowerLimitLabel.Name = "LowerLimitLabel";
-            this.LowerLimitLabel.Size = new System.Drawing.Size(60, 13);
-            this.LowerLimitLabel.TabIndex = 1;
-            this.LowerLimitLabel.Text = "Lower Limit";
-            // 
-            // LowerLimitUpDown
-            // 
-            this.LowerLimitUpDown.Location = new System.Drawing.Point(72, 53);
-            this.LowerLimitUpDown.Name = "LowerLimitUpDown";
-            this.LowerLimitUpDown.Size = new System.Drawing.Size(45, 20);
-            this.LowerLimitUpDown.TabIndex = 0;
-            this.LowerLimitUpDown.ValueChanged += new System.EventHandler(this.LowerLimitUpDown_ValueChanged);
-            // 
-            // MetaTabControl
-            // 
-            this.MetaTabControl.Controls.Add(this.PneumaticTab);
-            this.MetaTabControl.Dock = System.Windows.Forms.DockStyle.Top;
-            this.MetaTabControl.Location = new System.Drawing.Point(183, 86);
-            this.MetaTabControl.Margin = new System.Windows.Forms.Padding(2);
-            this.MetaTabControl.Name = "MetaTabControl";
-            this.MetaTabControl.SelectedIndex = 0;
-            this.MetaTabControl.Size = new System.Drawing.Size(177, 128);
-            this.MetaTabControl.TabIndex = 12;
-            this.MetaTabControl.Visible = false;
-            // 
-            // PneumaticTab
-            // 
-            this.PneumaticTab.Controls.Add(this.PneumaticLayout);
-            this.PneumaticTab.Location = new System.Drawing.Point(4, 22);
-            this.PneumaticTab.Margin = new System.Windows.Forms.Padding(2);
-            this.PneumaticTab.Name = "PneumaticTab";
-            this.PneumaticTab.Size = new System.Drawing.Size(169, 102);
-            this.PneumaticTab.TabIndex = 1;
-            this.PneumaticTab.Text = "Pneumatic";
-            this.PneumaticTab.UseVisualStyleBackColor = true;
-            // 
-            // PressureLabel
-            // 
-            this.PressureLabel.AutoSize = true;
-            this.PressureLabel.Location = new System.Drawing.Point(3, 47);
-            this.PressureLabel.Margin = new System.Windows.Forms.Padding(3);
-            this.PressureLabel.Name = "PressureLabel";
-            this.PressureLabel.Size = new System.Drawing.Size(48, 13);
-            this.PressureLabel.TabIndex = 13;
-            this.PressureLabel.Text = "Pressure";
-            // 
-            // PneumaticPressureComboBox
-            // 
-            this.PneumaticPressureComboBox.Dock = System.Windows.Forms.DockStyle.Top;
-            this.PneumaticPressureComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.PneumaticPressureComboBox.FormattingEnabled = true;
-            this.PneumaticPressureComboBox.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.PneumaticPressureComboBox.Items.AddRange(new object[] {
-            "60 psi",
-            "20 psi",
-            "10 psi"});
-            this.PneumaticPressureComboBox.Location = new System.Drawing.Point(2, 65);
-            this.PneumaticPressureComboBox.Margin = new System.Windows.Forms.Padding(2);
-            this.PneumaticPressureComboBox.Name = "PneumaticPressureComboBox";
-            this.PneumaticPressureComboBox.Size = new System.Drawing.Size(165, 21);
-            this.PneumaticPressureComboBox.TabIndex = 6;
-            // 
-            // PneumaticDiameterComboBox
-            // 
-            this.PneumaticDiameterComboBox.Dock = System.Windows.Forms.DockStyle.Top;
-            this.PneumaticDiameterComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.PneumaticDiameterComboBox.FormattingEnabled = true;
-            this.PneumaticDiameterComboBox.Items.AddRange(new object[] {
-            "1 in",
-            ".5 in",
-            ".25 in"});
-            this.PneumaticDiameterComboBox.Location = new System.Drawing.Point(2, 21);
-            this.PneumaticDiameterComboBox.Margin = new System.Windows.Forms.Padding(2);
-            this.PneumaticDiameterComboBox.Name = "PneumaticDiameterComboBox";
-            this.PneumaticDiameterComboBox.Size = new System.Drawing.Size(165, 21);
-            this.PneumaticDiameterComboBox.TabIndex = 12;
-            // 
-            // DiameterLabel
-            // 
-            this.DiameterLabel.AutoSize = true;
-            this.DiameterLabel.Location = new System.Drawing.Point(3, 3);
-            this.DiameterLabel.Margin = new System.Windows.Forms.Padding(3);
-            this.DiameterLabel.Name = "DiameterLabel";
-            this.DiameterLabel.Size = new System.Drawing.Size(87, 13);
-            this.DiameterLabel.TabIndex = 9;
-            this.DiameterLabel.Text = "Internal Diameter";
-            // 
-            // PortsGroupBox
-            // 
-            this.MainTableLayout.SetColumnSpan(this.PortsGroupBox, 2);
-            this.PortsGroupBox.Controls.Add(this.AutoAssignCheckBox);
-            this.PortsGroupBox.Controls.Add(this.PortTwoUpDown);
-            this.PortsGroupBox.Controls.Add(this.PortTwoLabel);
-            this.PortsGroupBox.Controls.Add(this.PortOneLabel);
-            this.PortsGroupBox.Controls.Add(this.PortOneUpDown);
-            this.PortsGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
-            this.PortsGroupBox.Location = new System.Drawing.Point(3, 30);
-            this.PortsGroupBox.Name = "PortsGroupBox";
-            this.PortsGroupBox.Size = new System.Drawing.Size(356, 51);
-            this.PortsGroupBox.TabIndex = 6;
-            this.PortsGroupBox.TabStop = false;
-            this.PortsGroupBox.Text = "Ports";
-            // 
-            // AutoAssignCheckBox
-            // 
-            this.AutoAssignCheckBox.AutoSize = true;
-            this.AutoAssignCheckBox.Location = new System.Drawing.Point(246, 20);
-            this.AutoAssignCheckBox.Name = "AutoAssignCheckBox";
-            this.AutoAssignCheckBox.Size = new System.Drawing.Size(82, 17);
-            this.AutoAssignCheckBox.TabIndex = 4;
-            this.AutoAssignCheckBox.Text = "Auto-Assign";
-            this.AutoAssignCheckBox.UseVisualStyleBackColor = true;
-            this.AutoAssignCheckBox.CheckedChanged += new System.EventHandler(this.AutoAssignCheckBox_CheckedChanged);
-            // 
-            // PortTwoUpDown
-            // 
-            this.PortTwoUpDown.Location = new System.Drawing.Point(147, 19);
-            this.PortTwoUpDown.Maximum = new decimal(new int[] {
-            20,
-            0,
-            0,
-            0});
-            this.PortTwoUpDown.Minimum = new decimal(new int[] {
-            2,
-            0,
-            0,
-            0});
-            this.PortTwoUpDown.Name = "PortTwoUpDown";
-            this.PortTwoUpDown.Size = new System.Drawing.Size(47, 20);
-            this.PortTwoUpDown.TabIndex = 3;
-            this.PortTwoUpDown.Value = new decimal(new int[] {
-            3,
-            0,
-            0,
-            0});
-            // 
-            // PortTwoLabel
-            // 
-            this.PortTwoLabel.AutoSize = true;
-            this.PortTwoLabel.Location = new System.Drawing.Point(103, 21);
-            this.PortTwoLabel.Name = "PortTwoLabel";
-            this.PortTwoLabel.Size = new System.Drawing.Size(38, 13);
-            this.PortTwoLabel.TabIndex = 2;
-            this.PortTwoLabel.Text = "Port 2:";
-            // 
-            // PortOneLabel
-            // 
-            this.PortOneLabel.AutoSize = true;
-            this.PortOneLabel.Location = new System.Drawing.Point(6, 21);
-            this.PortOneLabel.Name = "PortOneLabel";
-            this.PortOneLabel.Size = new System.Drawing.Size(38, 13);
-            this.PortOneLabel.TabIndex = 1;
-            this.PortOneLabel.Text = "Port 1:";
-            // 
-            // PortOneUpDown
-            // 
-            this.PortOneUpDown.Location = new System.Drawing.Point(50, 19);
-            this.PortOneUpDown.Maximum = new decimal(new int[] {
-            20,
-            0,
-            0,
-            0});
-            this.PortOneUpDown.Minimum = new decimal(new int[] {
-            2,
-            0,
-            0,
-            0});
-            this.PortOneUpDown.Name = "PortOneUpDown";
-            this.PortOneUpDown.Size = new System.Drawing.Size(47, 20);
-            this.PortOneUpDown.TabIndex = 0;
-            this.PortOneUpDown.Value = new decimal(new int[] {
-            2,
-            0,
-            0,
-            0});
-            // 
-            // DriverComboBox
-            // 
-            this.DriverComboBox.Dock = System.Windows.Forms.DockStyle.Top;
-            this.DriverComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.DriverComboBox.FormattingEnabled = true;
-            this.DriverComboBox.Items.AddRange(new object[] {
-            "No Driver",
-            "Motor",
-            "Servo",
-            "Bumper Pneumatic",
-            "Relay Pneumatic",
-            "Dual Motor"});
-            this.DriverComboBox.Location = new System.Drawing.Point(80, 3);
-            this.DriverComboBox.Name = "DriverComboBox";
-            this.DriverComboBox.Size = new System.Drawing.Size(279, 21);
-            this.DriverComboBox.TabIndex = 2;
-            this.DriverComboBox.SelectedIndexChanged += new System.EventHandler(this.DriverComboBox_SelectedIndexChanged);
-            // 
-            // SelectDriverLabel
-            // 
-            this.SelectDriverLabel.AutoSize = true;
-            this.SelectDriverLabel.Dock = System.Windows.Forms.DockStyle.Right;
-            this.SelectDriverLabel.Location = new System.Drawing.Point(3, 3);
-            this.SelectDriverLabel.Margin = new System.Windows.Forms.Padding(3);
-            this.SelectDriverLabel.Name = "SelectDriverLabel";
-            this.SelectDriverLabel.Size = new System.Drawing.Size(71, 21);
-            this.SelectDriverLabel.TabIndex = 1;
-            this.SelectDriverLabel.Text = "Select Driver:";
-            this.SelectDriverLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // MainTableLayout
             // 
@@ -352,14 +92,98 @@
             this.MainTableLayout.Controls.Add(this.JointLimitGroupBox, 0, 2);
             this.MainTableLayout.Controls.Add(this.PortsGroupBox, 0, 1);
             this.MainTableLayout.Controls.Add(this.MetaTabControl, 1, 2);
-            this.MainTableLayout.Location = new System.Drawing.Point(6, 19);
+            this.MainTableLayout.Location = new System.Drawing.Point(8, 23);
+            this.MainTableLayout.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MainTableLayout.Name = "MainTableLayout";
             this.MainTableLayout.RowCount = 3;
             this.MainTableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.MainTableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.MainTableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.MainTableLayout.Size = new System.Drawing.Size(362, 216);
+            this.MainTableLayout.Size = new System.Drawing.Size(530, 265);
             this.MainTableLayout.TabIndex = 14;
+            // 
+            // PortsGroupBox
+            // 
+            this.MainTableLayout.SetColumnSpan(this.PortsGroupBox, 2);
+            this.PortsGroupBox.Controls.Add(this.PortTwoUpDown);
+            this.PortsGroupBox.Controls.Add(this.PortTwoLabel);
+            this.PortsGroupBox.Controls.Add(this.PortOneLabel);
+            this.PortsGroupBox.Controls.Add(this.PortOneUpDown);
+            this.PortsGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
+            this.PortsGroupBox.Location = new System.Drawing.Point(4, 36);
+            this.PortsGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.PortsGroupBox.Name = "PortsGroupBox";
+            this.PortsGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.PortsGroupBox.Size = new System.Drawing.Size(522, 63);
+            this.PortsGroupBox.TabIndex = 6;
+            this.PortsGroupBox.TabStop = false;
+            this.PortsGroupBox.Text = "Ports";
+            // 
+            // PortTwoUpDown
+            // 
+            this.PortTwoUpDown.Location = new System.Drawing.Point(196, 23);
+            this.PortTwoUpDown.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.PortTwoUpDown.Maximum = new decimal(new int[] {
+            20,
+            0,
+            0,
+            0});
+            this.PortTwoUpDown.Minimum = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
+            this.PortTwoUpDown.Name = "PortTwoUpDown";
+            this.PortTwoUpDown.Size = new System.Drawing.Size(63, 22);
+            this.PortTwoUpDown.TabIndex = 3;
+            this.PortTwoUpDown.Value = new decimal(new int[] {
+            3,
+            0,
+            0,
+            0});
+            // 
+            // PortTwoLabel
+            // 
+            this.PortTwoLabel.AutoSize = true;
+            this.PortTwoLabel.Location = new System.Drawing.Point(137, 26);
+            this.PortTwoLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.PortTwoLabel.Name = "PortTwoLabel";
+            this.PortTwoLabel.Size = new System.Drawing.Size(45, 16);
+            this.PortTwoLabel.TabIndex = 2;
+            this.PortTwoLabel.Text = "Port 2:";
+            // 
+            // PortOneLabel
+            // 
+            this.PortOneLabel.AutoSize = true;
+            this.PortOneLabel.Location = new System.Drawing.Point(8, 26);
+            this.PortOneLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.PortOneLabel.Name = "PortOneLabel";
+            this.PortOneLabel.Size = new System.Drawing.Size(45, 16);
+            this.PortOneLabel.TabIndex = 1;
+            this.PortOneLabel.Text = "Port 1:";
+            // 
+            // PortOneUpDown
+            // 
+            this.PortOneUpDown.Location = new System.Drawing.Point(67, 23);
+            this.PortOneUpDown.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.PortOneUpDown.Maximum = new decimal(new int[] {
+            20,
+            0,
+            0,
+            0});
+            this.PortOneUpDown.Minimum = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
+            this.PortOneUpDown.Name = "PortOneUpDown";
+            this.PortOneUpDown.Size = new System.Drawing.Size(63, 22);
+            this.PortOneUpDown.TabIndex = 0;
+            this.PortOneUpDown.Value = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
             // 
             // DriverLayout
             // 
@@ -377,8 +201,138 @@
             this.DriverLayout.Name = "DriverLayout";
             this.DriverLayout.RowCount = 1;
             this.DriverLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.DriverLayout.Size = new System.Drawing.Size(362, 27);
+            this.DriverLayout.Size = new System.Drawing.Size(530, 32);
             this.DriverLayout.TabIndex = 0;
+            // 
+            // SelectDriverLabel
+            // 
+            this.SelectDriverLabel.AutoSize = true;
+            this.SelectDriverLabel.Dock = System.Windows.Forms.DockStyle.Right;
+            this.SelectDriverLabel.Location = new System.Drawing.Point(4, 4);
+            this.SelectDriverLabel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.SelectDriverLabel.Name = "SelectDriverLabel";
+            this.SelectDriverLabel.Size = new System.Drawing.Size(88, 24);
+            this.SelectDriverLabel.TabIndex = 1;
+            this.SelectDriverLabel.Text = "Select Driver:";
+            this.SelectDriverLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // DriverComboBox
+            // 
+            this.DriverComboBox.Dock = System.Windows.Forms.DockStyle.Top;
+            this.DriverComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.DriverComboBox.FormattingEnabled = true;
+            this.DriverComboBox.Items.AddRange(new object[] {
+            "No Driver",
+            "Motor",
+            "Servo",
+            "Bumper Pneumatic",
+            "Relay Pneumatic",
+            "Dual Motor"});
+            this.DriverComboBox.Location = new System.Drawing.Point(100, 4);
+            this.DriverComboBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.DriverComboBox.Name = "DriverComboBox";
+            this.DriverComboBox.Size = new System.Drawing.Size(426, 24);
+            this.DriverComboBox.TabIndex = 2;
+            this.DriverComboBox.SelectedIndexChanged += new System.EventHandler(this.DriverComboBox_SelectedIndexChanged);
+            // 
+            // JointLimitGroupBox
+            // 
+            this.JointLimitGroupBox.Controls.Add(this.TotalFreedomLabel);
+            this.JointLimitGroupBox.Controls.Add(this.FreedomFactorLabel);
+            this.JointLimitGroupBox.Controls.Add(this.UpperLimitUpDown);
+            this.JointLimitGroupBox.Controls.Add(this.UpperLimitLabel);
+            this.JointLimitGroupBox.Controls.Add(this.LowerLimitLabel);
+            this.JointLimitGroupBox.Controls.Add(this.LowerLimitUpDown);
+            this.JointLimitGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
+            this.JointLimitGroupBox.Location = new System.Drawing.Point(4, 107);
+            this.JointLimitGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.JointLimitGroupBox.Name = "JointLimitGroupBox";
+            this.JointLimitGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.JointLimitGroupBox.Size = new System.Drawing.Size(257, 102);
+            this.JointLimitGroupBox.TabIndex = 13;
+            this.JointLimitGroupBox.TabStop = false;
+            this.JointLimitGroupBox.Text = "Joint Limits";
+            // 
+            // TotalFreedomLabel
+            // 
+            this.TotalFreedomLabel.AutoSize = true;
+            this.TotalFreedomLabel.Location = new System.Drawing.Point(157, 34);
+            this.TotalFreedomLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.TotalFreedomLabel.Name = "TotalFreedomLabel";
+            this.TotalFreedomLabel.Size = new System.Drawing.Size(55, 16);
+            this.TotalFreedomLabel.TabIndex = 5;
+            this.TotalFreedomLabel.Text = "0.0 units";
+            // 
+            // FreedomFactorLabel
+            // 
+            this.FreedomFactorLabel.AutoSize = true;
+            this.FreedomFactorLabel.Location = new System.Drawing.Point(157, 20);
+            this.FreedomFactorLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.FreedomFactorLabel.Name = "FreedomFactorLabel";
+            this.FreedomFactorLabel.Size = new System.Drawing.Size(66, 16);
+            this.FreedomFactorLabel.TabIndex = 4;
+            this.FreedomFactorLabel.Text = "Freedom:";
+            // 
+            // UpperLimitUpDown
+            // 
+            this.UpperLimitUpDown.Location = new System.Drawing.Point(96, 32);
+            this.UpperLimitUpDown.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.UpperLimitUpDown.Name = "UpperLimitUpDown";
+            this.UpperLimitUpDown.Size = new System.Drawing.Size(61, 22);
+            this.UpperLimitUpDown.TabIndex = 3;
+            this.UpperLimitUpDown.ValueChanged += new System.EventHandler(this.UpperLimitUpDown_ValueChanged);
+            // 
+            // UpperLimitLabel
+            // 
+            this.UpperLimitLabel.AutoSize = true;
+            this.UpperLimitLabel.Location = new System.Drawing.Point(8, 34);
+            this.UpperLimitLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.UpperLimitLabel.Name = "UpperLimitLabel";
+            this.UpperLimitLabel.Size = new System.Drawing.Size(76, 16);
+            this.UpperLimitLabel.TabIndex = 2;
+            this.UpperLimitLabel.Text = "Upper Limit";
+            // 
+            // LowerLimitLabel
+            // 
+            this.LowerLimitLabel.AutoSize = true;
+            this.LowerLimitLabel.Location = new System.Drawing.Point(8, 68);
+            this.LowerLimitLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LowerLimitLabel.Name = "LowerLimitLabel";
+            this.LowerLimitLabel.Size = new System.Drawing.Size(74, 16);
+            this.LowerLimitLabel.TabIndex = 1;
+            this.LowerLimitLabel.Text = "Lower Limit";
+            // 
+            // LowerLimitUpDown
+            // 
+            this.LowerLimitUpDown.Location = new System.Drawing.Point(96, 65);
+            this.LowerLimitUpDown.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.LowerLimitUpDown.Name = "LowerLimitUpDown";
+            this.LowerLimitUpDown.Size = new System.Drawing.Size(60, 22);
+            this.LowerLimitUpDown.TabIndex = 0;
+            this.LowerLimitUpDown.ValueChanged += new System.EventHandler(this.LowerLimitUpDown_ValueChanged);
+            // 
+            // MetaTabControl
+            // 
+            this.MetaTabControl.Controls.Add(this.PneumaticTab);
+            this.MetaTabControl.Dock = System.Windows.Forms.DockStyle.Top;
+            this.MetaTabControl.Location = new System.Drawing.Point(268, 105);
+            this.MetaTabControl.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.MetaTabControl.Name = "MetaTabControl";
+            this.MetaTabControl.SelectedIndex = 0;
+            this.MetaTabControl.Size = new System.Drawing.Size(259, 158);
+            this.MetaTabControl.TabIndex = 12;
+            this.MetaTabControl.Visible = false;
+            // 
+            // PneumaticTab
+            // 
+            this.PneumaticTab.Controls.Add(this.PneumaticLayout);
+            this.PneumaticTab.Location = new System.Drawing.Point(4, 25);
+            this.PneumaticTab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.PneumaticTab.Name = "PneumaticTab";
+            this.PneumaticTab.Size = new System.Drawing.Size(251, 129);
+            this.PneumaticTab.TabIndex = 1;
+            this.PneumaticTab.Text = "Pneumatic";
+            this.PneumaticTab.UseVisualStyleBackColor = true;
             // 
             // PneumaticLayout
             // 
@@ -392,27 +346,88 @@
             this.PneumaticLayout.Controls.Add(this.PneumaticDiameterComboBox, 0, 1);
             this.PneumaticLayout.Dock = System.Windows.Forms.DockStyle.Top;
             this.PneumaticLayout.Location = new System.Drawing.Point(0, 0);
+            this.PneumaticLayout.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.PneumaticLayout.Name = "PneumaticLayout";
             this.PneumaticLayout.RowCount = 4;
             this.PneumaticLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.PneumaticLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.PneumaticLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.PneumaticLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.PneumaticLayout.Size = new System.Drawing.Size(169, 88);
+            this.PneumaticLayout.Size = new System.Drawing.Size(251, 104);
             this.PneumaticLayout.TabIndex = 15;
+            // 
+            // PressureLabel
+            // 
+            this.PressureLabel.AutoSize = true;
+            this.PressureLabel.Location = new System.Drawing.Point(4, 56);
+            this.PressureLabel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.PressureLabel.Name = "PressureLabel";
+            this.PressureLabel.Size = new System.Drawing.Size(62, 16);
+            this.PressureLabel.TabIndex = 13;
+            this.PressureLabel.Text = "Pressure";
+            // 
+            // DiameterLabel
+            // 
+            this.DiameterLabel.AutoSize = true;
+            this.DiameterLabel.Location = new System.Drawing.Point(4, 4);
+            this.DiameterLabel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.DiameterLabel.Name = "DiameterLabel";
+            this.DiameterLabel.Size = new System.Drawing.Size(109, 16);
+            this.DiameterLabel.TabIndex = 9;
+            this.DiameterLabel.Text = "Internal Diameter";
+            // 
+            // PneumaticPressureComboBox
+            // 
+            this.PneumaticPressureComboBox.Dock = System.Windows.Forms.DockStyle.Top;
+            this.PneumaticPressureComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.PneumaticPressureComboBox.FormattingEnabled = true;
+            this.PneumaticPressureComboBox.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.PneumaticPressureComboBox.Items.AddRange(new object[] {
+            "60 psi",
+            "20 psi",
+            "10 psi"});
+            this.PneumaticPressureComboBox.Location = new System.Drawing.Point(3, 78);
+            this.PneumaticPressureComboBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.PneumaticPressureComboBox.Name = "PneumaticPressureComboBox";
+            this.PneumaticPressureComboBox.Size = new System.Drawing.Size(245, 24);
+            this.PneumaticPressureComboBox.TabIndex = 6;
+            // 
+            // PneumaticDiameterComboBox
+            // 
+            this.PneumaticDiameterComboBox.Dock = System.Windows.Forms.DockStyle.Top;
+            this.PneumaticDiameterComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.PneumaticDiameterComboBox.FormattingEnabled = true;
+            this.PneumaticDiameterComboBox.Items.AddRange(new object[] {
+            "1 in",
+            ".5 in",
+            ".25 in"});
+            this.PneumaticDiameterComboBox.Location = new System.Drawing.Point(3, 26);
+            this.PneumaticDiameterComboBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.PneumaticDiameterComboBox.Name = "PneumaticDiameterComboBox";
+            this.PneumaticDiameterComboBox.Size = new System.Drawing.Size(245, 24);
+            this.PneumaticDiameterComboBox.TabIndex = 12;
             // 
             // DefinePartPanel
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.BackColor = System.Drawing.Color.Transparent;
             this.Controls.Add(this.NodeGroupBox);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "DefinePartPanel";
-            this.Size = new System.Drawing.Size(377, 257);
+            this.Size = new System.Drawing.Size(550, 315);
             this.NodeGroupBox.ResumeLayout(false);
             this.NodeGroupBox.PerformLayout();
+            this.MainTableLayout.ResumeLayout(false);
+            this.MainTableLayout.PerformLayout();
+            this.PortsGroupBox.ResumeLayout(false);
+            this.PortsGroupBox.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.PortTwoUpDown)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.PortOneUpDown)).EndInit();
+            this.DriverLayout.ResumeLayout(false);
+            this.DriverLayout.PerformLayout();
             this.JointLimitGroupBox.ResumeLayout(false);
             this.JointLimitGroupBox.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.UpperLimitUpDown)).EndInit();
@@ -420,14 +435,6 @@
             this.MetaTabControl.ResumeLayout(false);
             this.PneumaticTab.ResumeLayout(false);
             this.PneumaticTab.PerformLayout();
-            this.PortsGroupBox.ResumeLayout(false);
-            this.PortsGroupBox.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.PortTwoUpDown)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.PortOneUpDown)).EndInit();
-            this.MainTableLayout.ResumeLayout(false);
-            this.MainTableLayout.PerformLayout();
-            this.DriverLayout.ResumeLayout(false);
-            this.DriverLayout.PerformLayout();
             this.PneumaticLayout.ResumeLayout(false);
             this.PneumaticLayout.PerformLayout();
             this.ResumeLayout(false);
@@ -441,7 +448,6 @@
         private System.Windows.Forms.Label SelectDriverLabel;
         private System.Windows.Forms.ComboBox DriverComboBox;
         private System.Windows.Forms.GroupBox PortsGroupBox;
-        private System.Windows.Forms.CheckBox AutoAssignCheckBox;
         private System.Windows.Forms.NumericUpDown PortTwoUpDown;
         private System.Windows.Forms.Label PortTwoLabel;
         private System.Windows.Forms.Label PortOneLabel;

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
@@ -45,8 +45,11 @@ namespace BxDRobotExporter.Wizard
 
             DriverComboBox.SelectedIndex = 0;
             DriverComboBox_SelectedIndexChanged(null, null);
-            PortOneUpDown.Minimum = WizardData.Instance.NextFreePort;
-            PortTwoUpDown.Minimum = WizardData.Instance.NextFreePort;
+            PortOneUpDown.Minimum = 3;
+            PortTwoUpDown.Minimum = 3;
+
+            PortOneUpDown.Value = WizardData.Instance.NextFreePort;
+            PortTwoUpDown.Value = PortOneUpDown.Value + 1; // This may overlap with ports on next panel, but this only matters if the user chooses a two-port driver, which are less common
 
             // Add a highlight component action to all children. This is simpler than manually adding the hover event to each control.
             AddHighlightAction(this);

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
@@ -45,20 +45,11 @@ namespace BxDRobotExporter.Wizard
 
             DriverComboBox.SelectedIndex = 0;
             DriverComboBox_SelectedIndexChanged(null, null);
-            PortTwoUpDown.Minimum = WizardData.Instance.nextFreePort;
-            PortOneUpDown.Minimum = WizardData.Instance.nextFreePort;
+            PortOneUpDown.Minimum = WizardData.Instance.NextFreePort;
+            PortTwoUpDown.Minimum = WizardData.Instance.NextFreePort;
 
             // Add a highlight component action to all children. This is simpler than manually adding the hover event to each control.
             AddHighlightAction(this);
-        }
-
-        private void AutoAssignCheckBox_CheckedChanged(object sender, EventArgs e)
-        {
-            PortOneUpDown.Enabled = !AutoAssignCheckBox.Checked;
-            if(DriverComboBox.SelectedIndex == 3 || DriverComboBox.SelectedIndex == 5)
-            {
-                PortTwoUpDown.Enabled = PortOneUpDown.Enabled = !AutoAssignCheckBox.Checked;
-            }
         }
 
         /// <summary>
@@ -79,8 +70,8 @@ namespace BxDRobotExporter.Wizard
                     this.JointLimitGroupBox.Visible = true;
                     this.PortsGroupBox.Visible = true;
                     MetaTabControl.Visible = false;
-                    PortTwoLabel.Enabled = false;
-                    PortTwoUpDown.Enabled = false;
+                    PortTwoLabel.Visible = false;
+                    PortTwoUpDown.Visible = false;
                     UpperLimitUpDown.Maximum = LowerLimitUpDown.Maximum = 360;
                     UpperLimitUpDown.Minimum = LowerLimitUpDown.Minimum = 0;
                     unit = "°";
@@ -89,8 +80,8 @@ namespace BxDRobotExporter.Wizard
                     this.JointLimitGroupBox.Visible = true;
                     this.PortsGroupBox.Visible = true;
                     this.MetaTabControl.Visible = false;
-                    PortTwoLabel.Enabled = false;
-                    PortTwoUpDown.Enabled = false;
+                    PortTwoLabel.Visible = false;
+                    PortTwoUpDown.Visible = false;
                     unit = "cm";
                     break;
                 case 3: //Bumper Pneumatics
@@ -98,8 +89,8 @@ namespace BxDRobotExporter.Wizard
                     this.PortsGroupBox.Visible = true;
                     MetaTabControl.Visible = true;
                     if(!MetaTabControl.TabPages.Contains(PneumaticTab)) MetaTabControl.TabPages.Add(PneumaticTab);
-                    PortTwoLabel.Enabled = true;
-                    PortTwoUpDown.Enabled = true;
+                    PortTwoLabel.Visible = true;
+                    PortTwoUpDown.Visible = true;
                     unit = "cm";
                     break;
                 case 4: //Relay Pneumatics
@@ -107,16 +98,16 @@ namespace BxDRobotExporter.Wizard
                     this.PortsGroupBox.Visible = true;
                     MetaTabControl.Visible = true;
                     if(!MetaTabControl.TabPages.Contains(PneumaticTab)) MetaTabControl.TabPages.Add(PneumaticTab);
-                    PortTwoUpDown.Enabled = false;
-                    PortTwoLabel.Enabled = false;
+                    PortTwoUpDown.Visible = false;
+                    PortTwoLabel.Visible = false;
                     unit = "cm";
                     break;
                 case 5: //Dual Motor
                     this.JointLimitGroupBox.Visible = true;
                     this.PortsGroupBox.Visible = true;
                     this.MetaTabControl.Visible = false;
-                    PortTwoLabel.Enabled = true;
-                    PortTwoUpDown.Enabled = true;
+                    PortTwoLabel.Visible = true;
+                    PortTwoUpDown.Visible = true;
                     UpperLimitUpDown.Maximum = LowerLimitUpDown.Maximum = 360;
                     UpperLimitUpDown.Minimum = LowerLimitUpDown.Minimum = 0;
                     unit = "°";
@@ -168,34 +159,29 @@ namespace BxDRobotExporter.Wizard
                     ((RotationalJoint_Base)node.GetSkeletalJoint()).hasAngularLimit = true;
                     ((RotationalJoint_Base)node.GetSkeletalJoint()).angularLimitLow = (float)(LowerLimitUpDown.Value * (decimal)(Math.PI / 180));
                     ((RotationalJoint_Base)node.GetSkeletalJoint()).angularLimitHigh = (float)(UpperLimitUpDown.Value * (decimal)(Math.PI / 180));
-                    driver.SetPort((AutoAssignCheckBox.Checked) ? WizardData.Instance.nextFreePort : (int)PortOneUpDown.Value, 1);
-                    if (AutoAssignCheckBox.Checked) WizardData.Instance.nextFreePort++;
+                    driver.SetPort((int)PortOneUpDown.Value, 1);
                     return driver;
                 case 2: //Servo
                     driver = new JointDriver(JointDriverType.SERVO);
                     driver.SetLimits((float)(LowerLimitUpDown.Value / 100), (float)(UpperLimitUpDown.Value / 100));
-                    driver.SetPort((AutoAssignCheckBox.Checked) ? WizardData.Instance.nextFreePort : (int)PortOneUpDown.Value, 1);
-                    if (AutoAssignCheckBox.Checked) WizardData.Instance.nextFreePort++;
+                    driver.SetPort((int)PortOneUpDown.Value, 1);
                     return driver;
                 case 3: //Bumper Pneumatic
                     driver = new JointDriver(JointDriverType.BUMPER_PNEUMATIC);
                     driver.SetLimits((float)(LowerLimitUpDown.Value / 100), (float)(UpperLimitUpDown.Value / 100));
-                    driver.SetPort((AutoAssignCheckBox.Checked) ? WizardData.Instance.nextFreePort : (int)PortOneUpDown.Value, (AutoAssignCheckBox.Checked) ? WizardData.Instance.nextFreePort + 1 : (int)PortTwoUpDown.Value);
-                    if (AutoAssignCheckBox.Checked) WizardData.Instance.nextFreePort += 2;
+                    driver.SetPort((int)PortOneUpDown.Value, (int)PortTwoUpDown.Value);
                     return driver;
                 case 4: //Relay Pneumatic
                     driver = new JointDriver(JointDriverType.RELAY_PNEUMATIC);
                     driver.SetLimits((float)(LowerLimitUpDown.Value / 100), (float)(UpperLimitUpDown.Value / 100));
-                    driver.SetPort((AutoAssignCheckBox.Checked) ? WizardData.Instance.nextFreePort : (int)PortOneUpDown.Value, 1);
-                    if (AutoAssignCheckBox.Checked) WizardData.Instance.nextFreePort++;
+                    driver.SetPort((int)PortOneUpDown.Value, 1);
                     return driver;
                 case 5: //Dual Motor
                     driver = new JointDriver(JointDriverType.DUAL_MOTOR);
                     ((RotationalJoint_Base)node.GetSkeletalJoint()).hasAngularLimit = true;
                     ((RotationalJoint_Base)node.GetSkeletalJoint()).angularLimitLow = (float)(LowerLimitUpDown.Value * (decimal)(Math.PI / 180));
                     ((RotationalJoint_Base)node.GetSkeletalJoint()).angularLimitHigh = (float)(UpperLimitUpDown.Value * (decimal)(Math.PI / 180));
-                    driver.SetPort((AutoAssignCheckBox.Checked) ? WizardData.Instance.nextFreePort : (int)PortOneUpDown.Value, (AutoAssignCheckBox.Checked) ? WizardData.Instance.nextFreePort + 1 : (int)PortTwoUpDown.Value);
-                    if (AutoAssignCheckBox.Checked) WizardData.Instance.nextFreePort += 2;
+                    driver.SetPort((int)PortOneUpDown.Value, (int)PortTwoUpDown.Value);
                     return driver;
             }
             return null;

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
@@ -70,6 +70,7 @@ namespace BxDRobotExporter.Wizard
                     this.JointLimitGroupBox.Visible = true;
                     this.PortsGroupBox.Visible = true;
                     MetaTabControl.Visible = false;
+                    PortOneLabel.Text = "Port:";
                     PortTwoLabel.Visible = false;
                     PortTwoUpDown.Visible = false;
                     UpperLimitUpDown.Maximum = LowerLimitUpDown.Maximum = 360;
@@ -80,6 +81,7 @@ namespace BxDRobotExporter.Wizard
                     this.JointLimitGroupBox.Visible = true;
                     this.PortsGroupBox.Visible = true;
                     this.MetaTabControl.Visible = false;
+                    PortOneLabel.Text = "Port:";
                     PortTwoLabel.Visible = false;
                     PortTwoUpDown.Visible = false;
                     unit = "cm";
@@ -89,6 +91,7 @@ namespace BxDRobotExporter.Wizard
                     this.PortsGroupBox.Visible = true;
                     MetaTabControl.Visible = true;
                     if(!MetaTabControl.TabPages.Contains(PneumaticTab)) MetaTabControl.TabPages.Add(PneumaticTab);
+                    PortOneLabel.Text = "Port 1:";
                     PortTwoLabel.Visible = true;
                     PortTwoUpDown.Visible = true;
                     unit = "cm";
@@ -98,14 +101,16 @@ namespace BxDRobotExporter.Wizard
                     this.PortsGroupBox.Visible = true;
                     MetaTabControl.Visible = true;
                     if(!MetaTabControl.TabPages.Contains(PneumaticTab)) MetaTabControl.TabPages.Add(PneumaticTab);
-                    PortTwoUpDown.Visible = false;
+                    PortOneLabel.Text = "Port:";
                     PortTwoLabel.Visible = false;
+                    PortTwoUpDown.Visible = false;
                     unit = "cm";
                     break;
                 case 5: //Dual Motor
                     this.JointLimitGroupBox.Visible = true;
                     this.PortsGroupBox.Visible = true;
                     this.MetaTabControl.Visible = false;
+                    PortOneLabel.Text = "Port 1:";
                     PortTwoLabel.Visible = true;
                     PortTwoUpDown.Visible = true;
                     UpperLimitUpDown.Maximum = LowerLimitUpDown.Maximum = 360;

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Data/WizardData.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Data/WizardData.cs
@@ -24,7 +24,13 @@ namespace BxDRobotExporter.Wizard
         /// <summary>
         /// The next free PWM port to assign a driver to.
         /// </summary>
-        public int nextFreePort = 3;
+        private int _nextFreePort = 3;
+        public int NextFreePort
+        {
+            get => _nextFreePort++;
+            private set => _nextFreePort = value;
+        }
+
 
         #region Nested enums and classes
         public enum WizardDriveTrain


### PR DESCRIPTION
Resolves AARD-598:
- In the other moving parts page of the wizard, ports now default to sequentially increase, starting at 3 since the drive motors take ports 1 and 2.
- Auto assign has been removed because its general usage has been implemented into the initialization of the form