### PR TITLE
Fix background color

### DIFF
--- a/exporters/InventorRobotExporter/InventorRobotExporter/GUI/Editors/JointEditor/JointCardUC.cs
+++ b/exporters/InventorRobotExporter/InventorRobotExporter/GUI/Editors/JointEditor/JointCardUC.cs
@@ -225,7 +225,7 @@ namespace InventorRobotExporter.GUI.Editors.JointEditor
                 DriverLayout.BackColor = Color.FromArgb(227, 206, 169);
             } else {
                 advancedButton.Visible = true;
-                DriverLayout.ResetBackColor();
+                DriverLayout.BackColor = SystemColors.Control;
                 if ((string) jointTypeComboBox.SelectedItem == "Drivetrain Wheel")
                     InsertDriveTrainControls();
                 else if ((string) jointTypeComboBox.SelectedItem == "Mechanism Joint")


### PR DESCRIPTION
### Fix background color
- After a joint was highlighted in the joint editor, the gray background would match everything else and look extremely ugly