### PR TITLE
Enabled fancy colors by default

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Properties/Settings.Designer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace BxDRobotExporter.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.1.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -61,7 +61,7 @@ namespace BxDRobotExporter.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool FancyColors {
             get {
                 return ((bool)(this["FancyColors"]));

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Properties/Settings.settings
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Properties/Settings.settings
@@ -12,7 +12,7 @@
       <Value Profile="(Default)">firstRun</Value>
     </Setting>
     <Setting Name="FancyColors" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="ConfigVersion" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/app.config
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/app.config
@@ -26,7 +26,7 @@
         <value>firstRun</value>
       </setting>
       <setting name="FancyColors" serializeAs="String">
-        <value>False</value>
+        <value>True</value>
       </setting>
       <setting name="ConfigVersion" serializeAs="String">
         <value>0</value>

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/ExporterSettingsForm.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/ExporterSettingsForm.cs
@@ -65,7 +65,7 @@ namespace EditorsLibrary
             return new PluginSettingsValues()
             {
                 InventorChildColor = Color.FromArgb(255, 0, 125, 255),
-                GeneralUseFancyColors = false,
+                GeneralUseFancyColors = true,
                 GeneralSaveLocation = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Autodesk\Synthesis\Robots"
             };
         }


### PR DESCRIPTION
### Enabled fancy colors by default
* Updated boolean GeneralUseFancyColors in ExporterSettingsForm.cs from False to True
* Updated BxDRobotExporter Properties directly in Visual Studio GUI and changed FancyColors option from False to True
  * Directly updated subsequent files: Settings.settings, app.config, Settings.Designer.cs

### Jira
* Issue 483

|    DOD    | Done |    Reviewer    | Issue | Notes |
|-----------|------|----------------|-------|-------|
| Code      | ✅    |  Shawn Hice  |   483 |       |
| Unit Test | ❌   |            |       |   |
| Merged    | :x:  |  Matthew Moradi  |       |       |