### PR TITLE
Exporter limit switch fix

### DIFF
--- a/exporters/Aardvark-Libraries/SimulatorFileIO/Joints/Sensors/RobotSensor.cs
+++ b/exporters/Aardvark-Libraries/SimulatorFileIO/Joints/Sensors/RobotSensor.cs
@@ -58,7 +58,7 @@ public class RobotSensor : BinaryRWObject
             case SkeletalJointType.ROTATIONAL:
                 return new RobotSensorType[] {RobotSensorType.ENCODER/*, RobotSensorType.POTENTIOMETER, RobotSensorType.LIMIT*/};
             case SkeletalJointType.LINEAR:
-                return new RobotSensorType[] {RobotSensorType.LIMIT };
+                return new RobotSensorType[] {RobotSensorType.ENCODER };
             case SkeletalJointType.CYLINDRICAL:
                 return new RobotSensorType[] {RobotSensorType.ENCODER/*, RobotSensorType.POTENTIOMETER, RobotSensorType.LIMIT*/};
             case SkeletalJointType.PLANAR:

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineMovingPartsPage.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Pages/DefineMovingPartsPage.Designer.cs
@@ -38,14 +38,13 @@
             // 
             this.Step3InfoLabel.AutoSize = true;
             this.Step3InfoLabel.Dock = System.Windows.Forms.DockStyle.Top;
-            this.Step3InfoLabel.Location = new System.Drawing.Point(3, 3);
-            this.Step3InfoLabel.Margin = new System.Windows.Forms.Padding(3);
+            this.Step3InfoLabel.Location = new System.Drawing.Point(4, 4);
+            this.Step3InfoLabel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Step3InfoLabel.Name = "Step3InfoLabel";
-            this.Step3InfoLabel.Size = new System.Drawing.Size(454, 26);
+            this.Step3InfoLabel.Size = new System.Drawing.Size(605, 17);
             this.Step3InfoLabel.TabIndex = 1;
-            this.Step3InfoLabel.Text = "If you have any other moving parts on your robot that you believe would be useful" +
-    " to have in the simulation, set them up here by checking any of the nodes on the" +
-    " list.\r\n";
+            this.Step3InfoLabel.Text = "Define additional moving parts, any joints left undefined will not be bound to a " +
+    "control port.";
             // 
             // MainLayout
             // 
@@ -60,7 +59,7 @@
             this.MainLayout.RowCount = 2;
             this.MainLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.MainLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.MainLayout.Size = new System.Drawing.Size(460, 653);
+            this.MainLayout.Size = new System.Drawing.Size(613, 804);
             this.MainLayout.TabIndex = 3;
             // 
             // DefinePartsLayout
@@ -68,22 +67,24 @@
             this.DefinePartsLayout.AutoScroll = true;
             this.DefinePartsLayout.ColumnCount = 2;
             this.DefinePartsLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.DefinePartsLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.DefinePartsLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 27F));
             this.DefinePartsLayout.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DefinePartsLayout.Location = new System.Drawing.Point(3, 35);
+            this.DefinePartsLayout.Location = new System.Drawing.Point(4, 29);
+            this.DefinePartsLayout.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.DefinePartsLayout.Name = "DefinePartsLayout";
             this.DefinePartsLayout.RowCount = 1;
             this.DefinePartsLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.DefinePartsLayout.Size = new System.Drawing.Size(454, 615);
+            this.DefinePartsLayout.Size = new System.Drawing.Size(605, 771);
             this.DefinePartsLayout.TabIndex = 2;
             // 
             // DefineMovingPartsPage
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.MainLayout);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "DefineMovingPartsPage";
-            this.Size = new System.Drawing.Size(460, 653);
+            this.Size = new System.Drawing.Size(613, 804);
             this.MainLayout.ResumeLayout(false);
             this.MainLayout.PerformLayout();
             this.ResumeLayout(false);

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditSensorForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/EditSensorForm.cs
@@ -38,6 +38,19 @@ namespace EditorsLibrary
                 PortBNumericUpDown.Value = (decimal)sensor.portB;
                 ConversionNumericUpDown.Value = (decimal)sensor.conversionFactor;
             }
+            switch (joint.GetJointType())
+            {
+                case SkeletalJointType.ROTATIONAL:
+                    this.ConversionLbl.Text = "Counts Per Rev";
+                    break;
+                case SkeletalJointType.LINEAR:
+                    this.ConversionLbl.Text = "Counts Per Inch";
+                    break;
+                case SkeletalJointType.CYLINDRICAL:
+                    this.ConversionLbl.Text = "Counts Per Rev";
+                    break;
+
+            }
             if (typeBox.SelectedIndex == 0)
             {
                 this.PortALbl.Enabled = true;
@@ -96,7 +109,6 @@ namespace EditorsLibrary
             this.PortBNumericUpDown.Visible = true;
             this.ConversionLbl.Visible = true;
             this.ConversionNumericUpDown.Visible = true;
-            this.ConversionLbl.Text = "Counts per Rev";
         }
         public void HideSecondFields()
         {

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/Exporter/AssetProperties.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/Exporter/AssetProperties.cs
@@ -4,10 +4,12 @@ using Inventor;
 
 public class AssetProperties
 {
-    public uint color = 0;
+    public uint color = 0xFFFFFFFF;
     public double transparency = 0;
     public double translucency = 0;
     public double specular = 0;
+
+    public AssetProperties() { }
 
     public AssetProperties(Asset asset)
     {

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/Exporter/SurfaceExporter_MeshGenerator.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/Exporter/SurfaceExporter_MeshGenerator.cs
@@ -117,14 +117,26 @@ public partial class SurfaceExporter
             // Add facets for each face of the surface
             foreach (Face face in faces)
             {
-                face.CalculateFacets(tolerance, out bufferSurface.verts.count, out bufferSurface.facets.count, out bufferSurface.verts.coordinates, out bufferSurface.verts.norms, out bufferSurface.facets.indices);
-                outputMesh.AddSurface(ref bufferSurface, GetAssetProperties(face.Appearance));
+                if (face.Appearance != null) { 
+                    face.CalculateFacets(tolerance, out bufferSurface.verts.count, out bufferSurface.facets.count, out bufferSurface.verts.coordinates, out bufferSurface.verts.norms, out bufferSurface.facets.indices);
+                    outputMesh.AddSurface(ref bufferSurface, GetAssetProperties(face.Appearance));
+                }
             }
         }
         else
         {
             // Add facets once for the entire surface
-            outputMesh.AddSurface(ref bufferSurface, GetAssetProperties(faces[1].Appearance));
+            AssetProperties asset;
+            try
+            {
+                asset = GetAssetProperties(faces[1].Appearance);
+            }
+            catch (Exception)
+            {
+                asset = new AssetProperties();
+            }
+
+            outputMesh.AddSurface(ref bufferSurface, asset);
         }
     }
 


### PR DESCRIPTION
fixes 
AARD-822
"In the second page of Exporter Setup the text instruction at the top is too long, XD suggests it say "Define additional moving parts, any joints left undefined will not be bound to a control port."
AARD-823
"The option to add limit sensors should not be present since they are not implemented, encoders should be visible instead, and on all applicable driver types."

Fixed crashing issue when appearance was weird. Added encoders to linear joints and made parts page text flow better.