### PR TITLE
Added Shortcut To Installer

### DIFF
--- a/installer/installerRelease.nsi
+++ b/installer/installerRelease.nsi
@@ -169,13 +169,6 @@ Section "Robot Exporter Plugin (reccommended)" PluginExporter
 
   SetOutPath "C:\Program Files (x86)\Autodesk\Synthesis"
   File /r "RobotExporter\BxDRobotExporter.dll"
- 
-  SetOutPath "$APPDATA\RobotViewer"
-  File /r "RobotExporter\Viewer\RobotViewer.exe"
-  File /r "RobotExporter\Viewer\OpenTK.dll"
-  File /r "RobotExporter\Viewer\OpenTK.GLControl.dll"
-  File /r "RobotExporter\Viewer\OGLViewer.dll"
-  File /r "RobotExporter\Viewer\SimulatorAPI.dll"
 
 SectionEnd
 

--- a/installer/installerRelease.nsi
+++ b/installer/installerRelease.nsi
@@ -110,8 +110,8 @@ Section "Synthesis (required)" SynthesisRequired
   File /r "Synthesis\*"
 
   SetOutPath $INSTDIR
-  CreateShortCut "$SMPROGRAMS\Synthesis.lnk" "$INSTDIR\SynthesisLauncher.exe"
-  CreateShortCut "$DESKTOP\Synthesis.lnk" "$INSTDIR\SynthesisLauncher.exe"
+  CreateShortCut "$SMPROGRAMS\Synthesis.lnk" "$INSTDIR\Synthesis\Synthesis.exe"
+  CreateShortCut "$DESKTOP\Synthesis.lnk" "$INSTDIR\Synthesis\Synthesis.exe"
 
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Autodesk Synthesis" \
                 "DisplayName" "Autodesk Synthesis"


### PR DESCRIPTION
Just a quick fix so that the installer creates a desktop shortcut from the Unity executable, now that the launcher has been removed.