### PR TITLE
Fixed Titles & Removed Broken Image References

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter.csproj
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter.csproj
@@ -289,8 +289,6 @@
     <None Include="Images\ExportJoints32.bmp" />
     <None Include="Images\ExportMeshes16.bmp" />
     <None Include="Images\ExportMeshes32.bmp" />
-    <None Include="Images\Export16.png" />
-    <None Include="Images\Export32.png" />
     <None Include="Images\Export16.bmp" />
     <None Include="Images\Export32.bmp" />
     <Content Include="Images\ExportRobot16.bmp" />
@@ -309,8 +307,6 @@
     <None Include="Images\RobotMagicWand32.bmp" />
     <None Include="Images\Gears16.png" />
     <None Include="Images\Gears32.png" />
-    <None Include="Images\Save16.png" />
-    <None Include="Images\Save32.png" />
     <None Include="Images\Save16.bmp" />
     <None Include="Images\Save32.bmp" />
     <Content Include="Images\SelectJointInsideJoint16.bmp" />

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/JointGroupNameEditorForm.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/JointGroupNameEditorForm.Designer.cs
@@ -90,7 +90,7 @@
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "JointGroupNameEditorForm";
-            this.Text = "JointGroupNameEditorForm";
+            this.Text = "Joint Group Name Editor";
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SetWeightForm.Designer.cs
@@ -152,7 +152,6 @@
             this.UnitBox.Name = "UnitBox";
             this.UnitBox.Size = new System.Drawing.Size(75, 21);
             this.UnitBox.TabIndex = 2;
-            this.UnitBox.SelectedIndex = 0;
             // 
             // SetWeightForm
             // 
@@ -169,6 +168,7 @@
             this.Name = "SetWeightForm";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Set Weight";
             ((System.ComponentModel.ISupportInitialize)(this.WeightBox)).EndInit();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();


### PR DESCRIPTION
There's a few PNG images in the exporter that are broken, and appear to be duplicates of existing bitmaps, so I removed them to stop getting warnings.

Also fixed a couple quick titling issues with exporter forms.