### PR TITLE
Exporter post wizard export window

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter.csproj
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter.csproj
@@ -183,6 +183,12 @@
     <Compile Include="Wizard\Components\WheelSetupPanel.Designer.cs">
       <DependentUpon>WheelSetupPanel.cs</DependentUpon>
     </Compile>
+    <Compile Include="Wizard\Pages\ExportOrAdvancedForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Wizard\Pages\ExportOrAdvancedForm.Designer.cs">
+      <DependentUpon>ExportOrAdvancedForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="Wizard\WizardForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -237,6 +243,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Wizard\Components\WheelSetupPanel.resx">
       <DependentUpon>WheelSetupPanel.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Wizard\Pages\ExportOrAdvancedForm.resx">
+      <DependentUpon>ExportOrAdvancedForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Wizard\WizardForm.resx">
       <DependentUpon>WizardForm.cs</DependentUpon>

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Properties/Settings.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Properties/Settings.Designer.cs
@@ -70,7 +70,22 @@ namespace BxDRobotExporter.Properties {
                 this["FancyColors"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ShowExportOrAdvancedForm
+        {
+            get
+            {
+                return ((bool)(this["ShowExportOrAdvancedForm"]));
+            }
+            set
+            {
+                this["ShowExportOrAdvancedForm"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("0")]

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
@@ -543,12 +543,17 @@ namespace BxDRobotExporter
                     Utilities.GUI.OpenSynthesis();
         }
 
-        //Settings
-        /// <summary>
-        /// Opens the <see cref="SetWeightForm"/> form to allow the user to set the weight of their robot.
-        /// </summary>
-        /// <param name="Context"></param>
-        private void SetWeight_OnExecute(NameValueMap Context)
+        public void ForceExport()
+        {
+            ExportButton_OnExecute(null);
+        }
+
+    //Settings
+    /// <summary>
+    /// Opens the <see cref="SetWeightForm"/> form to allow the user to set the weight of their robot.
+    /// </summary>
+    /// <param name="Context"></param>
+    private void SetWeight_OnExecute(NameValueMap Context)
         {
             if (Utilities.GUI.PromptRobotWeight())
                 PendingChanges = true;

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineWheelsPage.Designer.cs
@@ -57,11 +57,13 @@
             this.AutoFillToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.WheelNodeGroupBox.SuspendLayout();
             this.WheelJointsLayout.SuspendLayout();
+            this.LeftWheelsGroup.SuspendLayout();
             this.RobotInfoGroupBox.SuspendLayout();
             this.RobotInfoLayout.SuspendLayout();
             this.DriveTrainLayout.SuspendLayout();
             this.WeightLayout.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.WeightBox)).BeginInit();
+            this.RightWheelsGroup.SuspendLayout();
             this.MainLayout.SuspendLayout();
             this.MiddleWheelsGroup.SuspendLayout();
             this.RightBackWheelsGroup.SuspendLayout();
@@ -178,9 +180,8 @@
             this.LeftWheelsPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 567F));
             this.LeftWheelsPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 567F));
             this.LeftWheelsPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.LeftWheelsPanel.Size = new System.Drawing.Size(290, 124);
+            this.LeftWheelsPanel.Size = new System.Drawing.Size(290, 398);
             this.LeftWheelsPanel.TabIndex = 1;
-            this.LeftWheelsPanel.Visible = true;
             this.LeftWheelsPanel.DragDrop += new System.Windows.Forms.DragEventHandler(this.LeftWheelsPanel_DragDrop);
             this.LeftWheelsPanel.DragEnter += new System.Windows.Forms.DragEventHandler(this.Field_DragEnter);
             // 
@@ -358,9 +359,8 @@
             this.RightWheelsPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 567F));
             this.RightWheelsPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 567F));
             this.RightWheelsPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.RightWheelsPanel.Size = new System.Drawing.Size(290, 0);
+            this.RightWheelsPanel.Size = new System.Drawing.Size(291, 398);
             this.RightWheelsPanel.TabIndex = 1;
-            this.RightWheelsPanel.Visible = true;
             this.RightWheelsPanel.DragDrop += new System.Windows.Forms.DragEventHandler(this.RightWheelsPanel_DragDrop);
             this.RightWheelsPanel.DragEnter += new System.Windows.Forms.DragEventHandler(this.Field_DragEnter);
             // 
@@ -514,6 +514,7 @@
             this.WheelNodeGroupBox.PerformLayout();
             this.WheelJointsLayout.ResumeLayout(false);
             this.WheelJointsLayout.PerformLayout();
+            this.LeftWheelsGroup.ResumeLayout(false);
             this.RobotInfoGroupBox.ResumeLayout(false);
             this.RobotInfoGroupBox.PerformLayout();
             this.RobotInfoLayout.ResumeLayout(false);
@@ -523,6 +524,7 @@
             this.WeightLayout.ResumeLayout(false);
             this.WeightLayout.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.WeightBox)).EndInit();
+            this.RightWheelsGroup.ResumeLayout(false);
             this.MainLayout.ResumeLayout(false);
             this.MainLayout.PerformLayout();
             this.MiddleWheelsGroup.ResumeLayout(false);

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.Designer.cs
@@ -28,44 +28,49 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.MainLayout = new System.Windows.Forms.TableLayoutPanel();
             this.MainTextLbl = new System.Windows.Forms.Label();
             this.AdvancedExportButton = new System.Windows.Forms.Button();
             this.exportRobotButton = new System.Windows.Forms.Button();
-            this.tableLayoutPanel1.SuspendLayout();
+            this.showAgainCheckBox = new System.Windows.Forms.CheckBox();
+            this.MainLayout.SuspendLayout();
             this.SuspendLayout();
             // 
-            // tableLayoutPanel1
+            // MainLayout
             // 
-            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tableLayoutPanel1.ColumnCount = 2;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.Controls.Add(this.MainTextLbl, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.AdvancedExportButton, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.exportRobotButton, 1, 1);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(12, 12);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 2;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(441, 155);
-            this.tableLayoutPanel1.TabIndex = 0;
+            this.MainLayout.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.MainLayout.ColumnCount = 2;
+            this.MainLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.MainLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.MainLayout.Controls.Add(this.MainTextLbl, 0, 0);
+            this.MainLayout.Controls.Add(this.AdvancedExportButton, 1, 0);
+            this.MainLayout.Controls.Add(this.exportRobotButton, 1, 1);
+            this.MainLayout.Controls.Add(this.showAgainCheckBox, 0, 2);
+            this.MainLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.MainLayout.Location = new System.Drawing.Point(0, 0);
+            this.MainLayout.Name = "MainLayout";
+            this.MainLayout.RowCount = 3;
+            this.MainLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 60F));
+            this.MainLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 40F));
+            this.MainLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.MainLayout.Size = new System.Drawing.Size(461, 185);
+            this.MainLayout.TabIndex = 0;
             // 
             // MainTextLbl
             // 
             this.MainTextLbl.AutoSize = true;
-            this.tableLayoutPanel1.SetColumnSpan(this.MainTextLbl, 2);
+            this.MainLayout.SetColumnSpan(this.MainTextLbl, 2);
+            this.MainTextLbl.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MainTextLbl.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.MainTextLbl.Location = new System.Drawing.Point(12, 8);
-            this.MainTextLbl.Margin = new System.Windows.Forms.Padding(12, 8, 8, 8);
+            this.MainTextLbl.Location = new System.Drawing.Point(0, 0);
+            this.MainTextLbl.Margin = new System.Windows.Forms.Padding(0);
             this.MainTextLbl.Name = "MainTextLbl";
-            this.MainTextLbl.Size = new System.Drawing.Size(415, 60);
+            this.MainTextLbl.Size = new System.Drawing.Size(461, 93);
             this.MainTextLbl.TabIndex = 0;
             this.MainTextLbl.Text = "You have now completed the initial setup for exporting your robot. Would you like" +
     " to configure advanced settings, or finish and export your robot to Synthesis?\r\n" +
     "";
+            this.MainTextLbl.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // AdvancedExportButton
             // 
@@ -82,7 +87,7 @@
             // 
             this.exportRobotButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.exportRobotButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.exportRobotButton.Location = new System.Drawing.Point(228, 102);
+            this.exportRobotButton.Location = new System.Drawing.Point(248, 102);
             this.exportRobotButton.Name = "exportRobotButton";
             this.exportRobotButton.Size = new System.Drawing.Size(210, 50);
             this.exportRobotButton.TabIndex = 2;
@@ -90,25 +95,36 @@
             this.exportRobotButton.UseVisualStyleBackColor = true;
             this.exportRobotButton.Click += new System.EventHandler(this.exportRobotButton_Click);
             // 
+            // showAgainCheckBox
+            // 
+            this.showAgainCheckBox.AutoSize = true;
+            this.showAgainCheckBox.Location = new System.Drawing.Point(3, 158);
+            this.showAgainCheckBox.Name = "showAgainCheckBox";
+            this.showAgainCheckBox.Size = new System.Drawing.Size(164, 21);
+            this.showAgainCheckBox.TabIndex = 3;
+            this.showAgainCheckBox.Text = "Don\'t show this again";
+            this.showAgainCheckBox.UseVisualStyleBackColor = true;
+            // 
             // ExportOrAdvancedForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(465, 179);
-            this.Controls.Add(this.tableLayoutPanel1);
+            this.ClientSize = new System.Drawing.Size(461, 185);
+            this.Controls.Add(this.MainLayout);
             this.Name = "ExportOrAdvancedForm";
             this.ShowIcon = false;
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
+            this.MainLayout.ResumeLayout(false);
+            this.MainLayout.PerformLayout();
             this.ResumeLayout(false);
 
         }
 
         #endregion
 
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.TableLayoutPanel MainLayout;
         private System.Windows.Forms.Button AdvancedExportButton;
         private System.Windows.Forms.Button exportRobotButton;
         private System.Windows.Forms.Label MainTextLbl;
+        private System.Windows.Forms.CheckBox showAgainCheckBox;
     }
 }

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.Designer.cs
@@ -1,0 +1,114 @@
+﻿namespace BxDRobotExporter.Wizard
+{
+    partial class ExportOrAdvancedForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.MainTextLbl = new System.Windows.Forms.Label();
+            this.AdvancedExportButton = new System.Windows.Forms.Button();
+            this.exportRobotButton = new System.Windows.Forms.Button();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.Controls.Add(this.MainTextLbl, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.AdvancedExportButton, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.exportRobotButton, 1, 1);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(12, 12);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(446, 206);
+            this.tableLayoutPanel1.TabIndex = 0;
+            // 
+            // MainTextLbl
+            // 
+            this.MainTextLbl.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.MainTextLbl, 2);
+            this.MainTextLbl.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.MainTextLbl.Location = new System.Drawing.Point(12, 8);
+            this.MainTextLbl.Margin = new System.Windows.Forms.Padding(12, 8, 8, 8);
+            this.MainTextLbl.Name = "MainTextLbl";
+            this.MainTextLbl.Size = new System.Drawing.Size(425, 60);
+            this.MainTextLbl.TabIndex = 0;
+            this.MainTextLbl.Text = "You now completed the initial setup for exporting your robot. Would you like to c" +
+    "ontinue to configure advanced settings or finish and export your robot to Synthe" +
+    "sis?\r\n";
+            // 
+            // AdvancedExportButton
+            // 
+            this.AdvancedExportButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.AdvancedExportButton.Location = new System.Drawing.Point(3, 153);
+            this.AdvancedExportButton.Name = "AdvancedExportButton";
+            this.AdvancedExportButton.Size = new System.Drawing.Size(210, 50);
+            this.AdvancedExportButton.TabIndex = 1;
+            this.AdvancedExportButton.Text = "Configure Advanced  Settings";
+            this.AdvancedExportButton.UseVisualStyleBackColor = true;
+            this.AdvancedExportButton.Click += new System.EventHandler(this.AdvancedExportButton_Click);
+            // 
+            // exportRobotButton
+            // 
+            this.exportRobotButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.exportRobotButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.exportRobotButton.Location = new System.Drawing.Point(233, 153);
+            this.exportRobotButton.Name = "exportRobotButton";
+            this.exportRobotButton.Size = new System.Drawing.Size(210, 50);
+            this.exportRobotButton.TabIndex = 2;
+            this.exportRobotButton.Text = "Export Robot";
+            this.exportRobotButton.UseVisualStyleBackColor = true;
+            this.exportRobotButton.Click += new System.EventHandler(this.exportRobotButton_Click);
+            // 
+            // ExportOrAdvancedForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(470, 230);
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.Name = "ExportOrAdvancedForm";
+            this.ShowIcon = false;
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Button AdvancedExportButton;
+        private System.Windows.Forms.Button exportRobotButton;
+        private System.Windows.Forms.Label MainTextLbl;
+    }
+}

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.Designer.cs
@@ -50,7 +50,7 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(446, 206);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(441, 155);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // MainTextLbl
@@ -61,16 +61,16 @@
             this.MainTextLbl.Location = new System.Drawing.Point(12, 8);
             this.MainTextLbl.Margin = new System.Windows.Forms.Padding(12, 8, 8, 8);
             this.MainTextLbl.Name = "MainTextLbl";
-            this.MainTextLbl.Size = new System.Drawing.Size(425, 60);
+            this.MainTextLbl.Size = new System.Drawing.Size(415, 60);
             this.MainTextLbl.TabIndex = 0;
-            this.MainTextLbl.Text = "You now completed the initial setup for exporting your robot. Would you like to c" +
-    "ontinue to configure advanced settings or finish and export your robot to Synthe" +
-    "sis?\r\n";
+            this.MainTextLbl.Text = "You have now completed the initial setup for exporting your robot. Would you like" +
+    " to configure advanced settings, or finish and export your robot to Synthesis?\r\n" +
+    "";
             // 
             // AdvancedExportButton
             // 
             this.AdvancedExportButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.AdvancedExportButton.Location = new System.Drawing.Point(3, 153);
+            this.AdvancedExportButton.Location = new System.Drawing.Point(3, 102);
             this.AdvancedExportButton.Name = "AdvancedExportButton";
             this.AdvancedExportButton.Size = new System.Drawing.Size(210, 50);
             this.AdvancedExportButton.TabIndex = 1;
@@ -82,7 +82,7 @@
             // 
             this.exportRobotButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.exportRobotButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.exportRobotButton.Location = new System.Drawing.Point(233, 153);
+            this.exportRobotButton.Location = new System.Drawing.Point(228, 102);
             this.exportRobotButton.Name = "exportRobotButton";
             this.exportRobotButton.Size = new System.Drawing.Size(210, 50);
             this.exportRobotButton.TabIndex = 2;
@@ -94,7 +94,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(470, 230);
+            this.ClientSize = new System.Drawing.Size(465, 179);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "ExportOrAdvancedForm";
             this.ShowIcon = false;

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.Designer.cs
@@ -109,8 +109,13 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.White;
             this.ClientSize = new System.Drawing.Size(461, 185);
             this.Controls.Add(this.MainLayout);
+            this.DoubleBuffered = true;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "ExportOrAdvancedForm";
             this.ShowIcon = false;
             this.MainLayout.ResumeLayout(false);

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace BxDRobotExporter.Wizard
+{
+    public partial class ExportOrAdvancedForm : Form
+    {
+        public ExportOrAdvancedForm()
+        {
+            InitializeComponent();
+        }
+
+        private void AdvancedExportButton_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
+
+        private void exportRobotButton_Click(object sender, EventArgs e)
+        {
+            Close();
+            StandardAddInServer.Instance.ForceExport();
+        }
+    }
+}

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.cs
@@ -15,6 +15,12 @@ namespace BxDRobotExporter.Wizard
         public ExportOrAdvancedForm()
         {
             InitializeComponent();
+            this.FormClosing += ExportOrAdvancedForm_FormClosing;
+        }
+
+        private void ExportOrAdvancedForm_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            Properties.Settings.Default.ShowExportOrAdvancedForm = !this.showAgainCheckBox.Checked;
         }
 
         private void AdvancedExportButton_Click(object sender, EventArgs e)

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.resx
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/ExportOrAdvancedForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/WizardForm.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/WizardForm.cs
@@ -44,7 +44,7 @@ namespace BxDRobotExporter.Wizard
                 if (Properties.Settings.Default.ShowExportOrAdvancedForm)
                 {
                     Form finishDialog = new ExportOrAdvancedForm();
-                    finishDialog.Show();
+                    finishDialog.ShowDialog();
                 }
             };
         }

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/WizardForm.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/WizardForm.cs
@@ -41,6 +41,8 @@ namespace BxDRobotExporter.Wizard
                 WizardData.Instance.Apply();
                 StandardAddInServer.Instance.PendingChanges = true;
                 Close();
+                Form finishDialog = new ExportOrAdvancedForm();
+                finishDialog.Show();
             };
         }
 

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/WizardForm.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/WizardForm.cs
@@ -41,8 +41,11 @@ namespace BxDRobotExporter.Wizard
                 WizardData.Instance.Apply();
                 StandardAddInServer.Instance.PendingChanges = true;
                 Close();
-                Form finishDialog = new ExportOrAdvancedForm();
-                finishDialog.Show();
+                if (Properties.Settings.Default.ShowExportOrAdvancedForm)
+                {
+                    Form finishDialog = new ExportOrAdvancedForm();
+                    finishDialog.Show();
+                }
             };
         }
 


### PR DESCRIPTION
fixes AARD-696
"Users have difficulty finding the "Export Robot" button after completing the wizard. This problem could be remedied by adding a popup that asks the user if they would like to export after they complete the wizard, but add an option to disable the popup for repeat/advanced users. Options should be "yes" which opens the export menu and "configure additional settings" or something similar to imply that the user has more chances to edit after this point."