### PR TITLE
Add preview icons to Fusion Joint Editor

### DIFF
--- a/exporters/FusionExporter/Source/AddIn/CustomHandlers.cpp
+++ b/exporters/FusionExporter/Source/AddIn/CustomHandlers.cpp
@@ -71,7 +71,7 @@ void ShowPaletteCommandExecuteHandler::notify(const Ptr<CommandEventArgs>& event
 void ReceiveFormDataHandler::notify(const Ptr<HTMLEventArgs>& eventArgs)
 {
 	if (eventArgs->action() == "highlight")
-		eui->highlightJoint(eventArgs->data(), true, 1);
+		eui->highlightJoint(eventArgs->data(), false, 1);
 
 	else if (eventArgs->action() == "edit_sensors")
 		eui->openSensorsPalette(eventArgs->data());

--- a/exporters/FusionExporter/Source/AddIn/CustomHandlers.cpp
+++ b/exporters/FusionExporter/Source/AddIn/CustomHandlers.cpp
@@ -71,7 +71,7 @@ void ShowPaletteCommandExecuteHandler::notify(const Ptr<CommandEventArgs>& event
 void ReceiveFormDataHandler::notify(const Ptr<HTMLEventArgs>& eventArgs)
 {
 	if (eventArgs->action() == "highlight")
-		eui->highlightJoint(eventArgs->data());
+		eui->highlightJoint(eventArgs->data(), true, 1);
 
 	else if (eventArgs->action() == "edit_sensors")
 		eui->openSensorsPalette(eventArgs->data());

--- a/exporters/FusionExporter/Source/AddIn/EUI-UIManagement.cpp
+++ b/exporters/FusionExporter/Source/AddIn/EUI-UIManagement.cpp
@@ -121,23 +121,23 @@ void EUI::openExportPalette()
 	static std::thread * uiThread = nullptr;
 	if (uiThread != nullptr) { uiThread->join(); delete uiThread; }
 
-	BXDJ::ConfigData config = Exporter::loadConfiguration(app->activeDocument());
+	BXDJ::ConfigData config = Exporter::loadConfiguration(app->activeDocument()); // Load joint config and update with current joints in document
 
-	Ptr<Camera> ogCam = app->activeViewport()->camera();
+	Ptr<Camera> ogCam = app->activeViewport()->camera(); // Save the original camera position
 
-	config.tempIconDir = std::experimental::filesystem::temp_directory_path().string() + "Synthesis\\FusionIconCache\\";
+	config.tempIconDir = std::experimental::filesystem::temp_directory_path().string() + "Synthesis\\FusionIconCache\\"; // Get OS temp dir for icons and save to JSON object
 
 	int index = 0;
-	for (std::pair<const std::basic_string<char>, BXDJ::ConfigData::JointConfig> joint : config.getJoints())
+	for (std::pair<const std::basic_string<char>, BXDJ::ConfigData::JointConfig> joint : config.getJoints()) // For each joint, focus on the joint, take a pic, save to temp dir
 	{
 		EUI::highlightJoint(joint.first, false, 0.6);
 		app->activeViewport()->saveAsImageFile(config.tempIconDir+std::to_string(index)+".png", 200, 200); // TODO: Make this cross-platform
 		index++;
 	};
 
-	EUI::resetHighlight(true, 1.5, ogCam);
+	EUI::resetHighlight(true, 1.5, ogCam); // clear highlight and move camera to look at whole robot
 
-	uiThread = new std::thread([this](std::string configJSON)
+	uiThread = new std::thread([this](std::string configJSON) // Actually open the palette and send the joint data
 	{
 		exportPalette->sendInfoToHTML("joints", configJSON); // TODO: Why is this duplicated
 		exportPalette->isVisible(true);

--- a/exporters/FusionExporter/Source/AddIn/EUI.cpp
+++ b/exporters/FusionExporter/Source/AddIn/EUI.cpp
@@ -105,7 +105,8 @@ void EUI::highlightJoint(std::string jointID, bool transition, double zoom)
 
 	app->activeViewport()->camera(cam);
 
-	auto fitCamera = app->activeViewport()->camera();
+	// TODO: There must be a better way to find the extents of the robot without calculations
+	auto fitCamera = app->activeViewport()->camera(); // This camera is only used to find the extents of the complete robot
 
 	cam->isFitView(false);
 	cam->viewExtents(fitCamera->viewExtents() * zoom);
@@ -127,7 +128,7 @@ void EUI::resetHighlight(bool transition, double zoom, Ptr<Camera> ogCam)
 	// Set camera view
 	Ptr<Camera> cam = app->activeViewport()->camera();
 
-	Ptr<Point3D> eyeLocation = Point3D::create(0, 100, 0);
+	Ptr<Point3D> eyeLocation = Point3D::create(0, 100, 0); // TODO: Much of this is the same as highlightJoint
 	Ptr<Point3D> targetLocation = Point3D::create(0, 0, 0);
 
 	cam->target(targetLocation);
@@ -139,7 +140,8 @@ void EUI::resetHighlight(bool transition, double zoom, Ptr<Camera> ogCam)
 
 	app->activeViewport()->camera(cam);
 
-	auto fitCamera = app->activeViewport()->camera();
+	// TODO: There must be a better way to find the extents of the robot without calculations
+	auto fitCamera = app->activeViewport()->camera(); // This camera is only used to find the extents of the complete robot
 
 	auto newCamera = app->activeViewport()->camera();
 	newCamera->viewExtents(fitCamera->viewExtents() * zoom);

--- a/exporters/FusionExporter/Source/AddIn/EUI.cpp
+++ b/exporters/FusionExporter/Source/AddIn/EUI.cpp
@@ -32,10 +32,10 @@ EUI::~EUI()
 
 // UI Controls
 
-void EUI::highlightJoint(std::string jointID)
+void EUI::highlightJoint(std::string jointID, bool transition, double zoom)
 {
 	std::vector<Ptr<Joint>> joints = Exporter::collectJoints(app->activeDocument());
-
+	
 	Ptr<JointGeometry> geo;
 
 	// Find the joint that was selected
@@ -91,6 +91,7 @@ void EUI::highlightJoint(std::string jointID)
 	}
 
 	// Set camera view
+	Ptr<Camera> ogCam = app->activeViewport()->camera();
 	Ptr<Camera> cam = app->activeViewport()->camera();
 
 	Ptr<Point3D> eyeLocation = Point3D::create(geo->origin()->x(), geo->origin()->y(), geo->origin()->z());
@@ -99,9 +100,59 @@ void EUI::highlightJoint(std::string jointID)
 	cam->target(geo->origin());
 	cam->upVector(Vector3D::create(1, 0, 0));
 	cam->eye(eyeLocation);
+	cam->isFitView(true);
+	cam->isSmoothTransition(false);
 
-	cam->isSmoothTransition(true);
 	app->activeViewport()->camera(cam);
+
+	auto fitCamera = app->activeViewport()->camera();
+
+	cam->isFitView(false);
+	cam->viewExtents(fitCamera->viewExtents() * zoom);
+
+	if (transition) { // If smooth transition, move the camera to the original starting place
+		ogCam->isSmoothTransition(false);
+		app->activeViewport()->camera(ogCam);
+		cam->isSmoothTransition(true);
+	}
+
+	app->activeViewport()->camera(cam);
+
+}
+
+void EUI::resetHighlight(bool transition, double zoom, Ptr<Camera> ogCam)
+{
+	UI->activeSelections()->clear();
+
+	// Set camera view
+	Ptr<Camera> cam = app->activeViewport()->camera();
+
+	Ptr<Point3D> eyeLocation = Point3D::create(0, 100, 0);
+	Ptr<Point3D> targetLocation = Point3D::create(0, 0, 0);
+
+	cam->target(targetLocation);
+	cam->upVector(Vector3D::create(1, 0, 0));
+	cam->eye(eyeLocation);
+
+	cam->isFitView(true);
+	cam->isSmoothTransition(false);
+
+	app->activeViewport()->camera(cam);
+
+	auto fitCamera = app->activeViewport()->camera();
+
+	auto newCamera = app->activeViewport()->camera();
+	newCamera->viewExtents(fitCamera->viewExtents() * zoom);
+
+	if (transition) { // If smooth transition, move the camera to the original starting place
+		ogCam->isSmoothTransition(false);
+		app->activeViewport()->camera(ogCam);
+		newCamera->isSmoothTransition(true);
+	}
+
+	cam->isSmoothTransition(transition);
+	app->activeViewport()->camera(newCamera);
+
 }
 
 // Robot Exporting

--- a/exporters/FusionExporter/Source/AddIn/EUI.h
+++ b/exporters/FusionExporter/Source/AddIn/EUI.h
@@ -10,6 +10,8 @@
 
 #include <thread>
 #include <list>
+#include <experimental/filesystem>
+#include <Core/Application/Viewport.h>
 #include "CustomHandlers.h"
 #include "Identifiers.h"
 #include "../Data/BXDJ/ConfigData.h"
@@ -56,7 +58,8 @@ namespace SynthesisAddIn
 		/// Highlights a joint in Fusion.
 		/// \param jointID ID generated from BXDJ::Utility::getUniqueJointID.
 		///
-		void highlightJoint(std::string jointID);
+		void highlightJoint(std::string jointID, bool transition, double zoom);
+		void resetHighlight(bool transition, double zoom, Ptr<Camera> ogCam);
 
 		// Robot Exporting
 		///

--- a/exporters/FusionExporter/Source/Data/BXDJ/ConfigData.cpp
+++ b/exporters/FusionExporter/Source/Data/BXDJ/ConfigData.cpp
@@ -13,12 +13,14 @@ ConfigData::ConfigData()
 {
 	robotName = "unnamed";
 	drivetrainType = TANK;
+	tempIconDir = "";
 }
 
 ConfigData::ConfigData(const ConfigData & other)
 {
 	robotName = other.robotName;
 	drivetrainType = other.drivetrainType;
+	tempIconDir = other.tempIconDir;
 
 	for (auto i = other.joints.begin(); i != other.joints.end(); i++)
 		joints[i->first] = i->second;
@@ -168,6 +170,8 @@ rapidjson::Value ConfigData::getJSONObject(rapidjson::MemoryPoolAllocator<>& all
 	configJSON.AddMember("name", rapidjson::Value(robotName.c_str(), robotName.length(), allocator), allocator);
 	configJSON.AddMember("drivetrainType", rapidjson::Value((int)drivetrainType), allocator);
 
+	configJSON.AddMember("tempIconDir", rapidjson::Value(tempIconDir.c_str(), tempIconDir.length(), allocator), allocator);
+
 	// Joints
 	rapidjson::Value jointsJSON;
 	jointsJSON.SetArray();
@@ -219,6 +223,9 @@ void ConfigData::loadJSONObject(const rapidjson::Value& configJSON)
 	if (configJSON.HasMember("drivetrainType") && configJSON["drivetrainType"].IsNumber())
 		drivetrainType = (DrivetrainType)configJSON["drivetrainType"].GetInt();
 
+	if (configJSON.HasMember("tempIconDir") && configJSON["tempIconDir"].IsString())
+		tempIconDir = configJSON["tempIconDir"].GetString();
+
 	// Read each joint configuration
 	auto jointsJSON = configJSON["joints"].GetArray();
 	for (rapidjson::SizeType i = 0; i < jointsJSON.Size(); i++)
@@ -267,6 +274,11 @@ std::string BXDJ::ConfigData::toString(DrivetrainType type)
 	}
 
 	return "NONE";
+}
+
+std::map<std::string, ConfigData::JointConfig> ConfigData::getJoints()
+{
+	return joints;
 }
 
 ConfigData::JointMotionType ConfigData::internalJointMotion(fusion::JointTypes type)

--- a/exporters/FusionExporter/Source/Data/BXDJ/ConfigData.h
+++ b/exporters/FusionExporter/Source/Data/BXDJ/ConfigData.h
@@ -27,6 +27,8 @@ namespace BXDJ
 		std::string robotName; ///< Name of the robot. Used for writing to the robot directory.
 		DrivetrainType drivetrainType; ///< The type of the robot's drivetrain.
 
+		std::string tempIconDir;
+
 		///
 		/// Creates a set of config data with no drivers, the name "unnamed," and tank drive.
 		///
@@ -81,7 +83,6 @@ namespace BXDJ
 
 		static std::string toString(DrivetrainType); ///< \return The name of the drivetrain.
 
-	private:
 		/// Constants used for communicating joint motion type
 		enum JointMotionType : int
 		{
@@ -128,6 +129,10 @@ namespace BXDJ
 				return *this;
 			}
 		};
+
+		std::map<std::string, JointConfig> getJoints();
+
+	private:
 
 		std::map<std::string, JointConfig> joints; ///< Map of all documented Fusion joints, accessed by their ID generated from Utility::getUniqueJointID.
 

--- a/exporters/FusionExporter/palette/export.html
+++ b/exporters/FusionExporter/palette/export.html
@@ -43,6 +43,14 @@
                 margin-top: 0.5rem;
                 margin-bottom: 0.5rem;
             }
+            
+            .joint-config-image {
+                float: left;
+                height: 112px;
+                border-color: #6d6d6d;
+                border-style: solid;
+                margin-right: 10px;
+            }
         </style>
     </head>
     <body>
@@ -58,6 +66,7 @@
 
                 <button class="edit-sensors-button" onclick="editSensors(this.parentNode)">Edit Sensors</button>
 
+                <img class="joint-config-image">
                 <div class="driver-div">
                     <span class="field-label">Driver Type: </span>
                     <span class="field-select"><select class="driver-type" onchange="updateFieldOptions(this)">

--- a/exporters/FusionExporter/palette/export.html
+++ b/exporters/FusionExporter/palette/export.html
@@ -62,7 +62,7 @@
             </div>
 
             <fieldset id="joint-config-template" class="joint-config">
-                <legend><a class="joint-config-legend">Joint</a></legend>
+                <legend class="joint-config-legend">Joint</legend>
 
                 <button class="edit-sensors-button" onclick="editSensors(this.parentNode)">Edit Sensors</button>
 

--- a/exporters/FusionExporter/palette/js/export.js
+++ b/exporters/FusionExporter/palette/js/export.js
@@ -138,7 +138,10 @@ function applyConfigData(configData)
         var jointTitle = getElByClass(fieldset, 'joint-config-legend');
         jointTitle.innerHTML = joints[i].name;
         jointTitle.dataset.jointId = joints[i].id;
-        jointTitle.onclick = function () { highlightJoint(this.dataset.jointId); };
+
+        var jointImage = getElByClass(fieldset, 'joint-config-image');
+        jointImage.setAttribute("src",configData.tempIconDir+i+".png");
+        
 
         // Filter for angular or linear joints
         var angularJointDiv = getElByClass(fieldset, 'angular-joint-div');

--- a/exporters/FusionExporter/palette/js/export.js
+++ b/exporters/FusionExporter/palette/js/export.js
@@ -97,6 +97,17 @@ window.fusionJavaScriptHandler =
         }
     };
 
+var delayHover = function (elem, callback) {
+    var timeout = null;
+    elem.onmouseover = function() {
+        timeout = setTimeout(callback, 500);
+    };
+
+    elem.onmouseout = function() {
+        clearTimeout(timeout);
+    }
+};
+
 // Populates the form with joints
 function applyConfigData(configData)
 {
@@ -121,6 +132,8 @@ function applyConfigData(configData)
         fieldset.dataset.jointId = joints[i].id;
         fieldset.dataset.asBuilt = joints[i].asBuilt ? 'true' : 'false';
         fieldset.dataset.sensors = JSON.stringify(joints[i].sensors);
+
+        (function(id){delayHover(fieldset, function() {highlightJoint(id)})}(fieldset.dataset.jointId));
 
         var jointTitle = getElByClass(fieldset, 'joint-config-legend');
         jointTitle.innerHTML = joints[i].name;

--- a/exporters/FusionExporter/palette/js/export.js
+++ b/exporters/FusionExporter/palette/js/export.js
@@ -133,6 +133,7 @@ function applyConfigData(configData)
         fieldset.dataset.asBuilt = joints[i].asBuilt ? 'true' : 'false';
         fieldset.dataset.sensors = JSON.stringify(joints[i].sensors);
 
+        // Highlight joint if hover for 0.5 seconds
         (function(id){delayHover(fieldset, function() {highlightJoint(id)})}(fieldset.dataset.jointId));
 
         var jointTitle = getElByClass(fieldset, 'joint-config-legend');

--- a/exporters/FusionExporter/palette/js/export.js
+++ b/exporters/FusionExporter/palette/js/export.js
@@ -97,10 +97,10 @@ window.fusionJavaScriptHandler =
         }
     };
 
-var delayHover = function (elem, callback) {
+var delayHover = function (elem, callback, hoverTime) {
     var timeout = null;
     elem.onmouseover = function() {
-        timeout = setTimeout(callback, 500);
+        timeout = setTimeout(callback, hoverTime);
     };
 
     elem.onmouseout = function() {
@@ -134,7 +134,9 @@ function applyConfigData(configData)
         fieldset.dataset.sensors = JSON.stringify(joints[i].sensors);
 
         // Highlight joint if hover for 0.5 seconds
-        (function(id){delayHover(fieldset, function() {highlightJoint(id)})}(fieldset.dataset.jointId));
+        (function(id){delayHover(fieldset, function () {
+            highlightJoint(id)
+        }, 200)}(fieldset.dataset.jointId));
 
         var jointTitle = getElByClass(fieldset, 'joint-config-legend');
         jointTitle.innerHTML = joints[i].name;


### PR DESCRIPTION
### Add preview icons to Fusion Joint Editor
- When the joint editor button is clicked, a snapshot is taken for each joint and saved in a temp directory
- The path to the temp dir is sent to the palette in the JSON string
- The js loads the appropriate icon for each joint

### Improved joint highlighting
- Joint highlight triggered on mouse hover for 0.5 seconds instead of clicking on the small link in the corner of the card
- In addition to moving the camera, the zoom of the camera is set to a constant
- When clicking on the joint setup button, the camera moves to show the whole robot and the highlighted objects are cleared

![NewJointEditor](https://user-images.githubusercontent.com/5054950/60904673-44e8a680-a228-11e9-931f-88065b70d3bc.PNG)

![HighlightZoom](https://user-images.githubusercontent.com/5054950/60905010-0e5f5b80-a229-11e9-9076-f24a989033e9.PNG)

### Jira
- Issue 1028

|    DOD    | Done |    Reviewer    | Issue | Notes |
|-----------|------|----------------|-------|-------|
| Code      | ❌   | Kira Corbett/Alex Carter |   1028|       |
| Unit Test | N/A  | N/A            |       |       |
| Merged    | ❌  |                |       |       |