### PR TITLE
Inventor exporter joint inversion

### DIFF
--- a/exporters/Aardvark-Libraries/SimulatorFileIO/IO/BXDJ/BXDJSkeleton.cs
+++ b/exporters/Aardvark-Libraries/SimulatorFileIO/IO/BXDJ/BXDJSkeleton.cs
@@ -169,9 +169,9 @@ public static partial class BXDJSkeleton
         //writer.WriteElementString("CurrentLinearPosition", joint.currentLinearPosition.ToString("F4"));
         //writer.WriteElementString("CurrentAngularPosition", joint.currentAngularPosition.ToString("F4"));
 
-        writer.WriteElementString("CurrentLinearPosition", joint.linearLimitStart.ToString("F4"));// writes the lowest point of the joint to the file as the positon so the joint starts at the bottom, hopefully prevents any weird issues with the joint limits being messed up do to being relative to the start of the joint
+        writer.WriteElementString("CurrentLinearPosition", joint.currentLinearPosition.ToString("F4"));// writes the lowest point of the joint to the file as the positon so the joint starts at the bottom, hopefully prevents any weird issues with the joint limits being messed up do to being relative to the start of the joint
 
-        writer.WriteElementString("CurrentAngularPosition", joint.angularLimitLow.ToString("F4"));// writes the lowest point of the joint to the file as the positon so the joint starts at the bottom, hopefully prevents any weird issues with the joint limits being messed up do to being relative to the start of the joint
+        writer.WriteElementString("CurrentAngularPosition", joint.currentAngularPosition.ToString("F4"));// writes the lowest point of the joint to the file as the positon so the joint starts at the bottom, hopefully prevents any weird issues with the joint limits being messed up do to being relative to the start of the joint
 
 
         writer.WriteEndElement();
@@ -198,7 +198,7 @@ public static partial class BXDJSkeleton
             writer.WriteElementString("LinearUpperLimit", joint.linearLimitHigh.ToString("F4"));
                
        // writer.WriteElementString("CurrentLinearPosition", joint.currentLinearPosition.ToString("F4"));
-        writer.WriteElementString("CurrentLinearPosition", joint.linearLimitLow.ToString("F4"));// writes the lowest point of the joint to the file as the positon so the joint starts at the bottom, hopefully prevents any weird issues with the joint limits being messed up do to being relative to the start of the joint
+        writer.WriteElementString("CurrentLinearPosition", joint.currentLinearPosition.ToString("F4"));// writes the lowest point of the joint to the file as the positon so the joint starts at the bottom, hopefully prevents any weird issues with the joint limits being messed up do to being relative to the start of the joint
 
         writer.WriteEndElement();
     }
@@ -239,7 +239,7 @@ public static partial class BXDJSkeleton
         }
 
        // writer.WriteElementString("CurrentAngularPosition", joint.currentAngularPosition.ToString("F4"));
-        writer.WriteElementString("CurrentAngularPosition", joint.angularLimitLow.ToString("F4"));// writes the lowest point of the joint to the file as the positon so the joint starts at the bottom, hopefully prevents any weird issues with the joint limits being messed up do to being relative to the start of the joint
+        writer.WriteElementString("CurrentAngularPosition", joint.currentAngularPosition.ToString("F4"));// writes the lowest point of the joint to the file as the positon so the joint starts at the bottom, hopefully prevents any weird issues with the joint limits being messed up do to being relative to the start of the joint
 
 
         writer.WriteEndElement();

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SkeletonExporterForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SkeletonExporterForm.cs
@@ -113,20 +113,6 @@ namespace JointResolver.ControlGUI
             {
                 throw new Exporter.EmptyAssemblyException();
             }
-
-            #region MoveJointsToStart
-            int NumCentered = 0;
-
-            SetProgress("Processing joints...", NumCentered, occurrences.Count);
-            foreach (ComponentOccurrence component in occurrences)
-            {
-                Exporter.BringJointsToStart(component);
-
-                NumCentered++;
-
-                SetProgress("Processing joints...", NumCentered, occurrences.Count + 3);
-            }
-            #endregion
             
             #region Build Models
             //Getting Rigid Body Info...

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
@@ -304,9 +304,14 @@ public partial class SynthesisGUI : Form
         }
         return false;
     }
-    public void writeLimits(RigidNode_Base skeleton)// generally, this class iterates over all the joints in the skeleton and writes the corrosponding Inventor limit into the internal joint limit
-        //needed because we want to be able to pull the limits into the joint as the exporter exports, but where the joint is actually written to the .bxdj (the SimulatorAPI) is unable
-        //to access RobotExporterAPI or BxDRobotExporter, so writing the limits here is a workaround to that issue
+    
+    /// <summary>
+    /// Iterates over all the joints in the skeleton and writes the corrosponding Inventor limit into the internal joint limit
+    /// Necessary to pull the limits into the joint as the exporter exports. Where the joint is actually written to the .bxdj,
+    /// we are unable to access RobotExporterAPI or BxDRobotExporter, so writing the limits here is a workaround to that issue.
+    /// </summary>
+    /// <param name="skeleton">Skeleton to write limits to</param>
+    public void WriteLimits(RigidNode_Base skeleton)
     {
         List<RigidNode_Base> nodes = new List<RigidNode_Base>();
         skeleton.ListAllNodes(nodes);
@@ -325,6 +330,7 @@ public partial class SynthesisGUI : Form
                 parentID[i] = -1;
             }
         }
+
         for (int i = 0; i < nodes.Count; i++)
         {
             if (parentID[i] >= 0)
@@ -380,10 +386,6 @@ public partial class SynthesisGUI : Form
                 }
             }
         }
-        foreach (ComponentOccurrence component in InventorManager.Instance.ComponentOccurrences.OfType<ComponentOccurrence>().ToList())
-        {
-            Exporter.BringJointsToStart(component);
-        }
     }
     /// <summary>
     /// Saves the robot to the directory it was loaded from or the default directory
@@ -393,7 +395,7 @@ public partial class SynthesisGUI : Form
     {
         try
         {
-            writeLimits(SkeletonBase);// write the limits from Inventor to the skeleton
+            WriteLimits(SkeletonBase);// write the limits from Inventor to the skeleton
             // If robot has not been named, prompt user for information
             if (RMeta.ActiveRobotName == null)
                 if (!PromptExportSettings())

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
@@ -335,55 +335,9 @@ public partial class SynthesisGUI : Form
         {
             if (parentID[i] >= 0)
             {
-                switch (nodes[i].GetSkeletalJoint().GetJointType())
-                {
-                    case SkeletalJointType.BALL:
-                        break;
-                    case SkeletalJointType.CYLINDRICAL:
-                        ((CylindricalJoint_Base)nodes[i].GetSkeletalJoint()).hasAngularLimit = ((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.HasAngularPositionLimits;//sets whether or not the joint has angular limits based off whether or not the joint has limist
-                        if (((CylindricalJoint_Base)nodes[i].GetSkeletalJoint()).hasAngularLimit)// if there are limits, write them to the file
-                        {
-                            ((CylindricalJoint_Base)nodes[i].GetSkeletalJoint()).angularLimitLow = (float)(((ModelParameter)((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.AngularPositionStartLimit).ModelValue);// get the JointDef from the joint and write the limits to the internal datatype
-                            ((CylindricalJoint_Base)nodes[i].GetSkeletalJoint()).angularLimitHigh = (float)(((ModelParameter)((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.AngularPositionEndLimit).ModelValue);// see above
-                        }
-                        ((CylindricalJoint_Base)nodes[i].GetSkeletalJoint()).hasLinearStartLimit = ((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.HasLinearPositionStartLimit;// see above
-                        if (((CylindricalJoint_Base)nodes[i].GetSkeletalJoint()).hasLinearStartLimit)// see above
-                        {
-                            ((CylindricalJoint_Base)nodes[i].GetSkeletalJoint()).linearLimitStart = (float)(((ModelParameter)((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.LinearPositionStartLimit).ModelValue);// see above
-                        }
-                        ((CylindricalJoint_Base)nodes[i].GetSkeletalJoint()).hasLinearEndLimit = ((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.HasLinearPositionEndLimit;// see above
-                        if (((CylindricalJoint_Base)nodes[i].GetSkeletalJoint()).hasLinearEndLimit)// see above
-                        {
-                            ((CylindricalJoint_Base)nodes[i].GetSkeletalJoint()).linearLimitEnd = (float)(((ModelParameter)((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.LinearPositionEndLimit).ModelValue);// see above
-                        }
-                        break;
-                    case SkeletalJointType.LINEAR:
-                        ((LinearJoint_Base)nodes[i].GetSkeletalJoint()).hasLowerLimit = ((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.HasLinearPositionStartLimit;// see cylindrical joint above
-                        if (((LinearJoint_Base)nodes[i].GetSkeletalJoint()).hasLowerLimit)// see cylindrical joint above
-                        {
-                            ((LinearJoint_Base)nodes[i].GetSkeletalJoint()).linearLimitLow = (float)(((ModelParameter)((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.LinearPositionStartLimit).ModelValue);// see cylindrical joint above
-                            ((ModelParameter)((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.LinearPosition).Value = ((ModelParameter)((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.LinearPositionEndLimit).ModelValue;
-                            
-                        }
-                        ((LinearJoint_Base)nodes[i].GetSkeletalJoint()).hasUpperLimit = ((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.HasLinearPositionEndLimit;// see cylindrical joint above
-                        if (((LinearJoint_Base)nodes[i].GetSkeletalJoint()).hasUpperLimit)// see cylindrical joint above
-                        {
-                            ((LinearJoint_Base)nodes[i].GetSkeletalJoint()).linearLimitHigh = (float)(((ModelParameter)((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.LinearPositionEndLimit).ModelValue);// see cylindrical joint above
-                        }
-                        break;
-                    case SkeletalJointType.PLANAR:
-                        break;
-                    case SkeletalJointType.ROTATIONAL:
-                        ((RotationalJoint_Base)nodes[i].GetSkeletalJoint()).hasAngularLimit = ((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.HasAngularPositionLimits;// see cylindrical joint above
-                        if (((RotationalJoint_Base)nodes[i].GetSkeletalJoint()).hasAngularLimit)// see cylindrical joint above
-                        {
-                            ((RotationalJoint_Base)nodes[i].GetSkeletalJoint()).angularLimitLow = (float)(((ModelParameter)((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.AngularPositionStartLimit).ModelValue);// see cylindrical joint above
-                            ((RotationalJoint_Base)nodes[i].GetSkeletalJoint()).angularLimitHigh = (float)(((ModelParameter)((InventorSkeletalJoint)nodes[i].GetSkeletalJoint()).GetWrapped().asmJoint.AngularPositionEndLimit).ModelValue);// see cylindrical joint above
-                        }
-                        break;
-                    default:
-                        throw new Exception("Could not determine type of joint");
-                }
+                InventorSkeletalJoint inventorJoint = nodes[i].GetSkeletalJoint() as InventorSkeletalJoint;
+                if (inventorJoint != null)
+                    inventorJoint.ReloadInventorJoint();
             }
         }
     }

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/Exporter/Exporter.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/Exporter/Exporter.cs
@@ -31,47 +31,6 @@ public class Exporter
         public NoGroundException() : base("Assembly has no ground.") { }
     }
 
-    public static void BringJointsToStart(ComponentOccurrence component)
-    {
-        Console.Write("Centering: " + component.Name);
-        foreach (AssemblyJoint joint in component.Joints)
-        {
-            //Takes the average of the linear or rotational limits and sets the joints position to it.
-            if (joint.Definition.JointType == AssemblyJointTypeEnum.kCylindricalJointType || joint.Definition.JointType == AssemblyJointTypeEnum.kRotationalJointType)
-            {
-                if (joint.Definition.HasAngularPositionLimits)
-                {
-                    joint.Definition.AngularPosition = (joint.Definition.AngularPositionStartLimit.Value);
-                }
-            }
-
-            if (joint.Definition.JointType == AssemblyJointTypeEnum.kCylindricalJointType || joint.Definition.JointType == AssemblyJointTypeEnum.kSlideJointType)
-            {
-                if (joint.Definition.HasLinearPositionStartLimit && joint.Definition.HasLinearPositionEndLimit)
-                {
-                    joint.Definition.LinearPosition = (joint.Definition.LinearPositionStartLimit.Value);
-                }
-                else
-                {
-                    //No robot would have a piece that would just keep going.
-                    throw new InvalidJointException(String.Format("Please add limits to \"{0}\" before exporting your robot.", joint.Name), joint);
-                }
-            }
-        }
-
-        try
-        {
-            //Contiues down to subassemblies.
-            foreach (ComponentOccurrence subComponent in component.SubOccurrences)
-            {
-                 BringJointsToStart(subComponent);
-            }
-        }
-        catch
-        {
-        }
-    }
-
     public static RigidNode_Base ExportSkeleton(List<ComponentOccurrence> occurrences)
     {
         if (occurrences.Count == 0) throw new Exception("No components selected!");
@@ -84,18 +43,6 @@ public class Exporter
         SynthesisGUI.Instance.ExporterSetMeshes(2);
 
         int numOccurrences = occurrences.Count;
-        int current = 0;
-
-        //Centers all the joints for each component.  Done to match the assembly's joint position with the subassembly's position.
-        foreach (ComponentOccurrence component in occurrences)
-        {
-            BringJointsToStart(component);
-            double totalProgress = (((double) (current + 1) / (double) numOccurrences) * 100.0);
-            SynthesisGUI.Instance.ExporterSetSubText(String.Format("Centering {1} / {2}", Math.Round(totalProgress, 2), (current + 1), numOccurrences));
-            SynthesisGUI.Instance.ExporterSetProgress(totalProgress);
-            current++;
-        }
-        Console.WriteLine();
 
         SynthesisGUI.Instance.ExporterStepOverall();
         SynthesisGUI.Instance.ExporterSetOverallText("Getting rigid info");

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/BallJoint.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/BallJoint.cs
@@ -14,6 +14,11 @@ public class BallJoint : BallJoint_Base, InventorSkeletalJoint
     {
     } // TODO
 
+    public void ReloadInventorJoint()
+    {
+        basePoint = Utilities.ToBXDVector(wrapped.rigidJoint.geomOne);
+    }
+
     public static bool IsBallJoint(CustomRigidJoint jointI)
     {
         if (jointI.joints.Count == 1)
@@ -31,7 +36,7 @@ public class BallJoint : BallJoint_Base, InventorSkeletalJoint
             throw new Exception("Not a rotational joint");
         wrapped = new SkeletalJoint(parent, rigidJoint);
 
-        basePoint = Utilities.ToBXDVector(rigidJoint.geomOne);
+        ReloadInventorJoint();
     }
 
     protected override string ToString_Internal()

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/CylindricalJoint.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/CylindricalJoint.cs
@@ -128,32 +128,17 @@ public class CylindricalJoint : CylindricalJoint_Base, InventorSkeletalJoint
         }
     }
 
-    public static bool IsCylindricalJoint(CustomRigidJoint jointI)
+    public void ReloadInventorJoint()
     {
-        // kMateLineLineJoint
-        if (jointI.joints.Count == 1)
+        if (wrapped.childGroup == wrapped.rigidJoint.groupOne)
         {
-            AssemblyJointDefinition joint = jointI.joints[0].Definition;
-            return joint.JointType == AssemblyJointTypeEnum.kCylindricalJointType;
-        }
-        return false;
-    }
-
-    public CylindricalJoint(CustomRigidGroup parent, CustomRigidJoint rigidJoint)
-    {
-        if (!(IsCylindricalJoint(rigidJoint)))
-            throw new Exception("Not a Cylindrical joint");
-        wrapped = new SkeletalJoint(parent, rigidJoint);
-
-        if (wrapped.childGroup == rigidJoint.groupOne)
-        {
-            axis = Utilities.ToBXDVector(rigidJoint.geomTwo.Direction);
-            basePoint = Utilities.ToBXDVector(rigidJoint.geomTwo.RootPoint);
+            axis = Utilities.ToBXDVector(wrapped.rigidJoint.geomTwo.Direction);
+            basePoint = Utilities.ToBXDVector(wrapped.rigidJoint.geomTwo.RootPoint);
         }
         else
         {
-            axis = Utilities.ToBXDVector(rigidJoint.geomOne.Direction);
-            basePoint = Utilities.ToBXDVector(rigidJoint.geomOne.RootPoint);
+            axis = Utilities.ToBXDVector(wrapped.rigidJoint.geomOne.Direction);
+            basePoint = Utilities.ToBXDVector(wrapped.rigidJoint.geomOne.RootPoint);
         }
 
         currentLinearPosition = (wrapped.asmJoint.LinearPosition != null) ? (float)wrapped.asmJoint.LinearPosition.Value : 0;
@@ -180,6 +165,26 @@ public class CylindricalJoint : CylindricalJoint_Base, InventorSkeletalJoint
             throw new Exception("Joints with linear motion need two limits.");
         }
         wrapped.asmJoint.LinearPosition = wrapped.asmJoint.LinearPosition;
+    }
+
+    public static bool IsCylindricalJoint(CustomRigidJoint jointI)
+    {
+        // kMateLineLineJoint
+        if (jointI.joints.Count == 1)
+        {
+            AssemblyJointDefinition joint = jointI.joints[0].Definition;
+            return joint.JointType == AssemblyJointTypeEnum.kCylindricalJointType;
+        }
+        return false;
+    }
+
+    public CylindricalJoint(CustomRigidGroup parent, CustomRigidJoint rigidJoint)
+    {
+        if (!(IsCylindricalJoint(rigidJoint)))
+            throw new Exception("Not a Cylindrical joint");
+        wrapped = new SkeletalJoint(parent, rigidJoint);
+
+        ReloadInventorJoint();
     }
 
     protected override string ToString_Internal()

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/CylindricalJoint.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/CylindricalJoint.cs
@@ -156,7 +156,7 @@ public class CylindricalJoint : CylindricalJoint_Base, InventorSkeletalJoint
             basePoint = Utilities.ToBXDVector(rigidJoint.geomOne.RootPoint);
         }
 
-        currentLinearPosition = wrapped.asmJoint.LinearPosition != null ? (float)wrapped.asmJoint.LinearPosition.Value : 0;
+        currentLinearPosition = (wrapped.asmJoint.LinearPosition != null) ? (float)wrapped.asmJoint.LinearPosition.Value : 0;
 
         hasAngularLimit = wrapped.asmJoint.HasAngularPositionLimits;
         if (hasAngularLimit)
@@ -164,7 +164,7 @@ public class CylindricalJoint : CylindricalJoint_Base, InventorSkeletalJoint
             angularLimitLow = (float)wrapped.asmJoint.AngularPositionStartLimit.Value;
             angularLimitHigh = (float)wrapped.asmJoint.AngularPositionEndLimit.Value;
         }
-        currentAngularPosition = wrapped.asmJoint.AngularPosition != null ? (float)wrapped.asmJoint.AngularPosition.Value : 0;
+        currentAngularPosition = (wrapped.asmJoint.AngularPosition != null) ? (float)wrapped.asmJoint.AngularPosition.Value : 0;
 
         hasLinearStartLimit = wrapped.asmJoint.HasLinearPositionStartLimit;
         hasLinearEndLimit = wrapped.asmJoint.HasLinearPositionEndLimit;

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/InventorSkeletalJoint.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/InventorSkeletalJoint.cs
@@ -4,4 +4,5 @@ public interface InventorSkeletalJoint
     SkeletalJoint GetWrapped();
 
     void DetermineLimits();
+    void ReloadInventorJoint();
 }

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/LinearJoint.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/LinearJoint.cs
@@ -9,8 +9,7 @@ public class LinearJoint : LinearJoint_Base, InventorSkeletalJoint
     {
         return wrapped;
     }
-
-
+    
     public void DetermineLimits()
     {
         MotionLimits cache = new MotionLimits();
@@ -72,6 +71,31 @@ public class LinearJoint : LinearJoint_Base, InventorSkeletalJoint
         }
     }
 
+    public void ReloadInventorJoint()
+    {
+        if (wrapped.childGroup == wrapped.rigidJoint.groupOne)
+        {
+            axis = Utilities.ToBXDVector(wrapped.rigidJoint.geomTwo.Direction);
+            basePoint = Utilities.ToBXDVector(wrapped.rigidJoint.geomTwo.RootPoint);
+        }
+        else
+        {
+            axis = Utilities.ToBXDVector(wrapped.rigidJoint.geomOne.Direction);
+            basePoint = Utilities.ToBXDVector(wrapped.rigidJoint.geomOne.RootPoint);
+        }
+
+        if ((hasUpperLimit = wrapped.asmJoint.HasLinearPositionEndLimit) && (hasLowerLimit = wrapped.asmJoint.HasLinearPositionStartLimit))
+        {
+            linearLimitHigh = (float)wrapped.asmJoint.LinearPositionEndLimit.Value;
+            linearLimitLow = (float)wrapped.asmJoint.LinearPositionStartLimit.Value;
+        }
+        else
+        {
+            throw new Exception("Joints with linear motion need two limits.");
+        }
+        currentLinearPosition = (wrapped.asmJoint.LinearPosition != null) ? ((float)wrapped.asmJoint.LinearPosition.Value) : 0;
+    }
+
     public static bool IsLinearJoint(CustomRigidJoint jointI)
     {
         // kTranslationalJoint
@@ -93,28 +117,7 @@ public class LinearJoint : LinearJoint_Base, InventorSkeletalJoint
             throw new Exception("Not a linear joint");
         wrapped = new SkeletalJoint(parent, rigidJoint);
 
-        if (wrapped.childGroup == rigidJoint.groupOne)
-        {
-            axis = Utilities.ToBXDVector(rigidJoint.geomTwo.Direction);
-            basePoint = Utilities.ToBXDVector(rigidJoint.geomTwo.RootPoint);
-        }
-        else
-        {
-            axis = Utilities.ToBXDVector(rigidJoint.geomOne.Direction);
-            basePoint = Utilities.ToBXDVector(rigidJoint.geomOne.RootPoint);
-        }
-
-        if ((hasUpperLimit = wrapped.asmJoint.HasLinearPositionEndLimit) && (hasLowerLimit = wrapped.asmJoint.HasLinearPositionStartLimit))
-        {
-            linearLimitHigh = (float)wrapped.asmJoint.LinearPositionEndLimit.Value;
-            linearLimitLow = (float)wrapped.asmJoint.LinearPositionStartLimit.Value;
-        }
-        else
-        {
-            throw new Exception("Joints with linear motion need two limits.");
-        }
-        currentLinearPosition = (wrapped.asmJoint.LinearPosition != null) ? ((float)wrapped.asmJoint.LinearPosition.Value) : 0;
-
+        ReloadInventorJoint();
     }
 
     protected override string ToString_Internal()

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/LinearJoint.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/LinearJoint.cs
@@ -113,7 +113,7 @@ public class LinearJoint : LinearJoint_Base, InventorSkeletalJoint
         {
             throw new Exception("Joints with linear motion need two limits.");
         }
-        currentLinearPosition = !((wrapped.asmJoint.LinearPosition == null)) ? ((float)wrapped.asmJoint.LinearPosition.Value) : 0;
+        currentLinearPosition = (wrapped.asmJoint.LinearPosition != null) ? ((float)wrapped.asmJoint.LinearPosition.Value) : 0;
 
     }
 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/PlanarJoint.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/PlanarJoint.cs
@@ -18,6 +18,21 @@ class PlanarJoint : PlanarJoint_Base, InventorSkeletalJoint
     {
         // TODO
     }
+
+    public void ReloadInventorJoint()
+    {
+        if (wrapped.childGroup == wrapped.rigidJoint.groupOne)
+        {
+            normal = Utilities.ToBXDVector(wrapped.rigidJoint.geomTwo.Normal);
+            basePoint = Utilities.ToBXDVector(wrapped.rigidJoint.geomTwo.RootPoint);
+        }
+        else
+        {
+            normal = Utilities.ToBXDVector(wrapped.rigidJoint.geomOne.Normal);
+            basePoint = Utilities.ToBXDVector(wrapped.rigidJoint.geomOne.RootPoint);
+        }
+    }
+
     public static bool IsPlanarJoint(CustomRigidJoint jointI)
     {
         if (jointI.joints.Count == 1)
@@ -34,17 +49,7 @@ class PlanarJoint : PlanarJoint_Base, InventorSkeletalJoint
             throw new Exception("Not a planar joint");
         wrapped = new SkeletalJoint(parent, rigidJoint);
 
-
-        if (wrapped.childGroup == rigidJoint.groupOne)
-        {
-            normal = Utilities.ToBXDVector(rigidJoint.geomTwo.Normal);
-            basePoint = Utilities.ToBXDVector(rigidJoint.geomTwo.RootPoint);
-        }
-        else
-        {
-            normal = Utilities.ToBXDVector(rigidJoint.geomOne.Normal);
-            basePoint = Utilities.ToBXDVector(rigidJoint.geomOne.RootPoint);
-        }
+        ReloadInventorJoint();
     }
 
     protected override string ToString_Internal()

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/RotationalJoint.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/RotationalJoint.cs
@@ -71,6 +71,28 @@ public class RotationalJoint : RotationalJoint_Base, InventorSkeletalJoint
         }
     }
 
+    public void ReloadInventorJoint()
+    {
+        try
+        {
+            axis = Utilities.ToBXDVector(wrapped.rigidJoint.geomOne.Normal);
+            basePoint = Utilities.ToBXDVector(wrapped.rigidJoint.geomOne.Center);
+        }
+        catch
+        {
+            axis = Utilities.ToBXDVector(wrapped.rigidJoint.geomOne.Direction);
+            basePoint = Utilities.ToBXDVector(wrapped.rigidJoint.geomOne.RootPoint);
+        }
+
+        hasAngularLimit = wrapped.asmJoint.HasAngularPositionLimits;
+        if ((hasAngularLimit))
+        {
+            angularLimitLow = (float)wrapped.asmJoint.AngularPositionStartLimit.Value;
+            angularLimitHigh = (float)wrapped.asmJoint.AngularPositionEndLimit.Value;
+        }
+        currentAngularPosition = (wrapped.asmJoint.AngularPosition != null) ? (float)wrapped.asmJoint.AngularPosition.Value : 0;
+    }
+
     public static bool IsRotationalJoint(CustomRigidJoint jointI)
     {
         // RigidBodyJointType = kConcentricCircleCircleJoint
@@ -94,25 +116,7 @@ public class RotationalJoint : RotationalJoint_Base, InventorSkeletalJoint
             throw new Exception("Not a rotational joint");
         wrapped = new SkeletalJoint(parent, rigidJoint);
 
-        try
-        {
-            axis = Utilities.ToBXDVector(rigidJoint.geomOne.Normal);
-            basePoint = Utilities.ToBXDVector(rigidJoint.geomOne.Center);
-        }
-        catch
-        {
-            axis = Utilities.ToBXDVector(rigidJoint.geomOne.Direction);
-            basePoint = Utilities.ToBXDVector(rigidJoint.geomOne.RootPoint);
-        }
-
-
-        hasAngularLimit = wrapped.asmJoint.HasAngularPositionLimits;
-        if ((hasAngularLimit))
-        {
-            angularLimitLow = (float) wrapped.asmJoint.AngularPositionStartLimit.Value;
-            angularLimitHigh = (float) wrapped.asmJoint.AngularPositionEndLimit.Value;
-        }
-        currentAngularPosition = (wrapped.asmJoint.AngularPosition != null) ? (float)wrapped.asmJoint.AngularPosition.Value : 0;
+        ReloadInventorJoint();
     }
 
     protected override string ToString_Internal()

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/RotationalJoint.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/SkeletalStructure/RotationalJoint.cs
@@ -112,7 +112,7 @@ public class RotationalJoint : RotationalJoint_Base, InventorSkeletalJoint
             angularLimitLow = (float) wrapped.asmJoint.AngularPositionStartLimit.Value;
             angularLimitHigh = (float) wrapped.asmJoint.AngularPositionEndLimit.Value;
         }
-        currentAngularPosition = !((wrapped.asmJoint.AngularPosition == null)) ? (float)wrapped.asmJoint.AngularPosition.Value : 0;
+        currentAngularPosition = (wrapped.asmJoint.AngularPosition != null) ? (float)wrapped.asmJoint.AngularPosition.Value : 0;
     }
 
     protected override string ToString_Internal()


### PR DESCRIPTION
Removed the setting of joint positions.
Improved the managing of limit values from Inventor.
Fixed issues where, if limits were defined in reverse order, joints would move in the wrong direction.
Made it actually export the current position of joints.
This resolves AARD-772.