### PR TITLE
Removed mecanum and swerve support in robot exporter

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Data/WizardData.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Data/WizardData.cs
@@ -36,16 +36,13 @@ namespace BxDRobotExporter.Wizard
         public enum WizardDriveTrain
         {
             TANK = 1,
-            MECANUM,
-            SWERVE,
             H_DRIVE,
             CUSTOM
         }
         public enum WizardWheelType
         {
             NORMAL = 1,
-            OMNI = 2,
-            MECANUM = 3
+            OMNI = 2
         }
         public enum WizardFrictionLevel
         {

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.Designer.cs
@@ -247,8 +247,6 @@
             this.DriveTrainDropdown.Items.AddRange(new object[] {
             "Select drive train...",
             "Tank",
-            "Mecanum",
-            "Swerve",
             "H-Drive",
             "Other/Custom"});
             this.DriveTrainDropdown.Location = new System.Drawing.Point(90, 4);

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.cs
@@ -93,27 +93,7 @@ namespace BxDRobotExporter.Wizard
                     this.MiddleWheelsPanel.Visible = false;
                     WizardData.Instance.driveTrain = WizardData.WizardDriveTrain.TANK;
                     break;
-                case 2: //Mecanum
-                    this.LeftWheelsGroup.Size = new System.Drawing.Size(224, 480);
-                    this.LeftWheelsPanel.Size = new System.Drawing.Size(218, 461);
-                    this.RightWheelsGroup.Size = new System.Drawing.Size(224, 480);
-                    this.RightWheelsPanel.Size = new System.Drawing.Size(218, 461);
-                    this.MainLayout.RowCount = 3;
-                    this.MiddleWheelsGroup.Visible = false;
-                    this.MiddleWheelsPanel.Visible = false;
-                    WizardData.Instance.driveTrain = WizardData.WizardDriveTrain.MECANUM;
-                    break;
-                case 3: //Swerve
-                    this.LeftWheelsGroup.Size = new System.Drawing.Size(224, 480);
-                    this.LeftWheelsPanel.Size = new System.Drawing.Size(218, 461);
-                    this.RightWheelsGroup.Size = new System.Drawing.Size(224, 480);
-                    this.RightWheelsPanel.Size = new System.Drawing.Size(218, 461);
-                    this.MainLayout.RowCount = 3;
-                    this.MiddleWheelsGroup.Visible = false;
-                    this.MiddleWheelsPanel.Visible = false;
-                    WizardData.Instance.driveTrain = WizardData.WizardDriveTrain.SWERVE;
-                    break;
-                case 4: //H-Drive
+                case 2: //H-Drive
                     this.LeftWheelsGroup.Size = new System.Drawing.Size(224, 374);
                     this.LeftWheelsPanel.Size = new System.Drawing.Size(218, 355);
                     this.RightWheelsGroup.Size = new System.Drawing.Size(224, 374);
@@ -123,7 +103,7 @@ namespace BxDRobotExporter.Wizard
                     this.MiddleWheelsPanel.Visible = true;
                     WizardData.Instance.driveTrain = WizardData.WizardDriveTrain.H_DRIVE;
                     break;
-                case 5: //Custom
+                case 3: //Custom
                     this.LeftWheelsGroup.Size = new System.Drawing.Size(224, 480);
                     this.LeftWheelsPanel.Size = new System.Drawing.Size(218, 461);
                     this.RightWheelsGroup.Size = new System.Drawing.Size(224, 480);
@@ -210,8 +190,7 @@ namespace BxDRobotExporter.Wizard
 
             foreach (RigidNode_Base node in Utilities.GUI.SkeletonBase.ListAllNodes())
             {
-                if ((node.GetSkeletalJoint() != null && node.GetSkeletalJoint().GetJointType() == SkeletalJointType.ROTATIONAL) ||
-                    (WizardData.Instance.driveTrain == WizardData.WizardDriveTrain.SWERVE && node.GetParent() != null && node.GetParent().GetParent() != null))
+                if (node.GetSkeletalJoint() != null && node.GetSkeletalJoint().GetJointType() == SkeletalJointType.ROTATIONAL)
                 {
                     string readableName = node.ModelFileName.Replace('_', ' ').Replace(".bxda", "");
                     readableName = readableName.Substring(0, 1).ToUpperInvariant() + readableName.Substring(1); // Capitalize first character
@@ -244,9 +223,7 @@ namespace BxDRobotExporter.Wizard
 
                 // Get default wheel type based on drive train
                 WizardData.WizardWheelType type;
-                if (WizardData.Instance.driveTrain == WizardData.WizardDriveTrain.MECANUM)
-                    type = WizardData.WizardWheelType.MECANUM;
-                else if (WizardData.Instance.driveTrain == WizardData.WizardDriveTrain.H_DRIVE)
+                if (WizardData.Instance.driveTrain == WizardData.WizardDriveTrain.H_DRIVE)
                     type = WizardData.WizardWheelType.OMNI;
                 else
                     type = WizardData.WizardWheelType.NORMAL;


### PR DESCRIPTION
Due to the scope of our project during the current development season, mecanum and swerve will not be functional in the next release. Therefore, we are removing them as options in the robot exporter wizard. 