### PR TITLE
Fix joint highlighting in Inventor robot exporter

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
@@ -612,13 +612,19 @@ namespace BxDRobotExporter
 
                 if (occurrence != null)
                 {
-                    SelectNode(occurrence);
                     occurrences.Add(occurrence);
                 }
             }
 
             // Set camera view
             ViewOccurrences(occurrences, 15, ViewDirection.Y);
+            
+            // Highlighting must occur after the camera is moved, as inventor clears highlight objects when the camera is moved
+            ChildHighlight.Clear(); 
+            foreach (var componentOccurrence in occurrences)
+            {
+                ChildHighlight.AddItem(componentOccurrence);
+            }
         }
         
         /// <summary>


### PR DESCRIPTION
### Fix joint highlighting
- Highlighting must occur after the camera is moved, as inventor clears highlight objects when the camera is moved for some reason

https://github.com/Autodesk/synthesis/blob/68337abfa3c6a1792913d5173b0908db3c9c32cb/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs#L619-L627

### Jira
- Issue 999

|    DOD    | Done |    Reviewer    | Issue | Notes |
|-----------|------|----------------|-------|-------|
| Code      | ✅    | Shawn Hice |   999 |       |
| Unit Test | N/A  | N/A            |       |       |
| Merged    | ✅   |                |       |       |