### PR TITLE
Fixed An Emulator Directory Pointer To AppData

### DIFF
--- a/engine/unity5/Assets/Scripts/States/MainState.cs
+++ b/engine/unity5/Assets/Scripts/States/MainState.cs
@@ -170,7 +170,7 @@ namespace Synthesis.States
             StateMachine.Link<SensorSpawnState>(Auxiliary.FindGameObject("ResetSensorSpawnpointUI"));
             StateMachine.Link<DefineSensorAttachmentState>(Auxiliary.FindGameObject("DefineSensorAttachmentUI"));
 
-            string defaultDirectory = (Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) + @"\Autodesk\Synthesis\Emulator");
+            string defaultDirectory = (Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Synthesis\Emulator");
             string directoryPath = "";
 
             if (Directory.Exists(defaultDirectory))


### PR DESCRIPTION
Not sure why this one was still pointing to the Program Files directory but this should change it to the correct directory. This is just a quick fix.