### PR TITLE
Initial Module CI Check

### DIFF
--- a/.github/workflows/Modules.yml
+++ b/.github/workflows/Modules.yml
@@ -7,19 +7,34 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  buildApiSolution:
+    name: Build API
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
+    - name: Install Dependencies
+      run: dotnet restore api/api.sln
+    - name: Build Solution
+      run: dotnet build api/api.sln --configuration Release --no-restore
+    - name: Test Solution
+      run: dotnet test api/api.sln --no-restore --verbosity normal
+      
+  buildModuleSolution:
+    name: Build Modules
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - name: Install Dependencies
+      run: dotnet restore modules/modules.sln
+    - name: Build Solution
+      run: dotnet build modules/modules.sln --configuration Release --no-restore
+    - name: Test Solution
+      run: dotnet test modules/modules.sln --no-restore --verbosity normal

--- a/.github/workflows/Modules.yml
+++ b/.github/workflows/Modules.yml
@@ -1,0 +1,25 @@
+name: Modules
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/Modules.yml
+++ b/.github/workflows/Modules.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   buildApiSolution:
-    name: Build API
+    name: Build ModuleAPI
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -16,25 +16,15 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.101
-    - name: Install Dependencies
+    - name: Install API Dependencies
       run: dotnet restore api/api.sln
-    - name: Build Solution
+    - name: Build API Solution
       run: dotnet build api/api.sln --configuration Release --no-restore
-    - name: Test Solution
+    - name: Test API Solution
       run: dotnet test api/api.sln --no-restore --verbosity normal
-      
-  buildModuleSolution:
-    name: Build Modules
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.101
-    - name: Install Dependencies
+    - name: Install Module Dependencies
       run: dotnet restore modules/modules.sln
-    - name: Build Solution
+    - name: Build Module Solution
       run: dotnet build modules/modules.sln --configuration Release --no-restore
-    - name: Test Solution
+    - name: Test Module Solution
       run: dotnet test modules/modules.sln --no-restore --verbosity normal


### PR DESCRIPTION
Ok, so I had to chain the continuous integration steps for the module solution to the API build job, due to the fact that the API is a registered dependency to the module system. This could eventually be compartmentalized into multiple job checks once the API is published to NuGet. This also runs all the NUnit tests contained in the solution.