### PR TITLE
Bug Fix for Issue #431 with Reset Issues

### DIFF
--- a/engine/unity5/Assets/Scripts/GUI/ToolbarStates/DPMToolbarState.cs
+++ b/engine/unity5/Assets/Scripts/GUI/ToolbarStates/DPMToolbarState.cs
@@ -25,6 +25,7 @@ namespace Assets.Scripts.GUI
     {
         GameObject canvas;
         GameObject dpmToolbar;
+        GameObject tabs;
 
         GameObject gamepieceDropdownButton;
         GameObject gamepieceDropdownArrow;
@@ -49,6 +50,7 @@ namespace Assets.Scripts.GUI
 
             canvas = GameObject.Find("Canvas");
             dpmToolbar = Auxiliary.FindObject(canvas, "DPMToolbar");
+            tabs = Auxiliary.FindObject(canvas, "Tabs");
 
             gamepieceDropdownButton = Auxiliary.FindObject(dpmToolbar, "GamepieceDropdownButton");
             gamepieceDropdownArrow = Auxiliary.FindObject(gamepieceDropdownButton, "Arrow");

--- a/engine/unity5/Assets/Scripts/GUI/ToolbarStates/MainToolbarState.cs
+++ b/engine/unity5/Assets/Scripts/GUI/ToolbarStates/MainToolbarState.cs
@@ -48,6 +48,7 @@ namespace Synthesis.GUI
         GameObject inputManagerPanel;
         GameObject checkSavePanel;
         GameObject toolbar;
+        GameObject tabs;
         GameObject pointImpulsePanel;
 
         public bool dpmWindowOn = false; //if the driver practice mode window is active
@@ -56,6 +57,9 @@ namespace Synthesis.GUI
         public override void Start() {
             canvas = GameObject.Find("Canvas");
             camera = GameObject.Find("Main Camera").GetComponent<DynamicCamera>();
+
+            tabs = Auxiliary.FindObject(canvas, "Tabs");
+            toolbar = Auxiliary.FindObject(canvas, "MainToolbar");
 
             changeRobotPanel = Auxiliary.FindObject(canvas, "ChangeRobotPanel");
             robotListPanel = Auxiliary.FindObject(changeRobotPanel, "RobotListPanel");

--- a/engine/unity5/Assets/Scripts/GUI/ToolbarStates/ScoringToolbarState.cs
+++ b/engine/unity5/Assets/Scripts/GUI/ToolbarStates/ScoringToolbarState.cs
@@ -19,11 +19,13 @@ namespace Assets.Scripts.GUI
     {
         GameObject canvas;
         GameObject toolbar;
+        GameObject tabs;
 
         public override void Start()
         {
             canvas = GameObject.Find("Canvas");
             toolbar = Auxiliary.FindObject(canvas, "ScoringToolbar");
+            tabs = Auxiliary.FindObject(canvas, "Tabs");
         }
 
         public override void ToggleHidden()

--- a/engine/unity5/Assets/Scripts/GUI/ToolbarStates/SensorToolbarState.cs
+++ b/engine/unity5/Assets/Scripts/GUI/ToolbarStates/SensorToolbarState.cs
@@ -22,6 +22,7 @@ namespace Assets.Scripts.GUI
 
         GameObject canvas;
         GameObject sensorToolbar;
+        GameObject tabs;
 
         Dropdown ultrasonicDropdown;
         Dropdown beamBreakerDropdown;
@@ -38,6 +39,7 @@ namespace Assets.Scripts.GUI
 
             canvas = GameObject.Find("Canvas");
             sensorToolbar = Auxiliary.FindObject(canvas, "SensorToolbar");
+            tabs = Auxiliary.FindObject(canvas, "Tabs");
 
             ultrasonicDropdown = Auxiliary.FindObject(sensorToolbar, "UltrasonicDropdown").GetComponent<Dropdown>();
             beamBreakerDropdown = Auxiliary.FindObject(sensorToolbar, "BeamBreakDropdown").GetComponent<Dropdown>();

--- a/engine/unity5/Assets/Scripts/Robot/SimulatorRobot.cs
+++ b/engine/unity5/Assets/Scripts/Robot/SimulatorRobot.cs
@@ -54,10 +54,7 @@ namespace Synthesis.Robot
         private MainState state;
 
         #region help ui variables
-        GameObject helpMenu;
         GameObject toolbar;
-        GameObject overlay;
-        Text helpBodyText;
         #endregion
 
         GameObject canvas;
@@ -271,24 +268,15 @@ namespace Synthesis.Robot
             resetCanvas.SetActive(true);
 
             #region init
-            if (helpMenu == null) helpMenu = Auxiliary.FindObject(resetCanvas, "Help");
             if (toolbar == null) toolbar = Auxiliary.FindObject(resetCanvas, "ResetStateToolbar");
-            if (overlay == null) overlay = Auxiliary.FindObject(resetCanvas, "Overlay");
-            if (helpBodyText == null) helpBodyText = Auxiliary.FindObject(resetCanvas, "BodyText").GetComponent<Text>();
             #endregion
 
             Button resetButton = Auxiliary.FindObject(resetCanvas, "ResetButton").GetComponent<Button>();
             resetButton.onClick.RemoveAllListeners();
             resetButton.onClick.AddListener(BeginRevertSpawnpoint);
-            Button helpButton = Auxiliary.FindObject(resetCanvas, "HelpButton").GetComponent<Button>();
-            helpButton.onClick.RemoveAllListeners();
-            helpButton.onClick.AddListener(HelpMenu);
             Button returnButton = Auxiliary.FindObject(resetCanvas, "ReturnButton").GetComponent<Button>();
             returnButton.onClick.RemoveAllListeners();
             returnButton.onClick.AddListener(EndReset);
-            Button closeHelp = Auxiliary.FindObject(helpMenu, "CloseHelpButton").GetComponent<Button>();
-            closeHelp.onClick.RemoveAllListeners();
-            closeHelp.onClick.AddListener(CloseHelpMenu);
 
             DynamicCamera dynamicCamera = UnityEngine.Camera.main.transform.GetComponent<DynamicCamera>();
             lastCameraState = dynamicCamera.ActiveState;
@@ -394,7 +382,6 @@ namespace Synthesis.Robot
             foreach (Tracker t in GetComponentsInChildren<Tracker>())
                 t.Clear();
 
-            if (helpMenu.activeSelf) CloseHelpMenu();
             InputControl.freeze = false;
             canvas.GetComponent<Canvas>().enabled = true;
             resetCanvas.SetActive(false);
@@ -459,35 +446,6 @@ namespace Synthesis.Robot
                 RigidBody r = (RigidBody)br.GetCollisionObject();
 
                 r.LinearFactor = r.AngularFactor = BulletSharp.Math.Vector3.One;
-            }
-        }
-
-        private void HelpMenu()
-        {
-            helpMenu.SetActive(true);
-            overlay.SetActive(true);
-
-            helpBodyText.GetComponent<Text>().text = "Move Robot: WASD keys or drag navigation arrows. " +
-                "\nClick and drag a face of the navigation cube to move robot freely" +
-                "\n\nRotate Robot: Hold RIGHT MOUSE BUTTON, and use A and D keys to rotate" +
-                "\n\nSave: Press ENTER";
-
-            toolbar.transform.Translate(new Vector3(100, 0, 0));
-            foreach (Transform t in toolbar.transform)
-            {
-                if (t.gameObject.name != "HelpButton") t.Translate(new Vector3(100, 0, 0));
-                else t.gameObject.SetActive(false);
-            }
-        }
-        private void CloseHelpMenu()
-        {
-            helpMenu.SetActive(false);
-            overlay.SetActive(false);
-            toolbar.transform.Translate(new Vector3(-100, 0, 0));
-            foreach (Transform t in toolbar.transform)
-            {
-                if (t.gameObject.name != "HelpButton") t.Translate(new Vector3(-100, 0, 0));
-                else t.gameObject.SetActive(true);
             }
         }
 

--- a/engine/unity5/Assets/Scripts/Robot/SimulatorRobot.cs
+++ b/engine/unity5/Assets/Scripts/Robot/SimulatorRobot.cs
@@ -53,10 +53,7 @@ namespace Synthesis.Robot
 
         private MainState state;
 
-        #region help ui variables
         GameObject toolbar;
-        #endregion
-
         GameObject canvas;
         GameObject resetCanvas;
 

--- a/engine/unity5/Assets/Scripts/States/DefineSensorAttachmentState.cs
+++ b/engine/unity5/Assets/Scripts/States/DefineSensorAttachmentState.cs
@@ -30,13 +30,6 @@ namespace Synthesis.States
         bool camera;
         SensorBase currentSensor;
         RobotCameraManager robotCameraManager;
-        
-        #region help ui variables
-        GameObject ui;
-        GameObject helpMenu;
-        GameObject toolbar;
-        GameObject overlay;
-        #endregion
 
         public DefineSensorAttachmentState(SensorBase currentSensor)
         {
@@ -51,25 +44,12 @@ namespace Synthesis.States
         // Use this for initialization
         public override void Start()
         {
-            #region init
-            ui = GameObject.Find("DefineSensorAttachmentUI");
-            helpMenu = Auxiliary.FindObject(ui, "Help");
-            toolbar = Auxiliary.FindObject(ui, "NodeStateToolbar");
-            overlay = Auxiliary.FindObject(ui, "Overlay");
-            #endregion
-
             highlightButton = GameObject.Find("HighlightButton").GetComponent<Button>();
             highlightButton.onClick.RemoveAllListeners();
             highlightButton.onClick.AddListener(HighlightNode);
-            Button helpButton = GameObject.Find("HelpButton").GetComponent<Button>();
-            helpButton.onClick.RemoveAllListeners();
-            helpButton.onClick.AddListener(HelpMenu);
             Button returnButton = GameObject.Find("ReturnButton").GetComponent<Button>();
             returnButton.onClick.RemoveAllListeners();
             returnButton.onClick.AddListener(ReturnToMainState);
-            Button closeHelp = Auxiliary.FindObject(helpMenu, "CloseHelpButton").GetComponent<Button>();
-            closeHelp.onClick.RemoveAllListeners();
-            closeHelp.onClick.AddListener(CloseHelpMenu);
         }
 
         // Update is called once per frame
@@ -174,30 +154,7 @@ namespace Synthesis.States
         {
             RevertNodeColors(hoveredNode, hoveredColors);
             RevertHighlight();
-            if (helpMenu.activeSelf) CloseHelpMenu();
             StateMachine.PopState();
-        }
-        private void HelpMenu()
-        {
-            helpMenu.SetActive(true);
-            overlay.SetActive(true);
-            toolbar.transform.Translate(new Vector3(100, 0, 0));
-            foreach (Transform t in toolbar.transform)
-            {
-                if (t.gameObject.name != "HelpButton") t.Translate(new Vector3(100, 0, 0));
-                else t.gameObject.SetActive(false);
-            }
-        }
-        private void CloseHelpMenu()
-        {
-            helpMenu.SetActive(false);
-            overlay.SetActive(false);
-            toolbar.transform.Translate(new Vector3(-100, 0, 0));
-            foreach (Transform t in toolbar.transform)
-            {
-                if (t.gameObject.name != "HelpButton") t.Translate(new Vector3(-100, 0, 0));
-                else t.gameObject.SetActive(true);
-            }
         }
     }
 }

--- a/engine/unity5/Assets/Scripts/States/GoalState.cs
+++ b/engine/unity5/Assets/Scripts/States/GoalState.cs
@@ -69,7 +69,7 @@ namespace Synthesis.States
             lastCameraState = dynamicCamera.ActiveState;
             dynamicCamera.SwitchCameraState(new DynamicCamera.ConfigurationState(dynamicCamera, goalIndicator));
 
-            //help menu stuff
+            //UI callbacks 
             Button resetButton = GameObject.Find("ResetButton").GetComponent<Button>();
             resetButton.onClick.RemoveAllListeners();
             resetButton.onClick.AddListener(Reset);

--- a/engine/unity5/Assets/Scripts/States/GoalState.cs
+++ b/engine/unity5/Assets/Scripts/States/GoalState.cs
@@ -24,13 +24,6 @@ namespace Synthesis.States
         bool settingGamepieceGoalVertical = false;
         DynamicCamera.CameraState lastCameraState;
 
-        #region help ui variables
-        GameObject ui;
-        GameObject helpMenu;
-        GameObject toolbar;
-        GameObject overlay;
-        #endregion
-
         public GoalState(string color, int gamepieceIndex, int goalIndex, GoalManager gm, bool move)
         {
             this.color = color;
@@ -42,13 +35,6 @@ namespace Synthesis.States
         // Use this for initialization
         public override void Start()
         {
-            #region init
-            ui = GameObject.Find("GoalStateUI");
-            helpMenu = Auxiliary.FindObject(ui, "Help");
-            toolbar = Auxiliary.FindObject(ui, "ResetStateToolbar");
-            overlay = Auxiliary.FindObject(ui, "Overlay");
-            #endregion
-
             //create indicator
             if (goalIndicator != null) GameObject.Destroy(goalIndicator);
             if (goalIndicator == null)
@@ -87,15 +73,9 @@ namespace Synthesis.States
             Button resetButton = GameObject.Find("ResetButton").GetComponent<Button>();
             resetButton.onClick.RemoveAllListeners();
             resetButton.onClick.AddListener(Reset);
-            Button helpButton = GameObject.Find("HelpButton").GetComponent<Button>();
-            helpButton.onClick.RemoveAllListeners();
-            helpButton.onClick.AddListener(HelpMenu);
             Button returnButton = GameObject.Find("ReturnButton").GetComponent<Button>();
             returnButton.onClick.RemoveAllListeners();
             returnButton.onClick.AddListener(ReturnToMainState);
-            Button closeHelp = Auxiliary.FindObject(helpMenu, "CloseHelpButton").GetComponent<Button>();
-            closeHelp.onClick.RemoveAllListeners();
-            closeHelp.onClick.AddListener(CloseHelpMenu);
         }
 
         // Update is called once per frame
@@ -146,35 +126,12 @@ namespace Synthesis.States
             DynamicCamera dynamicCamera = UnityEngine.Camera.main.transform.GetComponent<DynamicCamera>();
             dynamicCamera.SwitchCameraState(lastCameraState);
             GameObject.Destroy(goalIndicator);
-            if (helpMenu.activeSelf) CloseHelpMenu();
             StateMachine.PopState();
         }
         private void Reset()
         {
             if (move) goalIndicator.transform.position = new Vector3(0f, 4f, 0f);
             else goalIndicator.transform.localScale = Vector3.one;
-        }
-        private void HelpMenu()
-        {
-            helpMenu.SetActive(true);
-            overlay.SetActive(true);
-            toolbar.transform.Translate(new Vector3(100, 0, 0));
-            foreach (Transform t in toolbar.transform)
-            {
-                if (t.gameObject.name != "HelpButton") t.Translate(new Vector3(100, 0, 0));
-                else t.gameObject.SetActive(false);
-            }
-        }
-        private void CloseHelpMenu()
-        {
-            helpMenu.SetActive(false);
-            overlay.SetActive(false);
-            toolbar.transform.Translate(new Vector3(-100, 0, 0));
-            foreach (Transform t in toolbar.transform)
-            {
-                if (t.gameObject.name != "HelpButton") t.Translate(new Vector3(-100, 0, 0));
-                else t.gameObject.SetActive(true);
-            }
         }
     }
 }


### PR DESCRIPTION
Issue #431 has caused users to get stuck in Synthesis as they are not able to escape the reset UI, defining nodes, or defining goals. This bug fix removes old help callbacks which is preventing users from properly using these features. 

This should be merged in before other engine PRs due to the bug that is also in other engine PRs.
- Merge this PR #434 
- Then merge #432 (heavy scene changes, should be expedited before other engine PRs)
- Then any other engine PRs

Resolves JIRA #[AARD-1186](https://jira.autodesk.com/browse/AARD-1186)