### PR TITLE
Exporter sensor addition

### DIFF
--- a/exporters/Aardvark-Libraries/SimulatorFileIO/IO/BXDJ/BXDJReader_4_0.cs
+++ b/exporters/Aardvark-Libraries/SimulatorFileIO/IO/BXDJ/BXDJReader_4_0.cs
@@ -895,6 +895,10 @@ public partial class BXDJSkeleton
                 case "SensorConversionFactor":
                     // Assign a value to useSecondarySource.
                     robotSensor.conversionFactor = double.Parse(reader.ReadElementContentAsString());
+                    if(robotSensor.conversionFactor == 0)
+                    {
+                        robotSensor.conversionFactor = 1;
+                    }
                     break;
             }
         }

--- a/exporters/Aardvark-Libraries/SimulatorFileIO/IO/BXDJ/BXDJSkeleton.cs
+++ b/exporters/Aardvark-Libraries/SimulatorFileIO/IO/BXDJ/BXDJSkeleton.cs
@@ -395,7 +395,7 @@ public static partial class BXDJSkeleton
         writer.WriteElementString("SensorSignalType1", sensor.conTypePort1.ToString());
         writer.WriteElementString("SensorPortNumber2", sensor.port2.ToString());
         writer.WriteElementString("SensorSignalType2", sensor.conTypePort2.ToString());
-        writer.WriteElementString("SensorConversionFactor", sensor.conversionFactor.ToString(   ));
+        writer.WriteElementString("SensorConversionFactor", sensor.conversionFactor.ToString());
 
         writer.WriteEndElement();
     }

--- a/exporters/Aardvark-Libraries/SimulatorFileIO/Joints/Sensors/RobotSensor.cs
+++ b/exporters/Aardvark-Libraries/SimulatorFileIO/Joints/Sensors/RobotSensor.cs
@@ -56,11 +56,11 @@ public class RobotSensor : BinaryRWObject
         switch (joint.GetJointType())
         {
             case SkeletalJointType.ROTATIONAL:
-                return new RobotSensorType[] {RobotSensorType.ENCODER, RobotSensorType.POTENTIOMETER, RobotSensorType.LIMIT};
+                return new RobotSensorType[] {RobotSensorType.ENCODER/*, RobotSensorType.POTENTIOMETER, RobotSensorType.LIMIT*/};
             case SkeletalJointType.LINEAR:
                 return new RobotSensorType[] {RobotSensorType.LIMIT };
             case SkeletalJointType.CYLINDRICAL:
-                return new RobotSensorType[] {RobotSensorType.ENCODER, RobotSensorType.POTENTIOMETER, RobotSensorType.LIMIT};
+                return new RobotSensorType[] {RobotSensorType.ENCODER/*, RobotSensorType.POTENTIOMETER, RobotSensorType.LIMIT*/};
             case SkeletalJointType.PLANAR:
                 return new RobotSensorType[] { };
             case SkeletalJointType.BALL:

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
@@ -535,6 +535,17 @@ public partial class SynthesisGUI : Form
 
                     elevator.type = (ElevatorType)Utilities.GetProperty(propertySet, "elevator-type", (int)ElevatorType.NOT_MULTI);
                 }
+                for(int i = 0; i < Utilities.GetProperty(propertySet, "num-sensors", 0); i++)
+                {
+                    RobotSensor addedSensor;
+                    addedSensor = new RobotSensor((RobotSensorType)Utilities.GetProperty(propertySet, "sensorType" + i, (int)RobotSensorType.ENCODER));
+                    addedSensor.port1 = ((int)Utilities.GetProperty(propertySet, "sensorPort1" + i, 0));
+                    addedSensor.port2 = ((int)Utilities.GetProperty(propertySet, "sensorPort2" + i, 0));
+                    addedSensor.conTypePort1 = ((SensorConnectionType)Utilities.GetProperty(propertySet, "sensorPortCon1" + i, (int)SensorConnectionType.DIO));
+                    addedSensor.conTypePort2 = ((SensorConnectionType)Utilities.GetProperty(propertySet, "sensorPortCon2" + i, (int)SensorConnectionType.DIO));
+                    addedSensor.conversionFactor = Utilities.GetProperty(propertySet, "sensorConversion" + i, 0.0);
+                    joint.attachedSensors.Add(addedSensor);
+                }
             }
 
             // Recur along this child
@@ -640,12 +651,34 @@ public partial class SynthesisGUI : Form
 
                 // Elevator information
                 ElevatorDriverMeta elevator = joint.cDriver.GetInfo<ElevatorDriverMeta>();
+
+
+
                 Utilities.SetProperty(propertySet, "has-elevator", elevator != null);
 
                 if (elevator != null)
                 {
                     Utilities.SetProperty(propertySet, "elevator-type", (int)elevator.type);
                 }
+            }
+            for (int i = 0; i < Utilities.GetProperty(propertySet, "num-sensors", 0); i++)// delete existing sensors
+            {
+                Utilities.RemoveProperty(propertySet, "sensorType" + i);
+                Utilities.RemoveProperty(propertySet, "sensorPort1" + i);
+                Utilities.RemoveProperty(propertySet, "sensorPortCon1" + i);
+                Utilities.RemoveProperty(propertySet, "sensorPort2" + i);
+                Utilities.RemoveProperty(propertySet, "sensorPortCon2" + i);
+                Utilities.RemoveProperty(propertySet, "sensorConversion" + i);
+            }
+            Utilities.SetProperty(propertySet, "num-sensors", joint.attachedSensors.Count);
+            for(int i = 0; i < joint.attachedSensors.Count; i++) {
+
+                Utilities.SetProperty(propertySet, "sensorType" + i, (int)joint.attachedSensors[i].type);
+                Utilities.SetProperty(propertySet, "sensorPort1" + i, joint.attachedSensors[i].port1);
+                Utilities.SetProperty(propertySet, "sensorPortCon1" + i, (int)joint.attachedSensors[i].conTypePort1);
+                Utilities.SetProperty(propertySet, "sensorPort2" + i, joint.attachedSensors[i].port2);
+                Utilities.SetProperty(propertySet, "sensorPortCon2" + i, (int)joint.attachedSensors[i].conTypePort2);
+                Utilities.SetProperty(propertySet, "sensorConversion" + i, joint.attachedSensors[i].conversionFactor);
             }
 
             // Recur along this child

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditSensorForm.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditSensorForm.Designer.cs
@@ -35,8 +35,8 @@
             this.SaveButton = new System.Windows.Forms.Button();
             this.CancelButton = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.button1 = new System.Windows.Forms.Button();
             this.Port1NumericUpDown = new System.Windows.Forms.NumericUpDown();
+            this.button1 = new System.Windows.Forms.Button();
             this.Port2Lbl = new System.Windows.Forms.Label();
             this.Port2NumericUpDown = new System.Windows.Forms.NumericUpDown();
             this.ConversionLbl = new System.Windows.Forms.Label();
@@ -119,12 +119,12 @@
             this.tableLayoutPanel1.Controls.Add(this.CancelButton, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.SaveButton, 2, 3);
             this.tableLayoutPanel1.Controls.Add(this.typeBox, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.Port1NumericUpDown, 1, 1);
             this.tableLayoutPanel1.Controls.Add(this.button1, 3, 0);
             this.tableLayoutPanel1.Controls.Add(this.Port2Lbl, 2, 1);
             this.tableLayoutPanel1.Controls.Add(this.Port2NumericUpDown, 3, 1);
             this.tableLayoutPanel1.Controls.Add(this.ConversionLbl, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.ConversionNumericUpDown, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.Port1NumericUpDown, 1, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
@@ -137,6 +137,18 @@
             this.tableLayoutPanel1.Size = new System.Drawing.Size(400, 165);
             this.tableLayoutPanel1.TabIndex = 13;
             // 
+            // Port1NumericUpDown
+            // 
+            this.Port1NumericUpDown.Location = new System.Drawing.Point(103, 45);
+            this.Port1NumericUpDown.Maximum = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
+            this.Port1NumericUpDown.Name = "Port1NumericUpDown";
+            this.Port1NumericUpDown.Size = new System.Drawing.Size(94, 22);
+            this.Port1NumericUpDown.TabIndex = 14;
+            // 
             // button1
             // 
             this.button1.Location = new System.Drawing.Point(303, 3);
@@ -145,13 +157,6 @@
             this.button1.TabIndex = 13;
             this.button1.Text = "button1";
             this.button1.UseVisualStyleBackColor = true;
-            // 
-            // Port1NumericUpDown
-            // 
-            this.Port1NumericUpDown.Location = new System.Drawing.Point(103, 45);
-            this.Port1NumericUpDown.Name = "Port1NumericUpDown";
-            this.Port1NumericUpDown.Size = new System.Drawing.Size(94, 22);
-            this.Port1NumericUpDown.TabIndex = 14;
             // 
             // Port2Lbl
             // 
@@ -165,6 +170,11 @@
             // Port2NumericUpDown
             // 
             this.Port2NumericUpDown.Location = new System.Drawing.Point(303, 45);
+            this.Port2NumericUpDown.Maximum = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
             this.Port2NumericUpDown.Name = "Port2NumericUpDown";
             this.Port2NumericUpDown.Size = new System.Drawing.Size(94, 22);
             this.Port2NumericUpDown.TabIndex = 16;
@@ -180,7 +190,18 @@
             // 
             // ConversionNumericUpDown
             // 
+            this.ConversionNumericUpDown.DecimalPlaces = 3;
             this.ConversionNumericUpDown.Location = new System.Drawing.Point(103, 87);
+            this.ConversionNumericUpDown.Maximum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            0});
+            this.ConversionNumericUpDown.Minimum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            -2147483648});
             this.ConversionNumericUpDown.Name = "ConversionNumericUpDown";
             this.ConversionNumericUpDown.Size = new System.Drawing.Size(94, 22);
             this.ConversionNumericUpDown.TabIndex = 18;

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditSensorForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditSensorForm.cs
@@ -36,6 +36,7 @@ namespace EditorsLibrary
                 typeBox.SelectedIndex = Array.IndexOf(sensorTypeOptions, sensor.type);
                 Port1NumericUpDown.Value = (decimal)sensor.port1;
                 Port2NumericUpDown.Value = (decimal)sensor.port2;
+                ConversionNumericUpDown.Value = (decimal)sensor.conversionFactor;
             }
             if (typeBox.SelectedIndex == 0)
             {
@@ -74,7 +75,7 @@ namespace EditorsLibrary
             //Doesn't save if numbers aren't entered correctly.
             addedSensor.port1 = (int)this.Port1NumericUpDown.Value;
             addedSensor.port2 = (int)this.Port2NumericUpDown.Value;
-            addedSensor.conversionFactor = (int)this.ConversionNumericUpDown.Value;
+            addedSensor.conversionFactor = (double)this.ConversionNumericUpDown.Value;
             
             if (sourceIndex >= 0 && sourceIndex < joint.attachedSensors.Count)
             {

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditSensorForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditSensorForm.cs
@@ -25,7 +25,8 @@ namespace EditorsLibrary
             sensorTypeOptions = RobotSensor.GetAllowedSensors(joint);
             foreach (RobotSensorType sensorType in sensorTypeOptions)
             {
-                typeBox.Items.Add(Enum.GetName(typeof(RobotSensorType), sensorType).Replace('_', ' ').ToLowerInvariant());
+                typeBox.Items.Add(char.ToUpper(Enum.GetName(typeof(RobotSensorType), sensorType).Replace('_', ' ')[0])
+                    + Enum.GetName(typeof(RobotSensorType), sensorType).Replace('_', ' ').Substring(1).ToLower());
             }
             Console.WriteLine(sourceIndex >= 0 && sourceIndex < joint.attachedSensors.Count);
             base.Text = (sourceIndex >= 0 && sourceIndex < joint.attachedSensors.Count) ? ("Editing Sensor # " + sourceIndex) : "New Sensor";

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditSensorForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditSensorForm.cs
@@ -37,12 +37,24 @@ namespace EditorsLibrary
                 Port1NumericUpDown.Value = (decimal)sensor.port1;
                 Port2NumericUpDown.Value = (decimal)sensor.port2;
             }
-            this.port1Lbl.Enabled = false;
-            this.Port1NumericUpDown.Enabled = false;
-            this.Port2Lbl.Visible = false;
-            this.Port2NumericUpDown.Visible = false;
-            this.ConversionLbl.Visible = false;
-            this.ConversionNumericUpDown.Visible = false;
+            if (typeBox.SelectedIndex == 0)
+            {
+                this.port1Lbl.Enabled = true;
+                this.Port1NumericUpDown.Enabled = true;
+                this.Port2Lbl.Visible = true;
+                this.Port2NumericUpDown.Visible = true;
+                this.ConversionLbl.Visible = true;
+                this.ConversionNumericUpDown.Visible = true;
+            }
+            else
+            {
+                this.port1Lbl.Enabled = false;
+                this.Port1NumericUpDown.Enabled = false;
+                this.Port2Lbl.Visible = false;
+                this.Port2NumericUpDown.Visible = false;
+                this.ConversionLbl.Visible = false;
+                this.ConversionNumericUpDown.Visible = false;
+            }
         }
 
         private void saveButton_Click(object sender, EventArgs e)

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.Designer.cs
@@ -34,24 +34,23 @@
             this.moduleColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.portColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.sensorListView = new System.Windows.Forms.ListView();
-            this.polynomialHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.deleteButton = new System.Windows.Forms.Button();
             this.addSensorButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // typeColumnHeader
             // 
-            this.typeColumnHeader.Text = "Type";
+            this.typeColumnHeader.Text = "Sensor Type";
             this.typeColumnHeader.Width = 115;
             // 
             // moduleColumnHeader
             // 
-            this.moduleColumnHeader.Text = "Module #";
+            this.moduleColumnHeader.Text = "Port 1";
             this.moduleColumnHeader.Width = 76;
             // 
             // portColumnHeader
             // 
-            this.portColumnHeader.Text = "Port #";
+            this.portColumnHeader.Text = "Port 2";
             // 
             // sensorListView
             // 
@@ -59,8 +58,7 @@
             this.sensorListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.typeColumnHeader,
             this.moduleColumnHeader,
-            this.portColumnHeader,
-            this.polynomialHeader});
+            this.portColumnHeader});
             this.sensorListView.FullRowSelect = true;
             this.sensorListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
             this.sensorListView.HoverSelection = true;
@@ -69,21 +67,16 @@
             this.sensorListView.MultiSelect = false;
             this.sensorListView.Name = "sensorListView";
             this.sensorListView.ShowGroups = false;
-            this.sensorListView.Size = new System.Drawing.Size(516, 196);
+            this.sensorListView.Size = new System.Drawing.Size(507, 196);
             this.sensorListView.TabIndex = 0;
             this.sensorListView.UseCompatibleStateImageBehavior = false;
             this.sensorListView.View = System.Windows.Forms.View.Details;
             this.sensorListView.SelectedIndexChanged += new System.EventHandler(this.sensorListView_SelectedIndexChanged);
             // 
-            // polynomialHeader
-            // 
-            this.polynomialHeader.Text = "Polynomial";
-            this.polynomialHeader.Width = 134;
-            // 
             // deleteButton
             // 
             this.deleteButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.deleteButton.Location = new System.Drawing.Point(12, 223);
+            this.deleteButton.Location = new System.Drawing.Point(12, 222);
             this.deleteButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.deleteButton.Name = "deleteButton";
             this.deleteButton.Size = new System.Drawing.Size(129, 36);
@@ -95,7 +88,7 @@
             // addSensorButton
             // 
             this.addSensorButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.addSensorButton.Location = new System.Drawing.Point(415, 223);
+            this.addSensorButton.Location = new System.Drawing.Point(404, 222);
             this.addSensorButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.addSensorButton.Name = "addSensorButton";
             this.addSensorButton.Size = new System.Drawing.Size(115, 36);
@@ -108,7 +101,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(541, 272);
+            this.ClientSize = new System.Drawing.Size(531, 271);
             this.Controls.Add(this.addSensorButton);
             this.Controls.Add(this.deleteButton);
             this.Controls.Add(this.sensorListView);
@@ -135,7 +128,6 @@
         private System.Windows.Forms.ListView sensorListView;
         private System.Windows.Forms.Button deleteButton;
         private System.Windows.Forms.Button addSensorButton;
-        private System.Windows.Forms.ColumnHeader polynomialHeader;
 
     }
 }

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.Designer.cs
@@ -72,6 +72,7 @@
             this.sensorListView.UseCompatibleStateImageBehavior = false;
             this.sensorListView.View = System.Windows.Forms.View.Details;
             this.sensorListView.SelectedIndexChanged += new System.EventHandler(this.sensorListView_SelectedIndexChanged);
+            this.sensorListView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.sensorListView_SelectedIndexChanged);
             // 
             // deleteButton
             // 
@@ -114,8 +115,16 @@
             this.Name = "SensorListForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "Sensor List";
-            this.Load += new System.EventHandler(this.SensorListForm_Load);
+            this.Activated += new System.EventHandler(this.sensorListView_SelectedIndexChanged);
+            this.Deactivate += new System.EventHandler(this.sensorListView_SelectedIndexChanged);
             this.SizeChanged += new System.EventHandler(this.window_SizeChanged);
+            this.Enter += new System.EventHandler(this.sensorListView_SelectedIndexChanged);
+            this.Leave += new System.EventHandler(this.sensorListView_SelectedIndexChanged);
+            this.MouseEnter += new System.EventHandler(this.sensorListView_SelectedIndexChanged);
+            this.MouseHover += new System.EventHandler(this.sensorListView_SelectedIndexChanged);
+            this.MouseMove += new System.Windows.Forms.MouseEventHandler(this.sensorListView_SelectedIndexChanged);
+            this.Validating += new System.ComponentModel.CancelEventHandler(this.sensorListView_SelectedIndexChanged);
+            this.Validated += new System.EventHandler(this.sensorListView_SelectedIndexChanged);
             this.ResumeLayout(false);
 
         }

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.Designer.cs
@@ -41,7 +41,7 @@
             // typeColumnHeader
             // 
             this.typeColumnHeader.Text = "Sensor Type";
-            this.typeColumnHeader.Width = 115;
+            this.typeColumnHeader.Width = 134;
             // 
             // moduleColumnHeader
             // 
@@ -71,6 +71,7 @@
             this.sensorListView.TabIndex = 0;
             this.sensorListView.UseCompatibleStateImageBehavior = false;
             this.sensorListView.View = System.Windows.Forms.View.Details;
+            this.sensorListView.ColumnWidthChanging += new System.Windows.Forms.ColumnWidthChangingEventHandler(this.sensorListView_ColumnWidthChanging);
             this.sensorListView.SelectedIndexChanged += new System.EventHandler(this.sensorListView_SelectedIndexChanged);
             this.sensorListView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.sensorListView_SelectedIndexChanged);
             // 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.cs
@@ -82,12 +82,6 @@ namespace EditorsLibrary
             sensorListView.Height = newListHeight;
             sensorListView.Width = newListWidth;
         }
-
-        private void SensorListForm_Load(object sender, EventArgs e)
-        {
-
-        }
-
         private void sensorListView_SelectedIndexChanged(object sender, EventArgs e)
         {
             addSensorButton.Text = joint.attachedSensors.IndexOf(
@@ -95,10 +89,17 @@ namespace EditorsLibrary
                 sensorListView.SelectedItems[0].Tag is RobotSensor ?
                 (RobotSensor) sensorListView.SelectedItems[0].Tag : null) >= 0 ? "Edit Sensor" : "Add Sensor";
         }
-
         private void closeButton_Click(object sender, EventArgs e)
         {
             Close();
+        }
+
+        private void sensorListView_SelectedIndexChanged(object sender, MouseEventArgs e)
+        {
+            addSensorButton.Text = joint.attachedSensors.IndexOf(
+                sensorListView.SelectedItems.Count > 0 &&
+                sensorListView.SelectedItems[0].Tag is RobotSensor ?
+                (RobotSensor)sensorListView.SelectedItems[0].Tag : null) >= 0 ? "Edit Sensor" : "Add Sensor";
         }
     }
 }

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.cs
@@ -30,10 +30,22 @@ namespace EditorsLibrary
 
             foreach (RobotSensor sensor in joint.attachedSensors)
             {
-                System.Windows.Forms.ListViewItem item = new System.Windows.Forms.ListViewItem(new string[] { 
-                    sensor.type.ToString(), sensor.port1.ToString(), sensor.port2.ToString(), sensor.conversionFactor.ToString()});
-                item.Tag = sensor;
-                sensorListView.Items.Add(item);
+                if (sensor.type.Equals(RobotSensorType.ENCODER))
+                {// if the sensor is an encoder show both ports
+                    System.Windows.Forms.ListViewItem item = new System.Windows.Forms.ListViewItem(new string[] {
+                    char.ToUpper(sensor.type.ToString()[0]) + sensor.type.ToString().Substring(1).ToLower(),
+                        sensor.port1.ToString(), sensor.port2.ToString()});
+                    item.Tag = sensor;
+                    sensorListView.Items.Add(item);
+                } else
+                {
+                    System.Windows.Forms.ListViewItem item = new System.Windows.Forms.ListViewItem(new string[] {
+                    char.ToUpper(sensor.type.ToString()[0]) + sensor.type.ToString().Substring(1).ToLower(),
+                        sensor.port1.ToString()});
+                    item.Tag = sensor;
+                    sensorListView.Items.Add(item);
+
+                }
             }
         }
 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.cs
@@ -93,7 +93,11 @@ namespace EditorsLibrary
         {
             Close();
         }
-
+        private void sensorListView_ColumnWidthChanging(object sender, ColumnWidthChangingEventArgs e)
+        {
+            e.Cancel = true;
+            e.NewWidth = this.sensorListView.Columns[e.ColumnIndex].Width;
+        }
         private void sensorListView_SelectedIndexChanged(object sender, MouseEventArgs e)
         {
             addSensorButton.Text = joint.attachedSensors.IndexOf(
@@ -101,5 +105,6 @@ namespace EditorsLibrary
                 sensorListView.SelectedItems[0].Tag is RobotSensor ?
                 (RobotSensor)sensorListView.SelectedItems[0].Tag : null) >= 0 ? "Edit Sensor" : "Add Sensor";
         }
+        
     }
 }

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.resx
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/SensorListForm.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="sensorListView.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/Utilities.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/Utilities.cs
@@ -75,6 +75,21 @@ public class Utilities
             return null;
     }
 
+    public static bool HasProperty(Inventor.PropertySet set, string name)
+    {
+        // Inventor API provides no easy way to check if a property already exists. This try-catch is necessary.
+        try
+        {
+            // Try to add new property. This will result in an exception if the property already exists.
+            set[name].Value = 0;
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
     public static void SetProperty<T>(Inventor.PropertySet set, string name, T value)
     {
         // Inventor API provides no easy way to check if a property already exists. This try-catch is necessary.
@@ -87,6 +102,19 @@ public class Utilities
         {
             // Property already exists, update value
             set[name].Value = value;
+        }
+    }
+
+    public static void RemoveProperty(Inventor.PropertySet set, string name)
+    {
+        // Inventor API provides no easy way to check if a property already exists. This try-catch is necessary.
+        try
+        {
+            // Try to add new property. This will result in an exception if the property already exists.
+            set[name].Delete();
+        }
+        catch (Exception)
+        {
         }
     }
 


### PR DESCRIPTION
Fixes 
AARD 763: 
"Sensors cannot be edited after they are added"
AARD 762:
"Encoders in the exporter cannot have more than 100 Counts per Rev"
AARD 764:
"After adding a sensor in the adv exporter, the "Add Sensor" button changes to "Edit Sensor", and does not change back when a sensor is deselected."
AARD 769:
"Labels in Sensor list are resize able"
AARD 765:
"Exporter should save existing sensors to the .iam file like the rest of the fields in the exporter"
makes the UI more intuitive for adding sensors in the exporters and saves the sensors to the .iam file so sensors aren't lost between instances of Inventor. Part 2 of PR #142 