### PR TITLE
Fix "Undo" crash

### DIFF
--- a/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
+++ b/exporters/BxDRobotExporter/BxDRobotExporter/BxDRobotExporter/StandardAddInServer.cs
@@ -375,6 +375,7 @@ namespace BxDRobotExporter
 
             // Close add-in
             Utilities.DisposeDockableWindows();
+            ForceQuitExporter(AsmDocument);
 
             // Dispose of document
             if (AsmDocument != null)


### PR DESCRIPTION
### Fix "Undo" crash

The problem: the environment stays open after the action "Undo Open Robot Exporter" for some reason
Fix: force close exporter GUI

*This is a temporary fix until we figure out why the GUI does hide when the env is closed manually, but not through an "undo"*

Steps to reproduce on `master`:
1. Enter Inventor Robot Exporter environment
2. Ctrl-Z (or hit undo button)
3. Click any button on the Robot Exporter environment ribbon
4. An uncaught exception is thrown


|    DOD    | Done |    Reviewer    | Issue | Notes |
|-----------|------|----------------|-------|-------|
| Code      | ❌   | Nicolas Espinoza / Alex Carter |  1087 |       |
| Unit Test | N/A  | N/A            |       |       |
| Merged    | ❌  |                |       |       |