### PR TITLE
Fix analytics by using client ID instead of user ID and update GUID generation

### DIFF
--- a/exporters/InventorRobotExporter/InventorRobotExporter/Properties/Settings.Designer.cs
+++ b/exporters/InventorRobotExporter/InventorRobotExporter/Properties/Settings.Designer.cs
@@ -166,5 +166,17 @@ namespace InventorRobotExporter.Properties {
                 this["ExportCount"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("firstRun")]
+        public string AnalyticsID {
+            get {
+                return ((string)(this["AnalyticsID"]));
+            }
+            set {
+                this["AnalyticsID"] = value;
+            }
+        }
     }
 }

--- a/exporters/InventorRobotExporter/InventorRobotExporter/Properties/Settings.settings
+++ b/exporters/InventorRobotExporter/InventorRobotExporter/Properties/Settings.settings
@@ -38,5 +38,8 @@
     <Setting Name="ExportCount" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="AnalyticsID" Type="System.String" Scope="User">
+      <Value Profile="(Default)">firstRun</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/exporters/InventorRobotExporter/InventorRobotExporter/RobotExporterAddInServer.cs
+++ b/exporters/InventorRobotExporter/InventorRobotExporter/RobotExporterAddInServer.cs
@@ -74,7 +74,6 @@ namespace InventorRobotExporter
         protected override Environment CreateEnvironment()
         {
             const string clientId = "{0c9a07ad-2768-4a62-950a-b5e33b88e4a3}";
-            AnalyticsUtils.GenerateID();
 
             InitEnvironment(clientId);
 

--- a/exporters/InventorRobotExporter/InventorRobotExporter/RobotExporterAddInServer.cs
+++ b/exporters/InventorRobotExporter/InventorRobotExporter/RobotExporterAddInServer.cs
@@ -74,7 +74,7 @@ namespace InventorRobotExporter
         protected override Environment CreateEnvironment()
         {
             const string clientId = "{0c9a07ad-2768-4a62-950a-b5e33b88e4a3}";
-            AnalyticsUtils.SetUser(Application.UserName);
+            AnalyticsUtils.GenerateID();
 
             InitEnvironment(clientId);
 

--- a/exporters/InventorRobotExporter/InventorRobotExporter/Utilities/AnalyticsUtils.cs
+++ b/exporters/InventorRobotExporter/InventorRobotExporter/Utilities/AnalyticsUtils.cs
@@ -11,13 +11,13 @@ namespace InventorRobotExporter.Utilities
         private const string BASE_URL = "https://www.google-analytics.com/collect";
         private const string TRACKING = "UA-81892961-4";
         
-        private static string userId = "unknown";
+        private static string clientId = "unknown";
         
         private static readonly HttpClient client = new HttpClient();
         
         public static void SetUser(string user)
         {
-            userId = GetHashString(user);
+            clientId = GetHashString(user);
         }
 
         private static IEnumerable<byte> GetHash(string inputString)
@@ -40,7 +40,7 @@ namespace InventorRobotExporter.Utilities
             var res = BASE_URL;
             res += "?v=1";
             res += "&tid=" + TRACKING;
-            res += "&uid="+ userId;
+            res += "&cid="+ clientId;
             res += "&ds=" + "app";
             var version = RobotExporterAddInServer.Instance.Application.SoftwareVersion;
             res += "&dr=" + "inventor";

--- a/exporters/InventorRobotExporter/InventorRobotExporter/Utilities/AnalyticsUtils.cs
+++ b/exporters/InventorRobotExporter/InventorRobotExporter/Utilities/AnalyticsUtils.cs
@@ -17,14 +17,14 @@ namespace InventorRobotExporter.Utilities
         
         private static readonly HttpClient client = new HttpClient();
 
-        public static void GenerateID()
+        static AnalyticsUtils()
         {
             if (Guid.TryParse(Settings.Default.AnalyticsID, out clientId)) return;
             clientId = Guid.NewGuid();
             Settings.Default.AnalyticsID = clientId.ToString();
             Settings.Default.Save();
         }
-        
+
         private static string GetBaseURL()
         {
             var res = BASE_URL;

--- a/exporters/InventorRobotExporter/InventorRobotExporter/Utilities/AnalyticsUtils.cs
+++ b/exporters/InventorRobotExporter/InventorRobotExporter/Utilities/AnalyticsUtils.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using InventorRobotExporter.Properties;
 
 namespace InventorRobotExporter.Utilities
 {
@@ -11,30 +13,18 @@ namespace InventorRobotExporter.Utilities
         private const string BASE_URL = "https://www.google-analytics.com/collect";
         private const string TRACKING = "UA-81892961-4";
         
-        private static string clientId = "unknown";
+        private static Guid clientId;
         
         private static readonly HttpClient client = new HttpClient();
+
+        public static void GenerateID()
+        {
+            if (Guid.TryParse(Settings.Default.AnalyticsID, out clientId)) return;
+            clientId = Guid.NewGuid();
+            Settings.Default.AnalyticsID = clientId.ToString();
+            Settings.Default.Save();
+        }
         
-        public static void SetUser(string user)
-        {
-            clientId = GetHashString(user);
-        }
-
-        private static IEnumerable<byte> GetHash(string inputString)
-        {
-            HashAlgorithm algorithm = SHA256.Create();
-            return algorithm.ComputeHash(Encoding.UTF8.GetBytes(inputString));
-        }
-
-        private static string GetHashString(string inputString)
-        {
-            var sb = new StringBuilder();
-            foreach (var b in GetHash(inputString))
-                sb.Append(b.ToString("X2"));
-
-            return sb.ToString();
-        }
-
         private static string GetBaseURL()
         {
             var res = BASE_URL;

--- a/exporters/InventorRobotExporter/InventorRobotExporter/app.config
+++ b/exporters/InventorRobotExporter/InventorRobotExporter/app.config
@@ -40,6 +40,12 @@
             <setting name="ShowGuide" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="ExportCount" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="AnalyticsID" serializeAs="String">
+                <value>firstRun</value>
+            </setting>
         </InventorRobotExporter.Properties.Settings>
     </userSettings>
 </configuration>


### PR DESCRIPTION
- Use client ID instead of user ID as hits with a user ID were not showing up in the analytics dashboard
- Use randomly generated user ID instead of the hash of the username

|    DOD    | Done |    Reviewer    | Issue | Notes |
|-----------|------|----------------|-------|-------|
| Code      | ❌   |Kira Corbett|  1079|       |
| Unit Test | N/A  | N/A            |       |       |
| Merged    | ❌  |                |       |       |