### PR TITLE
Fixed Perjoint Weight Saving

### DIFF
--- a/exporters/Aardvark-Libraries/SimulatorFileIO/Joints/SkeletalJoint_Base.cs
+++ b/exporters/Aardvark-Libraries/SimulatorFileIO/Joints/SkeletalJoint_Base.cs
@@ -88,6 +88,7 @@ public abstract class SkeletalJoint_Base
     public void WriteBinaryJoint(System.IO.BinaryWriter writer)
     {
         writer.Write((byte) ((int) GetJointType()));
+        writer.Write((double)((double)weight));
         WriteBinaryJointInternal(writer);
 
         writer.Write(cDriver != null);
@@ -108,6 +109,7 @@ public abstract class SkeletalJoint_Base
     /// <param name="reader">Input stream</param>
     public void ReadBinaryJoint(System.IO.BinaryReader reader)
     {
+        weight = reader.ReadDouble();
         // ID is already read
         ReadBinaryJointInternal(reader);
 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs
@@ -457,6 +457,8 @@ public bool ExportRobot()
             if (propertySet == null)
                 return false;
 
+            joint.weight = Utilities.GetProperty(propertySet, "weight", 10);
+
             // Get joint properties from set
             // Get driver information
             if (Utilities.GetProperty(propertySet, "has-driver", false))
@@ -559,7 +561,7 @@ public bool ExportRobot()
             Utilities.SetProperty(propertySet, "robot-weight-kg", RMeta.TotalWeightKg * 10.0f); // x10 for better accuracy
             Utilities.SetProperty(propertySet, "robot-prefer-metric", RMeta.PreferMetric);
             Utilities.SetProperty(propertySet, "robot-driveTrainType", (int)SynthesisGUI.Instance.SkeletonBase.driveTrainType);
-
+          
             // Save joint data
             return SaveJointData(propertySets, SkeletonBase);
         }
@@ -593,7 +595,7 @@ public bool ExportRobot()
             // Save driver information
             JointDriver driver = joint.cDriver;
             Utilities.SetProperty(propertySet, "has-driver", driver != null);
-
+            Utilities.SetProperty(propertySet, "weight", joint.weight);
             if (driver != null)
             {
                 Utilities.SetProperty(propertySet, "driver-type", (int)driver.GetDriveType());


### PR DESCRIPTION
## Per-joint weight saves inside the file 
- Saves to file
https://github.com/Autodesk/synthesis/blob/1d6af54e810222425e433bee52e3f848c60d6a6a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs#L598
- Reads from file
https://github.com/Autodesk/synthesis/blob/1d6af54e810222425e433bee52e3f848c60d6a6a/exporters/BxDRobotExporter/robot_exporter/JointResolver/ControlGUI/SynthesisGUI.cs#L460

## Jira
Issue _1021_

## Table
|    DOD    | Done |    Reviewer    | Issue | Notes |
|-----------|------|----------------|-------|-------|
| Code      | ❌    | Matthew Moradi / Shawn Hice |   1021|       |
| Unit Test | N/A  | N/A            |       |       |
| Merged    | ❌    |                |       |       |