### PR TITLE
Inventor UI QOL improvements

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/InventorUtils.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/InventorUtils.cs
@@ -16,6 +16,9 @@ namespace BxDRobotExporter
         {
             if (nodes == null)
             {
+                ClearHighlight();
+                camera.Fit();
+                camera.ApplyWithoutTransition();
                 return;
             }
             var occurrences = GetComponentOccurrencesFromNodes(nodes);
@@ -63,6 +66,12 @@ namespace BxDRobotExporter
             {
                 StandardAddInServer.Instance.ChildHighlight.AddItem(componentOccurrence);
             }
+        }
+        
+        public static void ClearHighlight()
+        {
+            StandardAddInServer.Instance.ClearDOFHighlight();
+            StandardAddInServer.Instance.ChildHighlight.Clear();
         }
 
         public static List<ComponentOccurrence> GetComponentOccurrencesFromNodes(List<RigidNode_Base> nodes)
@@ -145,7 +154,7 @@ namespace BxDRobotExporter
             camera.Fit(); // TODO: Determine model size properly
             camera.GetExtents(out var width, out var height);
 
-            SetCameraView(focus, viewDistance, height * zoom * 3, height * zoom, camera, viewDirection, animate);
+            SetCameraView(focus, viewDistance, height * zoom, height * zoom, camera, viewDirection, animate);
         }
         
         /// <summary>

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/JointEditor/JointCard.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/JointEditor/JointCard.cs
@@ -50,7 +50,7 @@ namespace BxDRobotExporter.JointEditor
             jointForm.ResetAllHighlight();
             isHighlighted = true;
 
-            InventorUtils.FocusAndHighlightNode(node, StandardAddInServer.Instance.MainApplication.ActiveView.Camera, 0.5);
+            InventorUtils.FocusAndHighlightNode(node, StandardAddInServer.Instance.MainApplication.ActiveView.Camera, 0.8);
         }
 
         public void LoadPreviewIcon()

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/JointEditor/JointForm.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/JointEditor/JointForm.cs
@@ -31,6 +31,18 @@ namespace BxDRobotExporter.JointEditor
             {
                 jointCards.ForEach(card => card.LoadPreviewIcon());
             };
+
+            Closing += (sender, e) => // Every close
+            {
+                InventorUtils.FocusAndHighlightNodes(null, StandardAddInServer.Instance.MainApplication.ActiveView.Camera, 1);
+                Utilities.GUI.ReloadPanels();
+            };
+
+            FormClosing += (sender, e) =>
+            {
+                Hide();
+                e.Cancel = true; // this cancels the close event.
+            };
         }
 
         public void OnShowButtonClick()

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/JointEditor/JointForm.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/JointEditor/JointForm.cs
@@ -33,7 +33,7 @@ namespace BxDRobotExporter.JointEditor
             };
         }
 
-        public void PreShow()
+        public void OnShowButtonClick()
         {
             CollapseAllCards();
             jointCards.ForEach(card => card.LoadValuesRecursive());

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
@@ -292,7 +292,7 @@ namespace BxDRobotExporter
             WheelHighlight.Color = Utilities.GetInventorColor(System.Drawing.Color.Green);
 
             //Sets up events for selecting and deselecting parts in inventor
-            Utilities.GUI.jointEditorPane1.SelectedJoint += nodes => InventorUtils.FocusAndHighlightNodes(nodes, StandardAddInServer.Instance.MainApplication.ActiveView.Camera, 0.8);
+            Utilities.GUI.jointEditorPane1.SelectedJoint += nodes => InventorUtils.FocusAndHighlightNodes(nodes, Instance.MainApplication.ActiveView.Camera,  1);
             PluginSettingsForm.PluginSettingsValues.SettingsChanged += ExporterSettings_SettingsChanged;
 
             EnvironmentEnabled = true;

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
@@ -619,18 +619,27 @@ namespace BxDRobotExporter
 
         public void EditJoint_OnExecute(NameValueMap Context)
         {
-            if (Utilities.GUI.SkeletonBase == null && !Utilities.GUI.LoadRobotSkeleton())
-                return;
-
-            Utilities.HideAdvancedJointEditor();
-            jointForm.PreShow();
-            jointForm.ShowDialog();
-            Utilities.GUI.ReloadPanels();
+            if (jointForm.Visible)
+            {
+                jointForm.Hide();
+            }
+            else
+            {
+                if (Utilities.GUI.SkeletonBase == null && !Utilities.GUI.LoadRobotSkeleton())
+                    return;
+                Utilities.HideAdvancedJointEditor();
+                jointForm.OnShowButtonClick();
+                jointForm.ShowDialog();
+            }
         }
 
         private void AdvancedEditJoint_OnExecute(NameValueMap Context)
         {
             Utilities.ToggleAdvancedJointEditor();
+            if (Utilities.IsAdvancedJointEditorVisible())
+            {
+                jointForm.Hide();
+            }
         }
 
         /// <summary>

--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Utilities.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/Utilities.cs
@@ -83,21 +83,35 @@ namespace BxDRobotExporter
             }
         }
 
+        public static bool IsAdvancedJointEditorVisible()
+        {
+            if (EmbededJointPane == null) return false;
+            return EmbededJointPane.Visible;
+        }
+
         public static void ToggleAdvancedJointEditor()
         {
             if (EmbededJointPane != null)
             {
-                EmbededJointPane.Visible = !EmbededJointPane.Visible;
+                if (IsAdvancedJointEditorVisible())
+                {
+                    HideAdvancedJointEditor();
+                }
+                else
+                {
+                    ShowAdvancedJointEditor();
+                }
             }
         }
         /// <summary>
         /// Hides the dockable windows. Used when switching documents. Called in <see cref="StandardAddInServer.ApplicationEvents_OnDeactivateDocument(_Document, EventTimingEnum, NameValueMap, out HandlingCodeEnum)"/>.
         /// </summary>
-        public static void HideAdvancedJointEditor()
+        public static void HideAdvancedJointEditor() // TODO: Figure out how to call this when the advanced editor tab is closed manually (Inventor API)
         {
             if (EmbededJointPane != null)
             {
                 EmbededJointPane.Visible = false;
+                InventorUtils.FocusAndHighlightNodes(null, StandardAddInServer.Instance.MainApplication.ActiveView.Camera, 1);
             }
         }
 

--- a/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/JointEditorPane.cs
+++ b/exporters/BxDRobotExporter/robot_exporter/JointResolver/EditorsLibrary/JointEditorPane.cs
@@ -39,6 +39,8 @@ namespace EditorsLibrary
         /// The list of nodes to be attached as metadata
         /// </summary>
         private List<RigidNode_Base> nodeList = null;
+        
+        private Timer selectionFinishedTimeout = new Timer();
 
         /// <summary>
         /// Create a new JointEditorPane and register actions for the right click menu
@@ -75,6 +77,9 @@ namespace EditorsLibrary
 
                     EditDriver_Internal(GetSelectedNodes());
                 };
+
+            selectionFinishedTimeout.Tick += FinishedSelecting;
+            selectionFinishedTimeout.Interval = 55; // minimum accuracy of winforms timers
         }
 
         /// <summary>
@@ -185,6 +190,13 @@ namespace EditorsLibrary
         /// <param name="e"></param>
         private void LstJoints_SelectedIndexChanged(object sender, EventArgs e)
         {
+            selectionFinishedTimeout.Start(); // TODO: Find less hacky way to detect when selection is finished
+
+        }
+        
+        private void FinishedSelecting(object sender, EventArgs e)
+        {
+            selectionFinishedTimeout.Stop();
             foreach (ListViewItem item in lstJoints.Items.OfType<ListViewItem>())
             {
                 item.BackColor = Control.DefaultBackColor;


### PR DESCRIPTION
### Fix bugs
- Zoom for selected components was messed up, depended on viewport aspect ratio
- Viewport did not de-highlight components when joint editors were closed
- It was possible to open the regular and advanced joint editors at the same time
- Selecting multiple joints in the Advanced joint editor was slow and the viewport looked glitchy for a few seconds after selecting
- Joint editor buttons could be clicked again while joint editors were open and would not do anything

|    DOD    | Done |    Reviewer    | Issue | Notes |
|-----------|------|----------------|-------|-------|
| Code      | ❌   | Nicolas Espinoza/Alex Carter |  1074|       |
| Unit Test | N/A  | N/A            |       |       |
| Merged    | ❌  |                |       |       |