### PR TITLE
Fusion Exporter - As-built joints

### DIFF
--- a/exporters/FusionExporter/Source/Data/BXDJ/ConfigData.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/ConfigData.cpp
@@ -2,6 +2,7 @@
 #include <Fusion/FusionTypeDefs.h>
 #include <Fusion/Components/JointMotion.h>
 #include <Fusion/Components/Occurrence.h>
+#include <Fusion/Components/AsBuiltJoint.h>
 #include <rapidjson/document.h>
 #include "Utility.h"
 
@@ -32,11 +33,29 @@ std::unique_ptr<Driver> ConfigData::getDriver(core::Ptr<fusion::Joint> joint) co
 
 	return std::make_unique<Driver>(*joints.at(id).driver);
 }
+std::unique_ptr<Driver> ConfigData::getDriver(core::Ptr<fusion::AsBuiltJoint> joint) const
+{
+	std::string id = BXDJ::Utility::getUniqueJointID(joint);
+
+	if (joints.find(id) == joints.end() || joints.at(id).driver == nullptr)
+		return nullptr;
+
+	return std::make_unique<Driver>(*joints.at(id).driver);
+}
 
 void ConfigData::setDriver(core::Ptr<fusion::Joint> joint, const Driver & driver)
 {
 	std::string id = BXDJ::Utility::getUniqueJointID(joint);
 	joints[id].name = joint->name();
+	joints[id].asBuilt = false;
+	joints[id].motion = internalJointMotion(joint->jointMotion()->jointType());
+	joints[id].driver = std::make_unique<Driver>(driver);
+}
+void ConfigData::setDriver(core::Ptr<fusion::AsBuiltJoint> joint, const Driver & driver)
+{
+	std::string id = BXDJ::Utility::getUniqueJointID(joint);
+	joints[id].name = joint->name();
+	joints[id].asBuilt = true;
 	joints[id].motion = internalJointMotion(joint->jointMotion()->jointType());
 	joints[id].driver = std::make_unique<Driver>(driver);
 }
@@ -45,13 +64,31 @@ void ConfigData::setNoDriver(core::Ptr<fusion::Joint> joint)
 {
 	std::string id = BXDJ::Utility::getUniqueJointID(joint);
 	joints[id].name = joint->name();
+	joints[id].asBuilt = false;
+	joints[id].motion = internalJointMotion(joint->jointMotion()->jointType());
+	joints[id].driver = nullptr;
+}
+void ConfigData::setNoDriver(core::Ptr<fusion::AsBuiltJoint> joint)
+{
+	std::string id = BXDJ::Utility::getUniqueJointID(joint);
+	joints[id].name = joint->name();
+	joints[id].asBuilt = true;
 	joints[id].motion = internalJointMotion(joint->jointMotion()->jointType());
 	joints[id].driver = nullptr;
 }
 
 std::vector<std::shared_ptr<JointSensor>> ConfigData::getSensors(core::Ptr<fusion::Joint> joint) const
 {
-	std::string id = BXDJ::Utility::getUniqueJointID(joint);
+	std::string id = Utility::getUniqueJointID(joint);
+
+	if (joints.find(id) == joints.end() || joints.at(id).driver == nullptr)
+		return std::vector<std::shared_ptr<JointSensor>>();
+
+	return joints.at(id).sensors;
+}
+std::vector<std::shared_ptr<JointSensor>> ConfigData::getSensors(core::Ptr<fusion::AsBuiltJoint> joint) const
+{
+	std::string id = Utility::getUniqueJointID(joint);
 
 	if (joints.find(id) == joints.end() || joints.at(id).driver == nullptr)
 		return std::vector<std::shared_ptr<JointSensor>>();
@@ -76,11 +113,45 @@ void ConfigData::filterJoints(std::vector<core::Ptr<fusion::Joint>> filterJoints
 	std::vector<std::string> jointsToErase;
 	for (auto i = joints.begin(); i != joints.end(); i++)
 	{
-		int j = 0;
-		while (j < filterJointIDs.size() && filterJointIDs[j] != i->first) { j++; }
+		if (!i->second.asBuilt)
+		{
+			int j = 0;
+			while (j < filterJointIDs.size() && filterJointIDs[j] != i->first) { j++; }
 
-		if (j >= filterJointIDs.size())
-			jointsToErase.push_back(i->first);
+			if (j >= filterJointIDs.size())
+				jointsToErase.push_back(i->first);
+		}
+	}
+
+	// Erase joints
+	for (std::string jointToErase : jointsToErase)
+		joints.erase(jointToErase);
+}
+void ConfigData::filterJoints(std::vector<core::Ptr<fusion::AsBuiltJoint>> filterJoints)
+{
+	// Make list of IDs in filter while adding joints not yet present
+	std::vector<std::string> filterJointIDs;
+	for (core::Ptr<fusion::Joint> joint : filterJoints)
+	{
+		std::string id = Utility::getUniqueJointID(joint);
+		filterJointIDs.push_back(id);
+
+		if (joints.find(id) == joints.end() || joints[id].motion != internalJointMotion(joint->jointMotion()->jointType()))
+			setNoDriver(joint);
+	}
+
+	// Find all joints not present in filter
+	std::vector<std::string> jointsToErase;
+	for (auto i = joints.begin(); i != joints.end(); i++)
+	{
+		if (i->second.asBuilt)
+		{
+			int j = 0;
+			while (j < filterJointIDs.size() && filterJointIDs[j] != i->first) { j++; }
+
+			if (j >= filterJointIDs.size())
+				jointsToErase.push_back(i->first);
+		}
 	}
 
 	// Erase joints
@@ -112,6 +183,7 @@ rapidjson::Value ConfigData::getJSONObject(rapidjson::MemoryPoolAllocator<>& all
 		// Joint Info
 		jointJSON.AddMember("id", rapidjson::Value(jointID.c_str(), jointID.length(), allocator), allocator);
 		jointJSON.AddMember("name", rapidjson::Value(jointConfig.name.c_str(), jointConfig.name.length(), allocator), allocator);
+		jointJSON.AddMember("asBuilt", jointConfig.asBuilt, allocator);
 		jointJSON.AddMember("type", rapidjson::Value((int)jointConfig.motion), allocator);
 
 		// Driver Information
@@ -155,6 +227,7 @@ void ConfigData::loadJSONObject(const rapidjson::Value& configJSON)
 		std::string jointID = jointsJSON[i]["id"].GetString();
 
 		joints[jointID].name = jointsJSON[i]["name"].GetString();
+		joints[jointID].asBuilt = jointsJSON[i]["asBuilt"].GetBool();
 		joints[jointID].motion = (JointMotionType)jointsJSON[i]["type"].GetInt();
 
 		// Driver Information

--- a/exporters/FusionExporter/Source/Data/BXDJ/ConfigData.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/ConfigData.cpp
@@ -226,9 +226,9 @@ void ConfigData::loadJSONObject(const rapidjson::Value& configJSON)
 		// Joint Info
 		std::string jointID = jointsJSON[i]["id"].GetString();
 
-		joints[jointID].name = jointsJSON[i]["name"].GetString();
-		joints[jointID].asBuilt = jointsJSON[i]["asBuilt"].GetBool();
-		joints[jointID].motion = (JointMotionType)jointsJSON[i]["type"].GetInt();
+		if (jointsJSON[i].HasMember("name") && jointsJSON[i]["name"].IsString())		joints[jointID].name = jointsJSON[i]["name"].GetString();
+		if (jointsJSON[i].HasMember("asBuilt") && jointsJSON[i]["asBuilt"].IsBool())	joints[jointID].asBuilt = jointsJSON[i]["asBuilt"].GetBool();
+		if (jointsJSON[i].HasMember("type") && jointsJSON[i]["type"].IsNumber())		joints[jointID].motion = (JointMotionType)jointsJSON[i]["type"].GetInt();
 
 		// Driver Information
 		if (jointsJSON[i].HasMember("driver") && jointsJSON[i]["driver"].IsObject())

--- a/exporters/FusionExporter/Source/Data/BXDJ/ConfigData.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/ConfigData.cpp
@@ -131,7 +131,7 @@ void ConfigData::filterJoints(std::vector<core::Ptr<fusion::AsBuiltJoint>> filte
 {
 	// Make list of IDs in filter while adding joints not yet present
 	std::vector<std::string> filterJointIDs;
-	for (core::Ptr<fusion::Joint> joint : filterJoints)
+	for (core::Ptr<fusion::AsBuiltJoint> joint : filterJoints)
 	{
 		std::string id = Utility::getUniqueJointID(joint);
 		filterJointIDs.push_back(id);

--- a/exporters/FusionExporter/Source/Data/BXDJ/ConfigData.h
+++ b/exporters/FusionExporter/Source/Data/BXDJ/ConfigData.h
@@ -36,6 +36,7 @@ namespace BXDJ
 		ConfigData(const ConfigData & other);
 
 		std::unique_ptr<Driver> getDriver(core::Ptr<fusion::Joint>) const; ///< \return The driver assigned to a Fusion joint.
+		std::unique_ptr<Driver> getDriver(core::Ptr<fusion::AsBuiltJoint>) const; ///< \return The driver assigned to a Fusion as-built joint.
 
 		///
 		/// Assigns a driver to a joint in Fusion.
@@ -43,20 +44,37 @@ namespace BXDJ
 		/// \param driver Driver to apply to joint.
 		///
 		void setDriver(core::Ptr<fusion::Joint>, const Driver &);
+		///
+		/// Assigns a driver to an as-built joint in Fusion.
+		/// \param joint Joint to apply driver to.
+		/// \param driver Driver to apply to joint.
+		///
+		void setDriver(core::Ptr<fusion::AsBuiltJoint>, const Driver &);
 		
 		///
 		/// Unassigns any driver from a joint in Fusion.
 		/// \param joint Joint to remove driver from.
 		///
 		void setNoDriver(core::Ptr<fusion::Joint>);
+		///
+		/// Unassigns any driver from an as-built joint in Fusion.
+		/// \param joint Joint to remove driver from.
+		///
+		void setNoDriver(core::Ptr<fusion::AsBuiltJoint>);
 
 		std::vector<std::shared_ptr<JointSensor>> getSensors(core::Ptr<fusion::Joint>) const; ///< \return A vector containing the sensors attached to a Fusion joint.
+		std::vector<std::shared_ptr<JointSensor>> getSensors(core::Ptr<fusion::AsBuiltJoint>) const; ///< \return A vector containing the sensors attached to a Fusion as-built joint.
 
 		///
 		/// Ensures that the only documented joints are those listed in the given vector, and that all joints in that vector are documented.
 		/// \param filterJoints Joints to keep in the ConfigData.
 		///
 		void filterJoints(std::vector<core::Ptr<fusion::Joint>> filterJoints);
+		///
+		/// Ensures that the only documented as-built joints are those listed in the given vector, and that all joints in that vector are documented.
+		/// \param filterJoints As-built joints to keep in the ConfigData.
+		///
+		void filterJoints(std::vector<core::Ptr<fusion::AsBuiltJoint>> filterJoints);
 
 		rapidjson::Value getJSONObject(rapidjson::MemoryPoolAllocator<>&) const;
 		void loadJSONObject(const rapidjson::Value&);
@@ -77,6 +95,7 @@ namespace BXDJ
 		struct JointConfig
 		{
 			std::string name; ///< The name of the Fusion joint.
+			bool asBuilt; ///< Is an as built joint.
 			JointMotionType motion; ///< The limitation of the joint's motion.
 			std::unique_ptr<Driver> driver; ///< The driver assigned to the joint.
 			std::vector<std::shared_ptr<JointSensor>> sensors; /// The sensors assigned to the joint.
@@ -84,12 +103,13 @@ namespace BXDJ
 			///
 			/// Creates a nameless configuration without a driver.
 			///
-			JointConfig() { name = ""; motion = NEITHER; driver = nullptr; }
+			JointConfig() { name = ""; asBuilt = false; motion = NEITHER; driver = nullptr; }
 
 			/// Copy constructor.
 			JointConfig(const JointConfig & other)
 			{
 				name = other.name;
+				asBuilt = other.asBuilt;
 				motion = other.motion;
 				driver = (other.driver == nullptr) ? nullptr : std::make_unique<Driver>(*other.driver);
 				for (std::shared_ptr<JointSensor> sensor : other.sensors)
@@ -99,6 +119,7 @@ namespace BXDJ
 			JointConfig& JointConfig::operator=(const JointConfig &other)
 			{
 				name = other.name;
+				asBuilt = other.asBuilt;
 				motion = other.motion;
 				driver = (other.driver == nullptr) ? nullptr : std::make_unique<Driver>(*other.driver);
 				sensors.clear();

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joint.h
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joint.h
@@ -31,6 +31,15 @@ namespace BXDJ
 		///
 		Joint(RigidNode *, core::Ptr<fusion::Joint>, core::Ptr<fusion::Occurrence>);
 
+		///
+		/// Creates a joint between an existing RigidNode and one that will be created.
+		/// \param parent RigidNode that will serve as the parent of the joint.
+		/// \param fusionJoint The Fusion as-built joint to base the new Joint off of.
+		/// \param parentOccurrence The Fusion occurrence in the Fusion joint that is owned by the parent RigidNode.
+		///                         The other occurrence in the Fusion joint will become the primary occurrence for the new child RigidNode.
+		///
+		Joint(RigidNode *, core::Ptr<fusion::AsBuiltJoint>, core::Ptr<fusion::Occurrence>);
+
 		RigidNode * getParent() const; ///< \return The parent RigidNode of the Joint.
 		std::shared_ptr<RigidNode> getChild() const; ///< \return The child RigidNode of the Joint.
 		Vector3<> getParentBasePoint() const; ///< \return The point in space at which the parent occurrence is connected to the child occurrence in Fusion.
@@ -58,7 +67,8 @@ namespace BXDJ
 
 	private:
 		OneTwo parentOcc; ///< Specifies which occurrence in the Fusion joint is recognized as the parent.
-		core::Ptr<fusion::Joint> fusionJoint; ///< The Fusion joint used to create this Joint.
+		core::Ptr<fusion::Joint> fusionJoint = nullptr; ///< The Fusion joint used to create this Joint.
+		core::Ptr<fusion::AsBuiltJoint> fusionAsBuiltJoint = nullptr; ///< The Fusion as-built joint used to create this Joint.
 		RigidNode * parent; ///< The RigidNode that this Joint is a child of.
 		std::shared_ptr<RigidNode> child; ///< The RigidNode that is a child of this Joint.
 		std::unique_ptr<Driver> driver; ///< The Driver applied to this Joint.

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joint.h
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joint.h
@@ -61,7 +61,9 @@ namespace BXDJ
 		/// Used for specifying which occurrence in a Joint is recognized as the parent.
 		enum OneTwo : bool { ONE = true /**< joint->occurrenceOne() */, TWO = false /**< joint->occurrenceTwo() */ };
 
-		core::Ptr<fusion::Joint> getFusionJoint() { return fusionJoint; } ///< \return The joint in Fusion that was used to create this Joint.
+		std::unique_ptr<Driver> searchDriver(const ConfigData &); ///< \return The Driver associated with this joint in a ConfigData.
+		std::vector<std::shared_ptr<JointSensor>> searchSensors(const ConfigData &); ///< \return The Sensors associated with this joint in a ConfigData.
+
 		OneTwo getParentOccNum() { return parentOcc; } ///< \return Which Fusion occurrence (One or Two) that the parent of this Joint is in the Fusion joint.
 		virtual void write(XmlWriter &) const; ///< This should be called by any derived Joint classes. Writes driver and sensors to the BXDJ file.
 

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joints/BallJoint.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joints/BallJoint.cpp
@@ -1,4 +1,5 @@
 #include "BallJoint.h"
+#include <Fusion/Components/AsBuiltJoint.h>
 #include <Core/Geometry/Vector3D.h>
 #include "../ConfigData.h"
 #include "../Driver.h"
@@ -11,6 +12,11 @@ BallJoint::BallJoint(const BallJoint & jointToCopy) : Joint(jointToCopy)
 }
 
 BallJoint::BallJoint(RigidNode * parent, core::Ptr<fusion::Joint> fusionJoint, core::Ptr<fusion::Occurrence> parentOccurrence) : Joint(parent, fusionJoint, parentOccurrence)
+{
+	this->fusionJointMotion = fusionJoint->jointMotion();
+}
+
+BallJoint::BallJoint(RigidNode * parent, core::Ptr<fusion::AsBuiltJoint> fusionJoint, core::Ptr<fusion::Occurrence> parentOccurrence) : Joint(parent, fusionJoint, parentOccurrence)
 {
 	this->fusionJointMotion = fusionJoint->jointMotion();
 }

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joints/BallJoint.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joints/BallJoint.cpp
@@ -12,13 +12,13 @@ BallJoint::BallJoint(const BallJoint & jointToCopy) : Joint(jointToCopy)
 
 BallJoint::BallJoint(RigidNode * parent, core::Ptr<fusion::Joint> fusionJoint, core::Ptr<fusion::Occurrence> parentOccurrence) : Joint(parent, fusionJoint, parentOccurrence)
 {
-	this->fusionJointMotion = this->getFusionJoint()->jointMotion();
+	this->fusionJointMotion = fusionJoint->jointMotion();
 }
 
 void BallJoint::applyConfig(const ConfigData & config)
 {
 	// Update wheels with actual mesh information
-	std::unique_ptr<Driver> driver = config.getDriver(getFusionJoint());
+	std::unique_ptr<Driver> driver = searchDriver(config);
 	if (driver != nullptr)
 	{
 		setDriver(*driver);

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joints/BallJoint.h
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joints/BallJoint.h
@@ -23,6 +23,15 @@ namespace BXDJ
 		///
 		BallJoint(RigidNode *, core::Ptr<fusion::Joint>, core::Ptr<fusion::Occurrence>);
 
+		///
+		/// Creates a joint between an existing RigidNode and one that will be created.
+		/// \param parent RigidNode that will serve as the parent of the joint.
+		/// \param fusionJoint The Fusion as-built joint to base the new Joint off of.
+		/// \param parentOccurrence The Fusion occurrence in the Fusion joint that is owned by the parent RigidNode.
+		///                         The other occurrence in the Fusion joint will become the primary occurrence for the new child RigidNode.
+		///
+		BallJoint(RigidNode *, core::Ptr<fusion::AsBuiltJoint>, core::Ptr<fusion::Occurrence>);
+
 		void applyConfig(const ConfigData &);
 
 	private:

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joints/CylindricalJoint.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joints/CylindricalJoint.cpp
@@ -1,5 +1,6 @@
 #include "CylindricalJoint.h"
 #include <Fusion/Components/JointLimits.h>
+#include <Fusion/Components/AsBuiltJoint.h>
 #include <Core/Geometry/Vector3D.h>
 #include "../Driver.h"
 #include "../ConfigData.h"
@@ -12,6 +13,11 @@ CylindricalJoint::CylindricalJoint(const CylindricalJoint & jointToCopy) : Joint
 }
 
 CylindricalJoint::CylindricalJoint(RigidNode * parent, core::Ptr<fusion::Joint> fusionJoint, core::Ptr<fusion::Occurrence> parentOccurrence) : Joint(parent, fusionJoint, parentOccurrence)
+{
+	this->fusionJointMotion = fusionJoint->jointMotion();
+}
+
+CylindricalJoint::CylindricalJoint(RigidNode * parent, core::Ptr<fusion::AsBuiltJoint> fusionJoint, core::Ptr<fusion::Occurrence> parentOccurrence) : Joint(parent, fusionJoint, parentOccurrence)
 {
 	this->fusionJointMotion = fusionJoint->jointMotion();
 }

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joints/CylindricalJoint.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joints/CylindricalJoint.cpp
@@ -13,7 +13,7 @@ CylindricalJoint::CylindricalJoint(const CylindricalJoint & jointToCopy) : Joint
 
 CylindricalJoint::CylindricalJoint(RigidNode * parent, core::Ptr<fusion::Joint> fusionJoint, core::Ptr<fusion::Occurrence> parentOccurrence) : Joint(parent, fusionJoint, parentOccurrence)
 {
-	this->fusionJointMotion = getFusionJoint()->jointMotion();
+	this->fusionJointMotion = fusionJoint->jointMotion();
 }
 
 Vector3<> CylindricalJoint::getAxis() const
@@ -72,7 +72,7 @@ float CylindricalJoint::getMaxTranslation() const
 void CylindricalJoint::applyConfig(const ConfigData & config)
 {
 	// Update wheels with actual mesh information
-	std::unique_ptr<Driver> driver = config.getDriver(getFusionJoint());
+	std::unique_ptr<Driver> driver = searchDriver(config);
 	if (driver != nullptr)
 	{
 		setDriver(*driver);

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joints/CylindricalJoint.h
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joints/CylindricalJoint.h
@@ -22,6 +22,15 @@ namespace BXDJ
 		///
 		CylindricalJoint(RigidNode *, core::Ptr<fusion::Joint>, core::Ptr<fusion::Occurrence>);
 
+		///
+		/// Creates a joint between an existing RigidNode and one that will be created.
+		/// \param parent RigidNode that will serve as the parent of the joint.
+		/// \param fusionJoint The Fusion as-built joint to base the new Joint off of.
+		/// \param parentOccurrence The Fusion occurrence in the Fusion joint that is owned by the parent RigidNode.
+		///                         The other occurrence in the Fusion joint will become the primary occurrence for the new child RigidNode.
+		///
+		CylindricalJoint(RigidNode *, core::Ptr<fusion::AsBuiltJoint>, core::Ptr<fusion::Occurrence>);
+
 		Vector3<> getAxis() const; ///< \return The axis along which the child may move and rotate.
 
 		float getCurrentAngle() const; ///< \return The current angle of the child.

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joints/RotationalJoint.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joints/RotationalJoint.cpp
@@ -15,7 +15,7 @@ RotationalJoint::RotationalJoint(const RotationalJoint & jointToCopy) : Joint(jo
 
 RotationalJoint::RotationalJoint(RigidNode * parent, core::Ptr<fusion::Joint> fusionJoint, core::Ptr<fusion::Occurrence> parentOccurrence) : Joint(parent, fusionJoint, parentOccurrence)
 {
-	this->fusionJointMotion = this->getFusionJoint()->jointMotion();
+	this->fusionJointMotion = fusionJoint->jointMotion();
 }
 
 Vector3<> RotationalJoint::getAxisOfRotation() const
@@ -53,7 +53,7 @@ float RotationalJoint::getMaxAngle() const
 void RotationalJoint::applyConfig(const ConfigData & config)
 {
 	// Update wheels with actual mesh information
-	std::unique_ptr<Driver> driver = config.getDriver(getFusionJoint());
+	std::unique_ptr<Driver> driver = searchDriver(config);
 	if (driver != nullptr)
 	{
 		if (driver->getWheel() != nullptr)
@@ -63,7 +63,7 @@ void RotationalJoint::applyConfig(const ConfigData & config)
 	}
 
 	// Add sensors
-	std::vector<std::shared_ptr<JointSensor>> sensors = config.getSensors(getFusionJoint());
+	std::vector<std::shared_ptr<JointSensor>> sensors = searchSensors(config);
 	for (std::shared_ptr<JointSensor> sensor : sensors)
 		if (sensor->type == JointSensor::ENCODER) // Filter out unsupported sensors
 			addSensor(*sensor);

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joints/RotationalJoint.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joints/RotationalJoint.cpp
@@ -1,5 +1,6 @@
 #include "RotationalJoint.h"
 #include <Fusion/Components/JointLimits.h>
+#include <Fusion/Components/AsBuiltJoint.h>
 #include <Core/Geometry/Vector3D.h>
 #include "../ConfigData.h"
 #include "../Driver.h"
@@ -14,6 +15,11 @@ RotationalJoint::RotationalJoint(const RotationalJoint & jointToCopy) : Joint(jo
 }
 
 RotationalJoint::RotationalJoint(RigidNode * parent, core::Ptr<fusion::Joint> fusionJoint, core::Ptr<fusion::Occurrence> parentOccurrence) : Joint(parent, fusionJoint, parentOccurrence)
+{
+	this->fusionJointMotion = fusionJoint->jointMotion();
+}
+
+RotationalJoint::RotationalJoint(RigidNode * parent, core::Ptr<fusion::AsBuiltJoint> fusionJoint, core::Ptr<fusion::Occurrence> parentOccurrence) : Joint(parent, fusionJoint, parentOccurrence)
 {
 	this->fusionJointMotion = fusionJoint->jointMotion();
 }

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joints/RotationalJoint.h
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joints/RotationalJoint.h
@@ -22,6 +22,15 @@ namespace BXDJ
 		///
 		RotationalJoint(RigidNode *, core::Ptr<fusion::Joint>, core::Ptr<fusion::Occurrence>);
 
+		///
+		/// Creates a joint between an existing RigidNode and one that will be created.
+		/// \param parent RigidNode that will serve as the parent of the joint.
+		/// \param fusionJoint The Fusion as-built joint to base the new Joint off of.
+		/// \param parentOccurrence The Fusion occurrence in the Fusion joint that is owned by the parent RigidNode.
+		///                         The other occurrence in the Fusion joint will become the primary occurrence for the new child RigidNode.
+		///
+		RotationalJoint(RigidNode *, core::Ptr<fusion::AsBuiltJoint>, core::Ptr<fusion::Occurrence>);
+
 		Vector3<> getAxisOfRotation() const; ///< \return The axis along which the child may rotate.
 		float getCurrentAngle() const; ///< \return The current angle of the child.
 		bool hasLimits() const; ///< \return Whether or not rotation is limited.

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joints/SliderJoint.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joints/SliderJoint.cpp
@@ -14,7 +14,7 @@ SliderJoint::SliderJoint(const SliderJoint & jointToCopy) : Joint(jointToCopy)
 
 SliderJoint::SliderJoint(RigidNode * parent, core::Ptr<fusion::Joint> fusionJoint, core::Ptr<fusion::Occurrence> parentOccurrence) : Joint(parent, fusionJoint, parentOccurrence)
 {
-	this->fusionJointMotion = this->getFusionJoint()->jointMotion();
+	this->fusionJointMotion = fusionJoint->jointMotion();
 }
 
 Vector3<> SliderJoint::getAxisOfTranslation() const
@@ -47,14 +47,14 @@ float SliderJoint::getMaxTranslation() const
 void SliderJoint::applyConfig(const ConfigData & config)
 {
 	// Update wheels with actual mesh information
-	std::unique_ptr<Driver> driver = config.getDriver(getFusionJoint());
+	std::unique_ptr<Driver> driver = searchDriver(config);
 	if (driver != nullptr)
 	{
 		setDriver(*driver);
 	}
 
 	// Add sensors
-	std::vector<std::shared_ptr<JointSensor>> sensors = config.getSensors(getFusionJoint());
+	std::vector<std::shared_ptr<JointSensor>> sensors = searchSensors(config);
 	for (std::shared_ptr<JointSensor> sensor : sensors)
 		if (false) // Filter out unsupported sensors (no limit sensors are implemented)
 			addSensor(*sensor);

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joints/SliderJoint.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joints/SliderJoint.cpp
@@ -1,5 +1,6 @@
 #include "SliderJoint.h"
 #include <Fusion/Components/JointLimits.h>
+#include <Fusion/Components/AsBuiltJoint.h>
 #include <Core/Geometry/Vector3D.h>
 #include "../ConfigData.h"
 #include "../Driver.h"
@@ -13,6 +14,11 @@ SliderJoint::SliderJoint(const SliderJoint & jointToCopy) : Joint(jointToCopy)
 }
 
 SliderJoint::SliderJoint(RigidNode * parent, core::Ptr<fusion::Joint> fusionJoint, core::Ptr<fusion::Occurrence> parentOccurrence) : Joint(parent, fusionJoint, parentOccurrence)
+{
+	this->fusionJointMotion = fusionJoint->jointMotion();
+}
+
+SliderJoint::SliderJoint(RigidNode * parent, core::Ptr<fusion::AsBuiltJoint> fusionJoint, core::Ptr<fusion::Occurrence> parentOccurrence) : Joint(parent, fusionJoint, parentOccurrence)
 {
 	this->fusionJointMotion = fusionJoint->jointMotion();
 }

--- a/exporters/FusionExporter/Source/Data/BXDJ/Joints/SliderJoint.h
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Joints/SliderJoint.h
@@ -22,6 +22,15 @@ namespace BXDJ
 		///
 		SliderJoint(RigidNode *, core::Ptr<fusion::Joint>, core::Ptr<fusion::Occurrence>);
 
+		///
+		/// Creates a joint between an existing RigidNode and one that will be created.
+		/// \param parent RigidNode that will serve as the parent of the joint.
+		/// \param fusionJoint The Fusion as-built joint to base the new Joint off of.
+		/// \param parentOccurrence The Fusion occurrence in the Fusion joint that is owned by the parent RigidNode.
+		///                         The other occurrence in the Fusion joint will become the primary occurrence for the new child RigidNode.
+		///
+		SliderJoint(RigidNode *, core::Ptr<fusion::AsBuiltJoint>, core::Ptr<fusion::Occurrence>);
+
 		Vector3<> getAxisOfTranslation() const; ///< \return The axis along which the child may move.
 		float getCurrentTranslation() const; ///< \return The current position of the child along the axis.
 		float getMinTranslation() const; ///< \return The minimum position of the child.

--- a/exporters/FusionExporter/Source/Data/BXDJ/RigidNode-Tree.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/RigidNode-Tree.cpp
@@ -157,7 +157,7 @@ void RigidNode::buildTree(core::Ptr<fusion::Occurrence> rootOccurrence)
 		log += std::string(depth - 1, '\t') + "As-Built Joints:\n";
 #endif
 
-		for (core::Ptr<fusion::AsBuiltJoint> joint : jointSummary->parents[rootOccurrence])
+		for (core::Ptr<fusion::AsBuiltJoint> joint : jointSummary->asBuiltParents[rootOccurrence])
 			addJoint(joint, rootOccurrence);
 	}
 

--- a/exporters/FusionExporter/Source/Data/BXDJ/RigidNode-Tree.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/RigidNode-Tree.cpp
@@ -2,6 +2,7 @@
 #include <Fusion/Components/Occurrences.h>
 #include <Fusion/Components/OccurrenceList.h>
 #include <Fusion/Components/RigidGroup.h>
+#include <Fusion/Components/AsBuiltJoint.h>
 #include "Utility.h"
 #include "ConfigData.h"
 #include "Joint.h"
@@ -77,6 +78,19 @@ RigidNode::JointSummary RigidNode::getJointSummary(core::Ptr<fusion::Component> 
 		}
 	}
 
+	// Find all as-built jointed occurrences in the design
+	for (core::Ptr<fusion::AsBuiltJoint> joint : rootComponent->allAsBuiltJoints())
+	{
+		if (joint->occurrenceOne() != nullptr && joint->occurrenceTwo() != nullptr)
+		{
+			core::Ptr<fusion::Occurrence> lowerOccurrence = joint->occurrenceOne();
+			core::Ptr<fusion::Occurrence> upperOccurrence = joint->occurrenceTwo();
+
+			jointSummary.children[lowerOccurrence] = upperOccurrence;
+			jointSummary.asBuiltParents[upperOccurrence].push_back(joint);
+		}
+	}
+
 	// Find all rigid groups in the design
 	for (core::Ptr<fusion::RigidGroup> rgdGroup : rootComponent->allRigidGroups())
 	{
@@ -136,6 +150,17 @@ void RigidNode::buildTree(core::Ptr<fusion::Occurrence> rootOccurrence)
 			addJoint(joint, rootOccurrence);
 	}
 
+	// Create a joint from this occurrence if it is the parent of any as-built joints
+	if (jointSummary->asBuiltParents.find(rootOccurrence) != jointSummary->asBuiltParents.end())
+	{
+#if _DEBUG
+		log += std::string(depth - 1, '\t') + "As-Built Joints:\n";
+#endif
+
+		for (core::Ptr<fusion::AsBuiltJoint> joint : jointSummary->parents[rootOccurrence])
+			addJoint(joint, rootOccurrence);
+	}
+
 	// Merge this occurrence with any occurrences rigidgrouped to it
 	if (jointSummary->rigidgroups.find(rootOccurrence) != jointSummary->rigidgroups.end())
 	{
@@ -170,6 +195,44 @@ void RigidNode::buildTree(core::Ptr<fusion::Occurrence> rootOccurrence)
 }
 
 void RigidNode::addJoint(core::Ptr<fusion::Joint> joint, core::Ptr<fusion::Occurrence> parent)
+{
+	core::Ptr<fusion::Occurrence> child = (joint->occurrenceOne() != parent) ? joint->occurrenceOne() : joint->occurrenceTwo();
+
+	// Do not add joint if child has changed parents
+	if (jointSummary->children[child] != parent)
+	{
+#if _DEBUG
+		log += std::string(depth, '\t') + "Cannot joint \"" + child->fullPathName() + "\", parent has changed\n";
+#endif
+		return;
+	}
+
+	std::shared_ptr<Joint> newJoint = nullptr;
+
+	fusion::JointTypes jointType = joint->jointMotion()->jointType();
+
+	// Create joint based on the type of joint in Fusion
+	if (jointType == fusion::JointTypes::RevoluteJointType)
+		newJoint = std::make_shared<RotationalJoint>(this, joint, parent);
+	else if (jointType == fusion::JointTypes::SliderJointType)
+		newJoint = std::make_shared<SliderJoint>(this, joint, parent);
+	else if (jointType == fusion::JointTypes::CylindricalJointType)
+		newJoint = std::make_shared<CylindricalJoint>(this, joint, parent);
+	else if (jointType == fusion::JointTypes::BallJointType)
+		newJoint = std::make_shared<BallJoint>(this, joint, parent);
+	else
+	{
+		// If joint type is unsupported, add as if occurrence is attached by rigid joint (same rigidNode)
+		buildTree(child);
+		return;
+	}
+
+	// Apply user configuration to joint
+	newJoint->applyConfig(*configData);
+	childrenJoints.push_back(newJoint);
+}
+
+void RigidNode::addJoint(core::Ptr<fusion::AsBuiltJoint> joint, core::Ptr<fusion::Occurrence> parent)
 {
 	core::Ptr<fusion::Occurrence> child = (joint->occurrenceOne() != parent) ? joint->occurrenceOne() : joint->occurrenceTwo();
 

--- a/exporters/FusionExporter/Source/Data/BXDJ/RigidNode.h
+++ b/exporters/FusionExporter/Source/Data/BXDJ/RigidNode.h
@@ -76,6 +76,7 @@ namespace BXDJ
 		{
 			std::map<core::Ptr<fusion::Occurrence>, core::Ptr<fusion::Occurrence>> children; ///< Map of all Fusion occurrences that are children of joints/rigidgroups to their parents.
 			std::map<core::Ptr<fusion::Occurrence>, std::vector<core::Ptr<fusion::Joint>>> parents; ///< Map of all Fusion occurrences that are parents of joints to their children.
+			std::map<core::Ptr<fusion::Occurrence>, std::vector<core::Ptr<fusion::AsBuiltJoint>>> asBuiltParents; ///< Map of all Fusion occurrences that are parents of as-built joints to their children.
 			std::map<core::Ptr<fusion::Occurrence>, std::vector<core::Ptr<fusion::Occurrence>>> rigidgroups; ///< Map of all Fusion occurrences that are parents of rigidgroups to their children.
 
 			std::string toString() const; ///< \return A stringified version of the JointSummary.
@@ -116,6 +117,15 @@ namespace BXDJ
 		/// \param parent The occurrence that should be recognized as the parent of the Joint.
 		///
 		void addJoint(core::Ptr<fusion::Joint>, core::Ptr<fusion::Occurrence>);
+
+		///
+		/// Creates a Joint based on a Fusion as-built joint and attaches it to this RigidNode.
+		/// Unsupported joint types will be treated the same as rigid joints, that is,
+		/// they will be merged into this RigidNode.
+		/// \param joint Fusion as-built joint to base the Joint off of.
+		/// \param parent The occurrence that should be recognized as the parent of the Joint.
+		///
+		void addJoint(core::Ptr<fusion::AsBuiltJoint>, core::Ptr<fusion::Occurrence>);
 		
 		void write(XmlWriter &) const;
 

--- a/exporters/FusionExporter/Source/Data/BXDJ/Utility.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Utility.cpp
@@ -1,6 +1,7 @@
 #include "Utility.h"
 #include <Fusion/Components/Occurrence.h>
 #include <Fusion/Components/Joint.h>
+#include <Fusion/Components/AsBuiltJoint.h>
 
 using namespace adsk;
 using namespace BXDJ;
@@ -14,6 +15,11 @@ int Utility::levelOfOccurrence(core::Ptr<fusion::Occurrence> occurrence)
 }
 
 std::string Utility::getUniqueJointID(core::Ptr<adsk::fusion::Joint> joint)
+{
+	return joint->occurrenceTwo()->fullPathName() + joint->name();
+}
+
+std::string Utility::getUniqueJointID(core::Ptr<adsk::fusion::AsBuiltJoint> joint)
 {
 	return joint->occurrenceTwo()->fullPathName() + joint->name();
 }

--- a/exporters/FusionExporter/Source/Data/BXDJ/Utility.h
+++ b/exporters/FusionExporter/Source/Data/BXDJ/Utility.h
@@ -20,5 +20,12 @@ namespace BXDJ
 		/// \return Unique ID for the joint.
 		///
 		std::string getUniqueJointID(adsk::core::Ptr<adsk::fusion::Joint> joint);
+
+		///
+		/// Generates a unique identifier for a Fusion as-built joint.
+		/// \param joint As-built joint to create identifier for.
+		/// \return Unique ID for the joint.
+		///
+		std::string getUniqueJointID(adsk::core::Ptr<adsk::fusion::AsBuiltJoint> joint);
 	}
 }

--- a/exporters/FusionExporter/Source/Exporter.cpp
+++ b/exporters/FusionExporter/Source/Exporter.cpp
@@ -18,8 +18,6 @@ using namespace SynthesisAddIn;
 
 std::vector<Ptr<Joint>> Exporter::collectJoints(Ptr<FusionDocument> document)
 {
-	std::string stringifiedJoints;
-
 	std::vector<Ptr<Joint>> allJoints = document->design()->rootComponent()->allJoints();
 	std::vector<Ptr<Joint>> joints;
 
@@ -41,8 +39,6 @@ std::vector<Ptr<Joint>> Exporter::collectJoints(Ptr<FusionDocument> document)
 
 std::vector<Ptr<AsBuiltJoint>> Exporter::collectAsBuiltJoints(Ptr<FusionDocument> document)
 {
-	std::string stringifiedJoints;
-
 	std::vector<Ptr<AsBuiltJoint>> allJoints = document->design()->rootComponent()->allAsBuiltJoints();
 	std::vector<Ptr<AsBuiltJoint>> joints;
 

--- a/exporters/FusionExporter/Source/Exporter.cpp
+++ b/exporters/FusionExporter/Source/Exporter.cpp
@@ -3,6 +3,7 @@
 #include <Fusion/Fusion/Design.h>
 #include <Fusion/Components/Component.h>
 #include <Fusion/Components/JointMotion.h>
+#include <Fusion/Components/AsBuiltJoint.h>
 #include <Core/Application/Attributes.h>
 #include <Core/Application/Attribute.h>
 #include "Data/Filesystem.h"
@@ -38,6 +39,29 @@ std::vector<Ptr<Joint>> Exporter::collectJoints(Ptr<FusionDocument> document)
 	return joints;
 }
 
+std::vector<Ptr<AsBuiltJoint>> Exporter::collectAsBuiltJoints(Ptr<FusionDocument> document)
+{
+	std::string stringifiedJoints;
+
+	std::vector<Ptr<AsBuiltJoint>> allJoints = document->design()->rootComponent()->allAsBuiltJoints();
+	std::vector<Ptr<AsBuiltJoint>> joints;
+
+	for (int j = 0; j < allJoints.size(); j++)
+	{
+		Ptr<AsBuiltJoint> joint = allJoints[j];
+
+		JointTypes type = joint->jointMotion()->jointType();
+
+		// Check if joint is supported to have drivers
+		if (type == JointTypes::RevoluteJointType ||
+			type == JointTypes::SliderJointType ||
+			type == JointTypes::CylindricalJointType)
+			joints.push_back(joint);
+	}
+
+	return joints;
+}
+
 BXDJ::ConfigData Exporter::loadConfiguration(Ptr<FusionDocument> document)
 {
 	Ptr<Attribute> attr = document->attributes()->itemByName("Synthesis", "RobotConfigData.json");
@@ -47,6 +71,7 @@ BXDJ::ConfigData Exporter::loadConfiguration(Ptr<FusionDocument> document)
 		config.fromJSONString(attr->value());
 
 	config.filterJoints(collectJoints(document));
+	config.filterJoints(collectAsBuiltJoints(document));
 
 	return config;
 }

--- a/exporters/FusionExporter/Source/Exporter.h
+++ b/exporters/FusionExporter/Source/Exporter.h
@@ -18,6 +18,11 @@ namespace SynthesisAddIn
 		/// \param document Fusion document to get joints from.
 		///
 		static std::vector<Ptr<Joint>> collectJoints(Ptr<FusionDocument>);
+		///
+		/// Collects all configurable Fusion as-built joints.
+		/// \param document Fusion document to get joints from.
+		///
+		static std::vector<Ptr<AsBuiltJoint>> collectAsBuiltJoints(Ptr<FusionDocument>);
 
 		///
 		/// Loads ConfigData from a Fusion document's attributes.

--- a/exporters/FusionExporter/palette/js/export.js
+++ b/exporters/FusionExporter/palette/js/export.js
@@ -119,6 +119,7 @@ function applyConfigData(configData)
 
         fieldset.id = 'joint-config-' + String(i);
         fieldset.dataset.jointId = joints[i].id;
+        fieldset.dataset.asBuilt = joints[i].asBuilt ? 'true' : 'false';
         fieldset.dataset.sensors = JSON.stringify(joints[i].sensors);
 
         var jointTitle = getElByClass(fieldset, 'joint-config-legend');
@@ -319,6 +320,7 @@ function readConfigData()
         var joint = {
             'driver': null,
             'id': fieldset.dataset.jointId,
+            'asBuilt': fieldset.dataset.asBuilt == 'true',
             'name': getElByClass(fieldset, 'joint-config-legend').innerHTML,
             'type': parseInt(fieldset.dataset.joint_type),
             'sensors': JSON.parse(fieldset.dataset.sensors)


### PR DESCRIPTION
Implemented As-Built joints into Fusion exporter, allowing users to build their robots with as-built joints and still export.
This resolves AARD-892