### PR TITLE
Improved node selection system when highlighting nodes in Inventor

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
@@ -154,7 +154,7 @@ namespace BxDRobotExporter.Wizard
         /// <param name="e"></param>
         private void HighlightNode(object sender, EventArgs e)
         {
-            StandardAddInServer.Instance.WizardSelect(node);
+            StandardAddInServer.Instance.SelectNode(node);
         }
 
         private void AddHighlightAction(Control baseControl)

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/WheelSetupPanel.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/WheelSetupPanel.cs
@@ -38,7 +38,7 @@ namespace BxDRobotExporter.Wizard
             this.MouseClick += delegate (object sender, MouseEventArgs e)
             {
                 if (this.Node != null)
-                    StandardAddInServer.Instance.WizardSelect(this.Node);
+                    StandardAddInServer.Instance.SelectNode(this.Node);
             };
             
             BackColor = Color.White;
@@ -84,7 +84,7 @@ namespace BxDRobotExporter.Wizard
         /// <param name="e"></param>
         private void HighlightNode(object sender, EventArgs e)
         {
-            StandardAddInServer.Instance.WizardSelect(Node);
+            StandardAddInServer.Instance.SelectNode(Node);
         }
 
         /// <summary>

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.cs
@@ -474,7 +474,7 @@ namespace BxDRobotExporter.Wizard
             if (NodeListBox.SelectedItem != null)
             {
                 // Highlight node in Inventor
-                StandardAddInServer.Instance.WizardSelect(setupPanels[NodeListBox.SelectedItem.ToString()].Node);
+                StandardAddInServer.Instance.SelectNode(setupPanels[NodeListBox.SelectedItem.ToString()].Node);
                 // Start drag-and-drop process
                 NodeListBox.DoDragDrop(NodeListBox.SelectedItem.ToString(), DragDropEffects.Move);
             }
@@ -493,7 +493,7 @@ namespace BxDRobotExporter.Wizard
                 return;
 
             // Highlight node in Inventor
-            StandardAddInServer.Instance.WizardSelect(setupPanels[name].Node);
+            StandardAddInServer.Instance.SelectNode(setupPanels[name].Node);
             // Start drag-and-drop process
             NodeListBox.DoDragDrop(name, DragDropEffects.Move);
         }
@@ -609,7 +609,7 @@ namespace BxDRobotExporter.Wizard
             if (NodeListBox.SelectedItem != null)
             {
                 // Highlight node in Inventor
-                StandardAddInServer.Instance.WizardSelect(setupPanels[NodeListBox.SelectedItem.ToString()].Node);
+                StandardAddInServer.Instance.SelectNode(setupPanels[NodeListBox.SelectedItem.ToString()].Node);
             }
         }
 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/RigidAnalyzer/RigidNode.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/RigidAnalyzer/RigidNode.cs
@@ -1,8 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Text;
-using Inventor;
-using System;
+﻿using Inventor;
 using OGLViewer;
+using System;
+using System.Collections.Generic;
 
 public class RigidNode : OGL_RigidNode 
 {
@@ -42,13 +41,16 @@ public class RigidNode : OGL_RigidNode
                 components.Add(oc.Name);
             }
         }
-        components.Sort();
-        StringBuilder id = new StringBuilder();
-        foreach (string comp in components)
+
+        string id = "";
+        for (int i = 0; i < components.Count; i++)
         {
-            id.Append(comp);
-            id.Append("-_-");
+            id += components[i];
+
+            // Act as separators
+            if (i < components.Count - 1)
+                id += "-_-";
         }
-        return id.ToString();
+        return id;
     }
 }


### PR DESCRIPTION
This resolves AARD-672.

Before, the model ID of rigid nodes consisted of a concatenated list separated by the string "-_-", which was also tacked onto the end. This was apparently not known when the node selection code was written, as it simply cut the last three chars off instead of dividing the list by the separator. This has been corrected, and the "-_-" characters have been removed from the end of the model ID's and now only exist as separators.