### PR TITLE
NUnit Packages added and converted Preference Manager tests to NUnit tests

### DIFF
--- a/controller/Api/PreferenceManager/PreferenceManager.cs
+++ b/controller/Api/PreferenceManager/PreferenceManager.cs
@@ -15,11 +15,6 @@ namespace SynthesisAPI.PreferenceManager
         private static string ActualFilePath = FileSystem.BasePath + "files" + Path.DirectorySeparatorChar + "preferences.json";
         private static Guid MyGuid = Guid.NewGuid();
 
-        public static string BasePath {
-            get => Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + System.IO.Path.DirectorySeparatorChar
-                + "Autodesk" + System.IO.Path.DirectorySeparatorChar + "Synthesis" + System.IO.Path.DirectorySeparatorChar;
-        }
-
         static PreferenceManager()
         {
             preferences = new Dictionary<Guid, Dictionary<string, object>>();

--- a/controller/TestApi/Program.cs
+++ b/controller/TestApi/Program.cs
@@ -21,8 +21,6 @@ namespace TestApi
 
             TestAssetManager.Test();
 
-            TestPreferenceManager.Test();
-
             Console.WriteLine("=============================================\nTests finished");
         }
     }

--- a/controller/TestApi/TestApi.csproj
+++ b/controller/TestApi/TestApi.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Api\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\Api\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\Api\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\Api\packages\NUnit.3.12.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,6 +39,9 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\Api\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\Api\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -70,4 +77,11 @@
     <Content Include="files\test.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\Api\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\Api\packages\NUnit.3.12.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\Api\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\Api\packages\NUnit3TestAdapter.3.16.1\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
 </Project>

--- a/controller/TestApi/TestPreferenceManager.cs
+++ b/controller/TestApi/TestPreferenceManager.cs
@@ -4,18 +4,13 @@ using SynthesisAPI.PreferenceManager;
 using SynthesisAPI.VirtualFileSystem;
 using System;
 using System.Text;
+using NUnit.Framework;
 
 namespace TestApi
 {
-    public static class TestPreferenceManager
+    [TestFixture]
+    public class TestPreferenceManager
     {
-        private static (string, object)[] TestPrefs = new (string, object)[]
-        {
-            ("name", "Nikola Tesla"),
-            ("age", 163),
-            ("some_float", 1.5837f)
-        };
-
         [JsonObject("CustomStruct")]
         public struct CustomStruct
         {
@@ -23,48 +18,34 @@ namespace TestApi
             public string Name { get; set; }
         }
 
-        public static void TestSavingPreferences()
+        [Test]
+        public void TestSavingLoading()
         {
-            foreach (var pref in TestPrefs)
-            {
-                PreferenceManager.SetPreference(Program.TestGuid, pref.Item1, pref.Item2);
-            }
+            if (FileSystem.RootNode == null) FileSystem.Init();
+
+            PreferenceManager.SetPreference(Program.TestGuid, "name", "Nikola Tesla");
+            PreferenceManager.SetPreference(Program.TestGuid, "age", 163);
             if (!PreferenceManager.Save()) throw new Exception();
+            if (!PreferenceManager.Load()) throw new Exception();
+            string name = PreferenceManager.GetPreference<string>(Program.TestGuid, "name");
+            int age = PreferenceManager.GetPreference<int>(Program.TestGuid, "age");
+
+            Assert.AreEqual(name, "Nikola Tesla");
+            Assert.AreEqual(age, 163);
         }
 
-        public static void TestLoadingPreferences()
+        [Test]
+        public void TestCustomTypeSavingLoading()
         {
-            PreferenceManager.SetPreference(Program.TestGuid, "name", "Thomas Edison");
-            if (!PreferenceManager.Load(overrideChanges: true)) throw new Exception();
-            string name = PreferenceManager.GetPreference<string>(Program.TestGuid, TestPrefs[0].Item1);
-            int age = PreferenceManager.GetPreference<int>(Program.TestGuid, TestPrefs[1].Item1);
-            float someFloat = PreferenceManager.GetPreference<float>(Program.TestGuid, TestPrefs[2].Item1);
+            if (FileSystem.RootNode == null) FileSystem.Init();
 
-            if (!(name.Equals(TestPrefs[0].Item2) && age.Equals(TestPrefs[1].Item2) && someFloat.Equals(TestPrefs[2].Item2)))
-            {
-                throw new Exception("Test data doesn't match");
-            }
+            CustomStruct customOriginal = new CustomStruct() { Name = "Thomas Edison" };
+            PreferenceManager.SetPreference(Program.TestGuid, "custom_type", customOriginal);
+            if (!PreferenceManager.Save()) throw new Exception();
+            if (!PreferenceManager.Load()) throw new Exception();
+            CustomStruct customCopy = PreferenceManager.GetPreference<CustomStruct>(Program.TestGuid, "custom_type", useJsonReserialization: true);
 
-            Console.WriteLine(string.Format("Name: {0}\nAge: {1}\nSome Float: {2}", name, age, someFloat));
-        }
-
-        public static void TestCustomTypes()
-        {
-            PreferenceManager.SetPreference(Program.TestGuid, "custom_type", new CustomStruct() { Name = "Edward Newton" });
-            PreferenceManager.Save();
-            PreferenceManager.Load(overrideChanges: true);
-            object unCastableData = PreferenceManager.GetPreference(Program.TestGuid, "custom_type");
-            CustomStruct data = JsonConvert.DeserializeObject<CustomStruct>(JsonConvert.SerializeObject(unCastableData));
-
-            Console.WriteLine(string.Format("Name: {0}", data.Name));
-        }
-
-        public static void Test()
-        {
-            TestSavingPreferences();
-            TestLoadingPreferences();
-            TestSavingPreferences();
-            TestCustomTypes();
+            Assert.AreEqual(customOriginal, customCopy);
         }
     }
 }

--- a/controller/TestApi/packages.config
+++ b/controller/TestApi/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
+  <package id="NUnit" version="3.12.0" targetFramework="net48" />
+  <package id="NUnit3TestAdapter" version="3.16.1" targetFramework="net48" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Added the NUnit framework and NUnit test adapter. You can now run the unit tests inside of Visual Studios. You may need to install the NUnit test adapter extension for it to work inside your IDE. I'm unsure because I added that while trying to get this to work.
Issue #541 