### PR TITLE
Made File Path Casing Consistent

### DIFF
--- a/engine/unity5/Assets/Scripts/GUI/MainMenu.cs
+++ b/engine/unity5/Assets/Scripts/GUI/MainMenu.cs
@@ -160,19 +160,19 @@ namespace Synthesis.GUI
             file.Directory.Create();
 
             //Assigns the currently store registry values or default file path to the proper variables if they exist.
-            string robotDirectory = PlayerPrefs.GetString("RobotDirectory", (Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "synthesis" + Path.DirectorySeparatorChar + "Robots"));
-            string fieldDirectory = PlayerPrefs.GetString("FieldDirectory", (Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "synthesis" + Path.DirectorySeparatorChar + "Fields"));
+            string robotDirectory = PlayerPrefs.GetString("RobotDirectory", (Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Robots"));
+            string fieldDirectory = PlayerPrefs.GetString("FieldDirectory", (Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Fields"));
 
             //If the directory doesn't exist, create it.
             if (!Directory.Exists(robotDirectory))
             {
-                file = new FileInfo(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "synthesis" + Path.DirectorySeparatorChar + "Robots" + Path.DirectorySeparatorChar);
+                file = new FileInfo(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Robots" + Path.DirectorySeparatorChar);
                 file.Directory.Create();
                 robotDirectory = file.Directory.FullName;
             }
             if (!Directory.Exists(fieldDirectory))
             {
-                file = new FileInfo(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "synthesis" + Path.DirectorySeparatorChar + "Fields" + Path.DirectorySeparatorChar);
+                file = new FileInfo(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Fields" + Path.DirectorySeparatorChar);
                 file.Directory.Create();
                 fieldDirectory = file.Directory.FullName;
             }

--- a/engine/unity5/Assets/Scripts/GUI/Scrollables/ChangeFieldScrollable.cs
+++ b/engine/unity5/Assets/Scripts/GUI/Scrollables/ChangeFieldScrollable.cs
@@ -25,7 +25,7 @@ namespace Synthesis.GUI.Scrollables
 
         void OnEnable()
         {
-            directory = PlayerPrefs.GetString("FieldDirectory", (System.Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "synthesis" + Path.DirectorySeparatorChar + "Fields"));
+            directory = PlayerPrefs.GetString("FieldDirectory", (System.Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Fields"));
             items = new List<string>();
             items.Clear();
         }

--- a/engine/unity5/Assets/Scripts/GUI/Scrollables/ChangeRobotScrollable.cs
+++ b/engine/unity5/Assets/Scripts/GUI/Scrollables/ChangeRobotScrollable.cs
@@ -26,7 +26,7 @@ namespace Synthesis.GUI.Scrollables
 
         void OnEnable()
         {
-            directory = PlayerPrefs.GetString("RobotDirectory", (System.Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "synthesis" + Path.DirectorySeparatorChar + "Robots"));
+            directory = PlayerPrefs.GetString("RobotDirectory", (System.Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Robots"));
             items = new List<string>();
             items.Clear();
 

--- a/engine/unity5/Assets/Scripts/States/BrowseFieldState.cs
+++ b/engine/unity5/Assets/Scripts/States/BrowseFieldState.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace Synthesis.States
 {
@@ -8,7 +9,7 @@ namespace Synthesis.States
         /// Initializes a new <see cref="BrowseFieldState"/> instance.
         /// </summary>
         public BrowseFieldState() : base("FieldDirectory",
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Autodesk\synthesis\Fields")
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Fields")
         {
 
         }

--- a/engine/unity5/Assets/Scripts/States/BrowseRobotState.cs
+++ b/engine/unity5/Assets/Scripts/States/BrowseRobotState.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace Synthesis.States
 {
@@ -8,7 +9,7 @@ namespace Synthesis.States
         /// Initializes a new <see cref="BrowseFileState"/> instance.
         /// </summary>
         public BrowseRobotState() : base("RobotDirectory",
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Autodesk\synthesis\Robots")
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Robots")
         {
         }
     }

--- a/engine/unity5/Assets/Scripts/States/LoadFieldState.cs
+++ b/engine/unity5/Assets/Scripts/States/LoadFieldState.cs
@@ -32,7 +32,7 @@ namespace Synthesis.States
         /// </summary>
         public override void Start()
         {
-            fieldDirectory = PlayerPrefs.GetString("FieldDirectory", (Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "synthesis" + Path.DirectorySeparatorChar + "Fields"));
+            fieldDirectory = PlayerPrefs.GetString("FieldDirectory", (Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Fields"));
             mixAndMatchModeScript = Auxiliary.FindGameObject("MixAndMatchModeScript");
             splashScreen = Auxiliary.FindGameObject("LoadSplash");
             fieldList = GameObject.Find("SimLoadFieldList").GetComponent<SelectScrollable>();

--- a/engine/unity5/Assets/Scripts/States/LoadRobotState.cs
+++ b/engine/unity5/Assets/Scripts/States/LoadRobotState.cs
@@ -28,7 +28,7 @@ namespace Synthesis.States
         /// </summary>
         public override void Start()
         {
-            robotDirectory = PlayerPrefs.GetString("RobotDirectory", (Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "synthesis" + Path.DirectorySeparatorChar + "Robots"));
+            robotDirectory = PlayerPrefs.GetString("RobotDirectory", (Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Robots"));
             robotList = GameObject.Find("SimLoadRobotList").GetComponent<SelectScrollable>();
 
             robotList.ThumbTexture = Resources.Load("Images/New Textures/Synthesis_an_Autodesk_Technology_2019_lockup_OL_stacked_no_year") as Texture2D;


### PR DESCRIPTION
Currently, the file path cases are very inconsistent, as some use `\Synthesis\` and some use `\synthesis\`. Although this did not matter in the past since Windows file paths are generally case-insensitive, Linux file paths are case sensitive, so the Synthesis folder should be capitalized on all paths, since it is currently mixed.

Just test to make sure Robots & Fields still load on Windows after clearing your registry.