### PR TITLE
Master Bug with Global Controls

### DIFF
--- a/engine/Assets/Scripts/GUI/MenuUI.cs
+++ b/engine/Assets/Scripts/GUI/MenuUI.cs
@@ -159,7 +159,6 @@ namespace Synthesis.GUI
                 Controls.Load();
                 globalControlPanel.SetActive(true);
                 Auxiliary.FindObject(Auxiliary.FindObject(globalControlPanel, "ScrollRect"), "Content").GetComponent<CreateButton>().CreateButtons();
-                //Auxiliary.FindObject(globalControlPanel, "Content").GetComponent<CreateButton>().CreateButtons();
             }
             else
             {

--- a/engine/Assets/Scripts/GUI/MenuUI.cs
+++ b/engine/Assets/Scripts/GUI/MenuUI.cs
@@ -158,7 +158,8 @@ namespace Synthesis.GUI
             {
                 Controls.Load();
                 globalControlPanel.SetActive(true);
-                Auxiliary.FindObject(globalControlPanel, "Content").GetComponent<CreateButton>().CreateButtons();
+                Auxiliary.FindObject(Auxiliary.FindObject(globalControlPanel, "ScrollRect"), "Content").GetComponent<CreateButton>().CreateButtons();
+                //Auxiliary.FindObject(globalControlPanel, "Content").GetComponent<CreateButton>().CreateButtons();
             }
             else
             {


### PR DESCRIPTION
There is currently a null reference to the global controls on master. To test this fix, attempt to change your global control configurations by the following:
1. Attempt to change your controls by clicking on the "Menu" button -> Global Controls 
2. On first time generation, no controls were produced which resulted in a null reference error. This fix should now allow a user to change their controls. 