### PR TITLE
Set default startup project to InventorRobotExporter

### DIFF
--- a/exporters/InventorRobotExporter/InventorRobotExporter.sln
+++ b/exporters/InventorRobotExporter/InventorRobotExporter.sln
@@ -3,11 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29009.5
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InventorRobotExporter", "InventorRobotExporter\InventorRobotExporter.csproj", "{3DC284CE-6572-439D-ADA3-E703FF8498B6}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimulatorAPI", "..\Aardvark-Libraries\SimulatorFileIO\SimulatorAPI.csproj", "{52DC911D-AD5D-4D01-9FC1-22AAADA97740}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MIConvexHull", "..\Aardvark-Libraries\MIConvexHull\MIConvexHull.csproj", "{2337776D-7D0C-40AA-A439-C26C3CE24FAB}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InventorRobotExporter", "InventorRobotExporter\InventorRobotExporter.csproj", "{3DC284CE-6572-439D-ADA3-E703FF8498B6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RobotExporterTests", "RobotExporterTests\RobotExporterTests.csproj", "{6A1E6600-E31E-467B-86D9-E5473D86C68C}"
 EndProject

--- a/exporters/InventorRobotExporter/InventorRobotExporter.sln
+++ b/exporters/InventorRobotExporter/InventorRobotExporter.sln
@@ -18,6 +18,12 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Benchmark|Any CPU.ActiveCfg = Benchmark|Any CPU
+		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Benchmark|Any CPU.Build.0 = Benchmark|Any CPU
+		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{52DC911D-AD5D-4D01-9FC1-22AAADA97740}.Benchmark|Any CPU.ActiveCfg = Benchmark|Any CPU
 		{52DC911D-AD5D-4D01-9FC1-22AAADA97740}.Benchmark|Any CPU.Build.0 = Benchmark|Any CPU
 		{52DC911D-AD5D-4D01-9FC1-22AAADA97740}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -30,12 +36,6 @@ Global
 		{2337776D-7D0C-40AA-A439-C26C3CE24FAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2337776D-7D0C-40AA-A439-C26C3CE24FAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2337776D-7D0C-40AA-A439-C26C3CE24FAB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Benchmark|Any CPU.ActiveCfg = Benchmark|Any CPU
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Benchmark|Any CPU.Build.0 = Benchmark|Any CPU
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3DC284CE-6572-439D-ADA3-E703FF8498B6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6A1E6600-E31E-467B-86D9-E5473D86C68C}.Benchmark|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A1E6600-E31E-467B-86D9-E5473D86C68C}.Benchmark|Any CPU.Build.0 = Debug|Any CPU
 		{6A1E6600-E31E-467B-86D9-E5473D86C68C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
### Set default startup project to InventorRobotExporter
- Simply changes the default startup project from SimulatorAPI to InventorRobotExporter
  - Makes out-of-the-box clones or contributing easier