### PR TITLE
Custom node weights from json bots

### DIFF
--- a/engine/unity5/Assets/Scripts/RN/RNMesh.cs
+++ b/engine/unity5/Assets/Scripts/RN/RNMesh.cs
@@ -100,7 +100,7 @@ namespace Synthesis.RN
                 string jsonFile = Directory.GetParent(filePath).FullName + Path.DirectorySeparatorChar + "skeleton.json";
                 bool useJsonWeight = false;
                 if (File.Exists(jsonFile)) { useJsonWeight = true; }
-                float weight = 1.0f;
+                float weight = mesh.physics.mass;
                 if (useJsonWeight) {
                     try {
                         weight = (float)GetSkeletalJoint().weight;

--- a/engine/unity5/Assets/Scripts/RN/RNMesh.cs
+++ b/engine/unity5/Assets/Scripts/RN/RNMesh.cs
@@ -9,6 +9,7 @@ using Synthesis.FSM;
 using Synthesis.BUExtensions;
 using Synthesis.States;
 using Synthesis.Utils;
+using System.IO;
 
 namespace Synthesis.RN
 {
@@ -96,7 +97,18 @@ namespace Synthesis.RN
                 //Debug.Log(PhysicalProperties.centerOfMass);
 
                 BRigidBody rigidBody = MainObject.AddComponent<BRigidBody>();
-                rigidBody.mass = mesh.physics.mass;
+                string jsonFile = Directory.GetParent(filePath).FullName + Path.DirectorySeparatorChar + "skeleton.json";
+                bool useJsonWeight = false;
+                if (File.Exists(jsonFile)) { useJsonWeight = true; }
+                float weight = 1.0f;
+                if (useJsonWeight) {
+                    try {
+                        weight = (float)GetSkeletalJoint().weight;
+                    } catch (Exception e) {
+                        weight = mesh.physics.mass;
+                    }
+                }
+                rigidBody.mass = weight;
                 rigidBody.friction = 0.25f;
                 rigidBody.linearSleepingThreshold = LinearSleepingThreshold;
                 rigidBody.angularSleepingThreshold = AngularSleepingThreshold;


### PR DESCRIPTION
If a .json skeleton file is detected it will attempt to load the weight from the json file. If it fails in the process or doesn't detect a .json skeleton file it will default to the original weight designated in the mesh physics.
JIRA: https://jira.autodesk.com/browse/AARD-956