### PR TITLE
Fix Inventor joint editor collapse on focus change

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/JointEditor/JointForm.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/JointEditor/JointForm.cs
@@ -37,8 +37,6 @@ namespace BxDRobotExporter.JointEditor
 
             Activated += (sender, args) => // Every time the form is displayed
             {
-                CollapseAllCards();
-                jointCards.ForEach(card => card.LoadValuesRecursive());
                 progressBar.Hide();
                 progressBar.SetProgress("Loading Joint Parameters...", 0, 5);
             };
@@ -46,6 +44,8 @@ namespace BxDRobotExporter.JointEditor
 
         public async Task PreShow()
         {
+            CollapseAllCards();
+            jointCards.ForEach(card => card.LoadValuesRecursive());
             progressBar.SetProgress("Loading Joint Parameters...", 4, 5);
             progressBar.Show();
             await Task.Delay(500); // Wait for progress bar to fully load


### PR DESCRIPTION
### Fix bug where the joint editor would collapse all cards and reload when the window was re-focused after another application was focused

### Jira
- Issue 1049

|    DOD    | Done |    Reviewer    | Issue | Notes |
|-----------|------|----------------|-------|-------|
| Code      | ❌   | Nicolas Espinoza/Alex Carter |   1049|       |
| Unit Test | N/A  | N/A            |       |       |
| Merged    | ❌  |                |       |       |