### PR TITLE
Fix Inventor joint editor threading crash

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/JointEditor/JointForm.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/JointEditor/JointForm.cs
@@ -1,14 +1,11 @@
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using JointResolver.ControlGUI;
 
 namespace BxDRobotExporter.JointEditor
 {
     public partial class JointForm : Form
     {
         private readonly List<JointCard> jointCards = new List<JointCard>();
-        private readonly ProgressBarForm progressBar = new ProgressBarForm("Loading Joint Editor");
 
         public JointForm()
         {
@@ -34,21 +31,12 @@ namespace BxDRobotExporter.JointEditor
             {
                 jointCards.ForEach(card => card.LoadPreviewIcon());
             };
-
-            Activated += (sender, args) => // Every time the form is displayed
-            {
-                progressBar.Hide();
-                progressBar.SetProgress("Loading Joint Parameters...", 0, 5);
-            };
         }
 
-        public async Task PreShow()
+        public void PreShow()
         {
             CollapseAllCards();
             jointCards.ForEach(card => card.LoadValuesRecursive());
-            progressBar.SetProgress("Loading Joint Parameters...", 4, 5);
-            progressBar.Show();
-            await Task.Delay(500); // Wait for progress bar to fully load
         }
 
         public void CollapseAllCards(JointCard besides = null)

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
@@ -617,15 +617,14 @@ namespace BxDRobotExporter
             }
         }
 
-        public async void EditJoint_OnExecute(NameValueMap Context)
+        public void EditJoint_OnExecute(NameValueMap Context)
         {
             if (Utilities.GUI.SkeletonBase == null && !Utilities.GUI.LoadRobotSkeleton())
                 return;
 
             Utilities.HideAdvancedJointEditor();
-            await jointForm.PreShow();
+            jointForm.PreShow();
             jointForm.ShowDialog();
-
             Utilities.GUI.ReloadPanels();
         }
 


### PR DESCRIPTION
### Fix bug where the joint editor would crash on opening after previously opening the drive train type window

### Jira
- Issue 1063

|    DOD    | Done |    Reviewer    | Issue | Notes |
|-----------|------|----------------|-------|-------|
| Code      | ❌   | Nicolas Espinoza/Alex Carter |   1063|       |
| Unit Test | N/A  | N/A            |       |       |
| Merged    | ❌  |                |       |       |