### PR TITLE
Limit input and output gear values to between 1 to 1000

### DIFF
--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/DriveChooser.Designer.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/DriveChooser.Designer.cs
@@ -559,10 +559,10 @@
             0,
             0});
             this.OutputGeartxt.Minimum = new decimal(new int[] {
-            1000,
+            1,
             0,
             0,
-            -2147483648});
+            0});
             this.OutputGeartxt.Name = "OutputGeartxt";
             this.OutputGeartxt.Size = new System.Drawing.Size(206, 22);
             this.OutputGeartxt.TabIndex = 16;
@@ -603,10 +603,10 @@
             0,
             0});
             this.InputGeartxt.Minimum = new decimal(new int[] {
-            1000,
+            1,
             0,
             0,
-            -2147483648});
+            0});
             this.InputGeartxt.Name = "InputGeartxt";
             this.InputGeartxt.Size = new System.Drawing.Size(206, 22);
             this.InputGeartxt.TabIndex = 15;


### PR DESCRIPTION
### Increase the minimum gear value from -1000 to 1 for the input and output gear
https://github.com/Autodesk/synthesis/blob/1cabdb66f64d0cc5d25fe842ab83217645f0466b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/DriveChooser.Designer.cs#L562
https://github.com/Autodesk/synthesis/blob/1cabdb66f64d0cc5d25fe842ab83217645f0466b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/DriveChooser.Designer.cs#L606

### Jira
- Issue 914

|    DOD    | Done |    Reviewer    | Issue | Notes |
|-----------|------|----------------|-------|-------|
| Code      | ✅   | Shawn Hice |   914 |       |
| Unit Test | N/A  | N/A            |       |       |
| Merged    | ❌  |                |       |       |