### PR TITLE
Increased palette heights to fit new standard Fusion window sizes

### DIFF
--- a/exporters/FusionRobotExporter/Source/AddIn/EUI.h
+++ b/exporters/FusionRobotExporter/Source/AddIn/EUI.h
@@ -180,7 +180,7 @@ namespace SynthesisAddIn
 		// ReceiveFormDataHandler* keyCloseFormDataEventHandler = nullptr;
 		ReceiveFormDataHandler* settingsReceiveFormDataHandler = nullptr;
 		ReceiveFormDataHandler* finishPaletteReceiveFormDataHandler = nullptr;
-		int HEADER_HEIGHT = 25;
+		int HEADER_HEIGHT = 55;
 
 		template<typename E, typename T>
 		bool addHandler(Ptr<T> el, E* a);


### PR DESCRIPTION
### Increased palette heights to fix new standard Fusion window sizes
In a recent update of Fusion 360, it appears that they have added a soft border to palettes for some reason, blocking the "OK" and "Cancel" buttons, like so:
![Before](https://user-images.githubusercontent.com/31714622/68523228-0fea7000-026b-11ea-8303-2745affd278f.PNG)

The palette heights have been adjusted to accommodate this change:
![After](https://user-images.githubusercontent.com/31714622/68523234-1d075f00-026b-11ea-9d76-8442191c290d.PNG)

It isn't the most glamorous fix, but it appears it's all we can do at the moment.