### PR TITLE
Support CAN 0-63 and PWM 0-19 

### DIFF
--- a/exporters/Aardvark-Libraries/SimulatorFileIO/Joints/Driver/JointDriverType.cs
+++ b/exporters/Aardvark-Libraries/SimulatorFileIO/Joints/Driver/JointDriverType.cs
@@ -163,16 +163,18 @@ public static class JointDriverTypeExtensions
     /// </summary>
     /// <param name="type">Driver type</param>
     /// <returns>Max port number</returns>
-    public static int GetPortMax(this JointDriverType type)
+    public static int GetPortMax(this JointDriverType type, bool isCan)
     {
+      
         switch (type)
         {
             case JointDriverType.MOTOR:
+
             case JointDriverType.DUAL_MOTOR:
             case JointDriverType.SERVO:
             case JointDriverType.WORM_SCREW:
             case JointDriverType.ELEVATOR:
-                return 8; // PWM
+                return isCan ? 63 : 19;
             case JointDriverType.BUMPER_PNEUMATIC:
                 return 8; // Bumper
             case JointDriverType.RELAY_PNEUMATIC:
@@ -181,4 +183,6 @@ public static class JointDriverTypeExtensions
                 return -1;
         }
     }
+
+    
 }

--- a/exporters/BxDRobotExporter/BxDRobotExporter.sln
+++ b/exporters/BxDRobotExporter/BxDRobotExporter.sln
@@ -3,13 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BxDRobotExporter", "BxDRobotExporter\BxDRobotExporter\BxDRobotExporter.csproj", "{3DC284CE-6572-439D-ADA3-E703FF8498B6}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RobotExportAPI", "robot_exporter\JointResolver\RobotExportAPI.csproj", "{352CDE72-AEE2-4085-ADC5-99A860EA0768}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimulatorAPI", "..\Aardvark-Libraries\SimulatorFileIO\SimulatorAPI.csproj", "{52DC911D-AD5D-4D01-9FC1-22AAADA97740}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MIConvexHull", "..\Aardvark-Libraries\MIConvexHull\MIConvexHull.csproj", "{2337776D-7D0C-40AA-A439-C26C3CE24FAB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BxDRobotExporter", "BxDRobotExporter\BxDRobotExporter\BxDRobotExporter.csproj", "{3DC284CE-6572-439D-ADA3-E703FF8498B6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,13 +18,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Benchmark|Any CPU.ActiveCfg = Benchmark|Any CPU
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Benchmark|Any CPU.Build.0 = Benchmark|Any CPU
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{352CDE72-AEE2-4085-ADC5-99A860EA0768}.Benchmark|Any CPU.ActiveCfg = Benchmark|Any CPU
 		{352CDE72-AEE2-4085-ADC5-99A860EA0768}.Benchmark|Any CPU.Build.0 = Benchmark|Any CPU
 		{352CDE72-AEE2-4085-ADC5-99A860EA0768}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,8 +36,17 @@ Global
 		{2337776D-7D0C-40AA-A439-C26C3CE24FAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2337776D-7D0C-40AA-A439-C26C3CE24FAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2337776D-7D0C-40AA-A439-C26C3CE24FAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Benchmark|Any CPU.ActiveCfg = Benchmark|Any CPU
+		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Benchmark|Any CPU.Build.0 = Benchmark|Any CPU
+		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {13241C65-3005-4F88-B55B-ACBB368C1F50}
 	EndGlobalSection
 EndGlobal

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter.csproj
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter.csproj
@@ -331,10 +331,11 @@
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
+    <ProgramFiles64>$(ProgramW6432)</ProgramFiles64>
+    <ProgramFiles64 Condition="$(ProgramFiles64) == ''">$(ProgramFiles)</ProgramFiles64>
     <PreBuildEvent>
     </PreBuildEvent>
-    <PostBuildEvent>"C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x86\mt.exe" -manifest "$(ProjectDir)BxDRobotExporter.X.manifest" -outputresource:"$(TargetPath)";#2 -nologo
-XCopy "$(TargetPath)" "%25ProgramFiles%25\Autodesk\Synthesis\Exporter\" /Y /R /S
+    <PostBuildEvent>XCopy "$(TargetPath)" "$(ProgramFiles64)\Autodesk\Synthesis\Exporter\" /Y /R /S
 XCopy "$(ProjectDir)Autodesk.BxDRobotExporter.Inventor.addin" "%25AppData%25\Autodesk\ApplicationPlugins\$(TargetName)\" /Y /R   
 </PostBuildEvent>
   </PropertyGroup>

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter.csproj.user
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter.csproj.user
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <StartAction>Program</StartAction>
-    <StartProgram>C:\Program Files\Autodesk\Inventor 2019\Bin\Inventor.exe</StartProgram>
+    <StartProgram>C:\Program Files\Autodesk\Inventor 2020\Bin\Inventor.exe</StartProgram>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <StartAction>Program</StartAction>

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs
@@ -96,6 +96,15 @@ namespace BxDRobotExporter.Wizard
             typeOptions = JointDriver.GetAllowedDrivers(joint);
             DriverComboBox.SelectedIndex = Array.IndexOf(typeOptions, joint.cDriver.GetDriveType()) + 1;
 
+            if (rbCAN.Checked)
+            {
+                PortOneUpDown.Maximum = PortTwoUpDown.Maximum = 64;
+            }
+            else
+            {
+                PortOneUpDown.Maximum = PortTwoUpDown.Maximum = 20;
+            }
+
             if (joint.cDriver.port1 < PortOneUpDown.Minimum)
                 PortOneUpDown.Value = PortOneUpDown.Minimum;
             else if (joint.cDriver.port1 > PortOneUpDown.Maximum)

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/DriveChooser.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/DriveChooser.cs
@@ -339,7 +339,8 @@ public partial class DriveChooser : Form
             JointDriverType cType = typeOptions[cmbJointDriver.SelectedIndex - 1];
             lblPort.Text = cType.GetPortType(rbCAN.Checked) + " Port" + (cType.HasTwoPorts() ? "s" : "");
             txtPort2.Visible = cType.HasTwoPorts();
-            txtPort1.Maximum = txtPort2.Maximum = cType.GetPortMax();
+            
+            txtPort1.Maximum = txtPort2.Maximum = cType.GetPortMax(rbCAN.Checked);
             grpDriveOptions.Visible = true;
 
             if (cType.IsMotor())
@@ -568,6 +569,7 @@ public partial class DriveChooser : Form
         {
             lblPort.Text = "PWM Port";
         }
+        PrepLayout();
     }
 
     private void RobotCompetitionDropDown_SelectedIndexChanged(object sender, EventArgs e)
@@ -618,5 +620,15 @@ public partial class DriveChooser : Form
                 break;
         }
         MotorTypeDropDown.SelectedItem = "GENERIC";
+    }
+
+    private void LblPort_Click(object sender, EventArgs e)
+    {
+
+    }
+
+    private void TxtPort1_ValueChanged(object sender, EventArgs e)
+    {
+
     }
 }


### PR DESCRIPTION
### Robot Exporter Supports 64 CAN ID's and 20 PWM Ports
 - Raised the max ports depending on if it's CAN or PWM 
https://github.com/Autodesk/synthesis/blob/c7fe44c28827c2cdf811634691146b6ea7150ebf/exporters/Aardvark-Libraries/SimulatorFileIO/Joints/Driver/JointDriverType.cs#L177
- Changed Wizard UI with new values
https://github.com/Autodesk/synthesis/blob/c7fe44c28827c2cdf811634691146b6ea7150ebf/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Wizard/Components/DefinePartPanel.cs#L99-L106
- Now Takes in `isCan` to determine max
https://github.com/Autodesk/synthesis/blob/c7fe44c28827c2cdf811634691146b6ea7150ebf/exporters/Aardvark-Libraries/SimulatorFileIO/Joints/Driver/JointDriverType.cs#L166
- `DriveChooser` now passes in `inCan`
https://github.com/Autodesk/synthesis/blob/c7fe44c28827c2cdf811634691146b6ea7150ebf/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/DriveChooser.cs#L343

### Fixed DLL Copying in PostBuild
- Added new macro to locate Program Files (64bit)
https://github.com/Autodesk/synthesis/blob/c7fe44c28827c2cdf811634691146b6ea7150ebf/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter.csproj#L334-L335
- Use new macro for post build
https://github.com/Autodesk/synthesis/blob/c7fe44c28827c2cdf811634691146b6ea7150ebf/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter.csproj#L338-L340


### Jira
- Issue 935


|    DOD    | Done |    Reviewer    | Issue | Notes |
|-----------|------|----------------|-------|-------|
| Code      | 👍    | Matthew Moradi |   935|       |
| Unit Test | N/A  | N/A            |       |       |
| Merged    | :x:  |                |       |       |
