### PR TITLE
Disabled MaM if it's not available

### DIFF
--- a/engine/unity5/Assets/Scripts/GUI/SimUI.cs
+++ b/engine/unity5/Assets/Scripts/GUI/SimUI.cs
@@ -632,7 +632,11 @@ namespace Synthesis.GUI
             }
             else
             {
-                addPanel.SetActive(true);
+                if (IsMaMInstalled()) {
+                    addPanel.SetActive(true);
+                } else {
+                    ToggleChangeRobotPanel();
+                }
                 changePanel.SetActive(false);
             }
         }
@@ -1117,6 +1121,12 @@ namespace Synthesis.GUI
 
         public void QualitySelectionChanged(int a) {
             OnQualitySelection(a);
+        }
+
+        public static bool IsMaMInstalled() {
+            return Directory.Exists(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar
+                + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "MixAndMatch" + Path.DirectorySeparatorChar
+                + "DriveBases");
         }
     }
 }

--- a/engine/unity5/Assets/Scripts/GUI/ToolbarStates/MainToolbarState.cs
+++ b/engine/unity5/Assets/Scripts/GUI/ToolbarStates/MainToolbarState.cs
@@ -121,7 +121,11 @@ namespace Synthesis.GUI
                 changePanel.SetActive(false);
             }
             else {
-                changePanel.SetActive(true);
+                if (SimUI.IsMaMInstalled()) {
+                    changePanel.SetActive(true);
+                } else {
+                    SimUI.getSimUI().ToggleChangeRobotPanel();
+                }
                 addPanel.SetActive(false);
 
                 AnalyticsManager.GlobalInstance.LogEventAsync(AnalyticsLedger.EventCatagory.ChangeRobot,


### PR DESCRIPTION
I made a check for the drivebases folder and if it doesn't exist then it will skip the option for MaM bots and only do exported
JIRA: https://jira.autodesk.com/browse/AARD-1166