### PR TITLE
Add Drive Joints Support for MXP PWM

### DIFF
--- a/engine/unity5/Assets/Scripts/Emulation/EmulatedRoboRIO.cs
+++ b/engine/unity5/Assets/Scripts/Emulation/EmulatedRoboRIO.cs
@@ -136,5 +136,23 @@ namespace Synthesis
                 };
             }
         }
+
+        public static int MXPDigitalToPWMIndex(int mxp)
+        {
+            if (mxp >= 4) // First 4 MXP PWM outputs have the right index, but the ones after are offset by 4
+            {
+                return mxp - 4;
+            }
+            return mxp;
+        }
+
+        public static int MXPPWMToDigitalIndex(int pwm)
+        {
+            if (pwm >= 4) // First 4 MXP PWM outputs have the right index, but the ones after are offset by 4
+            {
+                return pwm + 4;
+            }
+            return pwm;
+        }
     }
 }

--- a/engine/unity5/Assets/Scripts/GUI/RobotIOPanel.cs
+++ b/engine/unity5/Assets/Scripts/GUI/RobotIOPanel.cs
@@ -706,11 +706,7 @@ namespace Synthesis.GUI
                                 }
                                 else
                                 {
-                                    int digital_index = j - (int)EmulatedRoboRIO.Constants.NUM_PWM_HDRS;
-                                    if (digital_index >= 4) // First 4 MXP PWM outputs have the right index, but the ones after are offset by 4
-                                    {
-                                        digital_index += 4;
-                                    }
+                                    int digital_index = EmulatedRoboRIO.MXPPWMToDigitalIndex(j - (int)EmulatedRoboRIO.Constants.NUM_PWM_HDRS);
                                     if (EmulatedRoboRIO.RobotOutputs.MxpData[digital_index].Config == EmulationService.MXPData.Types.Config.Pwm)
                                     {
                                         robotIOField.inputField.text = EmulatedRoboRIO.RobotOutputs.MxpData[digital_index].Value.ToString();


### PR DESCRIPTION
When emulating robot code, drive joints will now use MXP PWM signals in addition to PWM headers.