### PR TITLE
Exporter Damage Control

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Autodesk.BxDRobotExporter.Inventor.addin
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Autodesk.BxDRobotExporter.Inventor.addin
@@ -4,7 +4,7 @@
   <ClientId>{0c9a07ad-2768-4a62-950a-b5e33b88e4a3}</ClientId>
   <DisplayName>Synthesis Robot Exporter</DisplayName>
   <Description>Export Inventor Assembly files as robots into Synthesis</Description>
-  <Assembly>C:\Program Files (x86)\Autodesk\Synthesis\Exporter\BxDRobotExporter.dll</Assembly>
+  <Assembly>C:\Program Files\Autodesk\Synthesis\Exporter\BxDRobotExporter.dll</Assembly>
   <LoadOnStartUp>1</LoadOnStartUp>
   <UserUnloadable>1</UserUnloadable>
   <SupportedSoftwareVersionGreaterThan>20..</SupportedSoftwareVersionGreaterThan>

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Utilities.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Utilities.cs
@@ -13,7 +13,7 @@ namespace BxDRobotExporter
 {
     internal static class Utilities
     {
-        public const string SYNTHESIS_PATH = @"C:\Program Files (x86)\Autodesk\Synthesis\Synthesis\Synthesis.exe";
+        public const string SYNTHESIS_PATH = @"C:\Program Files\Autodesk\Synthesis\Synthesis\Synthesis.exe";
 
         static internal SynthesisGUI GUI;
         static DockableWindow EmbededJointPane;

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/Utilities.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/Utilities.cs
@@ -7,7 +7,7 @@ using System.Windows.Forms;
 
 public class Utilities
 {
-    public const string SYNTHESIS_PATH = @"C:\Program Files (x86)\Autodesk\Synthesis\Synthesis\Synthesis.exe";
+    public const string SYNTHESIS_PATH = @"C:\Program Files\Autodesk\Synthesis\Synthesis\Synthesis.exe";
     public static string VIEWER_PATH = System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments) + @"\RobotViewer\RobotViewer.exe";
     
     public static Vector ToInventorVector(BXDVector3 v)

--- a/installer/MainInstaller.nsi
+++ b/installer/MainInstaller.nsi
@@ -78,7 +78,7 @@ IfFileExists "$INSTDIR" +1 +28
         Delete "$SMPROGRAMS\BXD Synthesis.lnk"
 		
         ; Remove directories used
-        RMDir $INSTDIR
+		RMDir /r "$PROGRAMFILES\Autodesk\Synthesis"
 
         DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Autodesk Synthesis"
 


### PR DESCRIPTION
Refactored some directory paths to fix:
- Inventor Exporter Plugin DLL Dependencies
- Synthesis Launcher For Inventor Exporter Plugin

Also added a RMDir with restart privileges in the installer to prevent hidden or outdated x86 Synthesis builds, which is what the exporter was previously referencing.