### PR TITLE
Game piece controls disappearing from the controls menu

### DIFF
--- a/engine/unity5/Assets/Scripts/Input/Controls.cs
+++ b/engine/unity5/Assets/Scripts/Input/Controls.cs
@@ -172,7 +172,9 @@ namespace Synthesis.Input
         /// </summary>
         public static void Load()
         {
+            ArcadeControls();
             ReadOnlyCollection<KeyMapping> keys = InputControl.GetKeysList();
+            Debug.Log(keys.Count + " KEYS");
 
             foreach (KeyMapping key in keys)
             {

--- a/engine/unity5/Assets/Scripts/Input/Controls.cs
+++ b/engine/unity5/Assets/Scripts/Input/Controls.cs
@@ -174,7 +174,6 @@ namespace Synthesis.Input
         {
             ArcadeControls();
             ReadOnlyCollection<KeyMapping> keys = InputControl.GetKeysList();
-            Debug.Log(keys.Count + " KEYS");
 
             foreach (KeyMapping key in keys)
             {


### PR DESCRIPTION
If you went into any field/any robot, then left and went into a different field the control listings for interaction with the game pieces for that specific field would be gone and can't be reset and changed. Basically someone added in code to remove the field specific controls but never had it update to the new controls for the new field. I just ran the function that set these controls when the control menu tried to grab the controls
Issue 939 : https://jira.autodesk.com/browse/AARD-939