### PR TITLE
Disabled Errornote when there is no selected bot

### DIFF
--- a/engine/unity5/Assets/Scripts/States/ErrorScreenState.cs
+++ b/engine/unity5/Assets/Scripts/States/ErrorScreenState.cs
@@ -18,9 +18,9 @@ namespace Synthesis.States
             if (error.Split('|')[0].Equals("ROBOT_SELECT")) {
                 AppModel.ClearError();
                 StateMachine.ChangeState(new LoadRobotState());
-                Auxiliary.FindGameObject("ErrorNote").GetComponent<Text>().text = error.Split('|')[1];
-            }
-            else {
+                if (error.Split('|')[1].Equals("FIRST")) Auxiliary.FindGameObject("ErrorNote").GetComponent<Text>().text = "";
+                else Auxiliary.FindGameObject("ErrorNote").GetComponent<Text>().text = error.Split('|')[1];
+            } else {
                 Auxiliary.FindGameObject("ErrorScreen").SetActive(true);
                 Auxiliary.FindGameObject("ErrorText").GetComponent<Text>().text = AppModel.ErrorMessage;
                 AppModel.ClearError();

--- a/engine/unity5/Assets/Scripts/States/MainState.cs
+++ b/engine/unity5/Assets/Scripts/States/MainState.cs
@@ -162,6 +162,13 @@ namespace Synthesis.States
             //If a replay has been selected, load the replay. Otherwise, load the field and robot.
             string selectedReplay = PlayerPrefs.GetString("simSelectedReplay");
 
+            if (PlayerPrefs.GetString("simSelectedRobot", "").Equals(""))
+            {
+                AppModel.ErrorToMenu("ROBOT_SELECT|FIRST");
+                Debug.Log("ASKJHASDFKJHDSAKJHGDSAF");
+                return;
+            }
+
             if (string.IsNullOrEmpty(selectedReplay))
             {
                 Tracking = true;

--- a/engine/unity5/Assets/Scripts/States/MainState.cs
+++ b/engine/unity5/Assets/Scripts/States/MainState.cs
@@ -165,7 +165,6 @@ namespace Synthesis.States
             if (PlayerPrefs.GetString("simSelectedRobot", "").Equals(""))
             {
                 AppModel.ErrorToMenu("ROBOT_SELECT|FIRST");
-                Debug.Log("ASKJHASDFKJHDSAKJHGDSAF");
                 return;
             }
 


### PR DESCRIPTION
If the registry key is blank it makes the error note disable as to not confuse the user that an error occurred.