### PR TITLE
Added EmuInstaller Cross-Architecture Support

### DIFF
--- a/installer/EmuInstaller.nsi
+++ b/installer/EmuInstaller.nsi
@@ -14,19 +14,20 @@
   ;Request application privileges
   RequestExecutionLevel admin
 
-;--------------------------------
-;Installer Sections
-
 Section
 
-  IfFileExists "$PROGRAMFILES\Autodesk\Synthesis\Synthesis\Synthesis.exe" file_found file_not_found
+  IfFileExists "$PROGRAMFILES64\Autodesk\Synthesis\Synthesis\Synthesis.exe" file_found file_not_found
 
   file_found: goto perform_install
   
-  file_not_found:
+  file_not_found: IfFileExists "$PROGRAMFILES\Autodesk\Synthesis\Synthesis32.exe" file_detected file_not_detected
+  
+  file_detected: goto perform_install
+  
+  file_not_detected:
   
 	MessageBox MB_YESNO "It appears that you do not have Synthesis installed. Would you like to download it now?" IDNO NoDownload
-      ExecShell "open" "http://bxd.autodesk.com/download.html"
+      ExecShell "open" "http://synthesis.autodesk.com/download.html"
 	  ExecShell "open" "http://synthesis.autodesk.com/Downloadables/Synthesis%20Installer.exe"
 	  
 	  Quit


### PR DESCRIPTION
Emulator should now install on both 32bit and 64bit OS and detect either Synthesis.

Though personally, I've never actually seen the emulator run on a 32 bit system.

I feel this is something we should test before our next release @BradenMccoy 