### PR TITLE
Revert to previous method of generating preview icons

### DIFF
--- a/exporters/FusionRobotExporter/Source/AddIn/CustomHandlers.cpp
+++ b/exporters/FusionRobotExporter/Source/AddIn/CustomHandlers.cpp
@@ -30,8 +30,6 @@ void WorkspaceActivatedHandler::notify(const Ptr<WorkspaceEventArgs>& eventArgs)
 			eui->openGuidePalette();
 		else
 			eui->closeGuidePalette(true);
-
-		eui->imagesGenerated = false;
 	}
 }
 

--- a/exporters/FusionRobotExporter/Source/AddIn/EUI-UIManagement.cpp
+++ b/exporters/FusionRobotExporter/Source/AddIn/EUI-UIManagement.cpp
@@ -269,18 +269,15 @@ void EUI::openJointEditorPalette()
 
 	config.tempIconDir = std::experimental::filesystem::temp_directory_path().string() + "Synthesis\\FusionIconCache\\"; // Get OS temp dir for icons and save to JSON object
 
-	if (!imagesGenerated)
+	int index = 0;
+	for (std::pair<const std::basic_string<char>, BXDJ::ConfigData::JointConfig> joint : config.getJoints()) // For each joint, focus on the joint, take a pic, save to temp dir
 	{
-		int index = 0;
-		for (std::pair<const std::basic_string<char>, BXDJ::ConfigData::JointConfig> joint : config.getJoints()) // For each joint, focus on the joint, take a pic, save to temp dir
-		{
-			EUI::highlightAndFocusSingleJoint(joint.first, false, 0.6);
-			app->activeViewport()->saveAsImageFile(config.tempIconDir + std::to_string(index) + ".png", 90, 90); // TODO: Is this cross-platform?
-			index++;
-		};
+		EUI::highlightAndFocusSingleJoint(joint.first, false, 0.6);
+		app->activeViewport()->saveAsImageFile(config.tempIconDir+std::to_string(index)+".png", 90, 90); // TODO: Is this cross-platform?
+		index++;
+	};
 
-		imagesGenerated = true;
-	}
+	EUI::resetHighlightAndFocusWholeModel(true, 1.5, ogCam); // clear highlight and move camera to look at whole robot
 
 	uiThread = new std::thread([this](std::string configJSON) // Actually open the palette and send the joint data
 	{
@@ -289,8 +286,6 @@ void EUI::openJointEditorPalette()
 		jointEditorPalette->sendInfoToHTML("joints", configJSON);
 	}, config.toJSONString());
 	Analytics::LogPage(U("Joint Editor"));
-
-	UI->activeSelections()->clear();
 }
 
 

--- a/exporters/FusionRobotExporter/Source/AddIn/EUI-UIManagement.cpp
+++ b/exporters/FusionRobotExporter/Source/AddIn/EUI-UIManagement.cpp
@@ -277,7 +277,7 @@ void EUI::openJointEditorPalette()
 		index++;
 	};
 
-	EUI::resetHighlightAndFocusWholeModel(true, 1.5, ogCam); // clear highlight and move camera to look at whole robot
+	// EUI::resetHighlightAndFocusWholeModel(true, 1.5, ogCam); // clear highlight and move camera to look at whole robot
 
 	uiThread = new std::thread([this](std::string configJSON) // Actually open the palette and send the joint data
 	{
@@ -286,6 +286,8 @@ void EUI::openJointEditorPalette()
 		jointEditorPalette->sendInfoToHTML("joints", configJSON);
 	}, config.toJSONString());
 	Analytics::LogPage(U("Joint Editor"));
+
+	UI->activeSelections()->clear();
 }
 
 

--- a/exporters/FusionRobotExporter/Source/AddIn/EUI.h
+++ b/exporters/FusionRobotExporter/Source/AddIn/EUI.h
@@ -107,7 +107,6 @@ namespace SynthesisAddIn
 		void focusWholeModel(bool transition, double zoom, Ptr<Camera> ogCam);
 
 		// bool dofViewEnabled = false;
-		bool imagesGenerated = false;
 
 		Ptr<Application> getApp() { return app; }
 


### PR DESCRIPTION
### Revert to previous method of generating preview icons
- [adab5ce](https://github.com/Autodesk/synthesis/commit/adab5ce62ac5d32e2f8adad56faa75fea6329a7d) caused issues with generating preview icons sometimes, or using outdated ones
- Changed back to creating preview icons each time the Joint Editor is opened

|    DOD    | Done |    Reviewer    | Issue | Notes |
|-----------|------|----------------|-------|-------|
| Code      | ❌   | Liam Wang |  |       |
| Unit Test | N/A  | N/A            |       |       |
| Merged    | ❌  |                |       |       |