### PR TITLE
Create help panel with links to multiple Synthesis resources

### DIFF
--- a/modules/SynthesisCore/Assets/UI/uss/Entity.uss
+++ b/modules/SynthesisCore/Assets/UI/uss/Entity.uss
@@ -10,7 +10,7 @@
     padding-top: 8px;
     padding-bottom: 8px;
     flex-direction: row;
-    width: 480px;
+    width: 99%;
     margin-bottom: 10px;
 }
 

--- a/modules/SynthesisCore/Assets/UI/uss/HelpWindow.uss
+++ b/modules/SynthesisCore/Assets/UI/uss/HelpWindow.uss
@@ -1,0 +1,33 @@
+.help-button {
+    height: 30px;
+    width: 99%;
+    flex-direction: row;
+	text-align: middle-left;
+    background-color: rgba(237, 237, 237, 255);
+    border-top-left-radius: 5px;
+    border-bottom-left-radius: 5px;
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+	border-top-width: 0px;
+	border-bottom-width: 0px;
+	border-left-width: 0px;
+	border-right-width: 0px;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+}
+
+.vertical-divider {
+	width: 100%;
+	height: 2px;
+    background-color: rgb(128, 128, 128);
+    border-top-right-radius: 3px;
+    border-bottom-right-radius: 3px;
+    border-top-left-radius: 3px;
+    border-bottom-left-radius: 3px;
+	margin-top: 1px;
+	margin-bottom: 11px;
+	flex-shrink: 0;
+}

--- a/modules/SynthesisCore/Assets/UI/uss/Module.uss
+++ b/modules/SynthesisCore/Assets/UI/uss/Module.uss
@@ -7,7 +7,7 @@
 
 .module-container {
     height: 50px;
-    width: 100%;
+    width: 99%;
     flex-direction: row;
     background-color: rgba(237, 237, 237, 255);
     border-top-left-radius: 5px;

--- a/modules/SynthesisCore/Assets/UI/uss/Toolbar.uss
+++ b/modules/SynthesisCore/Assets/UI/uss/Toolbar.uss
@@ -54,6 +54,7 @@
     border-bottom-left-radius: 3px;
 	margin-left: 10px;
 	margin-right: 10px;
+	flex-shrink: 0;
 }
 
 .toolbar-button-container {
@@ -69,6 +70,7 @@
 	padding-right: 2px;
 	padding-top: 2px;
 	padding-bottom: 2px;
+	flex-shrink: 0;
 }
 
 .toolbar-button {
@@ -83,7 +85,7 @@
 	padding-right: 0px;
 	padding-top: 0px; 
 	padding-bottom: 0px;
-	margin-left: 0px;
+	margin-left: 5px;
 	margin-right: 0px;
 	margin-top: 0px; 
 	margin-bottom: 0px;

--- a/modules/SynthesisCore/Assets/UI/uss/Window.uss
+++ b/modules/SynthesisCore/Assets/UI/uss/Window.uss
@@ -122,6 +122,10 @@
     margin-right: 10px;
     margin-top: 10px;
     margin-bottom: 10px;
+    padding-left: 2px;
+    padding-right: 2px;
+    padding-top: 2px;
+    padding-bottom: 2px;
     flex-direction: column;
 }
 

--- a/modules/SynthesisCore/Assets/UI/uxml/HelpWindow.uxml
+++ b/modules/SynthesisCore/Assets/UI/uxml/HelpWindow.uxml
@@ -1,0 +1,22 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
+    <ui:VisualElement name="window" class="window" style="height: 400px; width: 300px;">
+        <Style src="/modules/synthesis_core/UI/uss/Window.uss" />
+        <Style src="/modules/synthesis_core/UI/uss/HelpWindow.uss" />
+        <ui:VisualElement name="header" class="window-header-container">
+            <ui:VisualElement name="icon" class="window-header-icon" style="background-image: url(&apos;/modules/synthesis_core/UI/images/help-icon.png&apos;);" />
+            <ui:Label text="Help" name="title" class="window-header-title" />
+        </ui:VisualElement>
+        <ui:VisualElement name="content" class="window-content">
+            <ui:ListView focusable="True" name="help-list" style="height: 300px;">
+				<ui:Button text="Getting Started" name="getting-started-button" class="help-button" />
+				<ui:Button text="Community Forum" name="community-forum-button" class="help-button" />
+				<ui:Button text="Submit an Idea" name="submit-an-idea-button" class="help-button" />
+				<ui:VisualElement class="vertical-divider" />
+				<ui:Button text="About" name="about-button" class="help-button" />
+			</ui:ListView>
+        </ui:VisualElement>
+        <ui:VisualElement name="bottom-button-panel" class="window-bottom-button-panel" style="flex-direction: row-reverse;">
+            <ui:Button text="Close" name="close-button" class="window-button" />
+        </ui:VisualElement>
+    </ui:VisualElement>
+</ui:UXML>

--- a/modules/SynthesisCore/Assets/metadata.xml
+++ b/modules/SynthesisCore/Assets/metadata.xml
@@ -17,6 +17,7 @@
 	<string>UI/uxml/Environments.uxml</string>
     <string>UI/uxml/General.uxml</string>
     <string>UI/uxml/Graphics.uxml</string>
+    <string>UI/uxml/HelpWindow.uxml</string>
     <string>UI/uxml/Modules.uxml</string>
     <string>UI/uxml/Module.uxml</string>
     <string>UI/uxml/Settings.uxml</string>
@@ -27,6 +28,7 @@
     <string>UI/uxml/ToolbarCategory.uxml</string>
     <string>UI/uxml/Dialog.uxml</string>
     <string>UI/uss/Entity.uss</string>
+    <string>UI/uss/HelpWindow.uss</string>
     <string>UI/uss/Modules.uss</string>
     <string>UI/uss/Module.uss</string>
     <string>UI/uss/Settings.uss</string>

--- a/modules/SynthesisCore/UI/EngineToolbar.cs
+++ b/modules/SynthesisCore/UI/EngineToolbar.cs
@@ -3,6 +3,7 @@ using SynthesisAPI.UIManager;
 using SynthesisAPI.UIManager.UIComponents;
 using SynthesisAPI.UIManager.VisualElements;
 using SynthesisAPI.Utilities;
+using SynthesisCore.UI.Windows;
 
 namespace SynthesisCore.UI
 {

--- a/modules/SynthesisCore/UI/Ui.cs
+++ b/modules/SynthesisCore/UI/Ui.cs
@@ -6,6 +6,7 @@ using SynthesisAPI.UIManager;
 using SynthesisAPI.UIManager.UIComponents;
 using SynthesisAPI.UIManager.VisualElements;
 using SynthesisAPI.Utilities;
+using SynthesisCore.UI.Windows;
 
 namespace SynthesisCore.UI
 {
@@ -34,6 +35,7 @@ namespace SynthesisCore.UI
             var settingsAsset = AssetManager.GetAsset<VisualElementAsset>("/modules/synthesis_core/UI/uxml/Settings.uxml");
             
             UIManager.AddPanel(new ModuleWindow().Panel);
+            UIManager.AddPanel(new HelpWindow().Panel);
 
             Panel settingsWindow = new Panel("Settings", settingsAsset,
                 element => Utilities.RegisterOKCloseButtons(element, "Settings"));
@@ -69,9 +71,6 @@ namespace SynthesisCore.UI
             
             Button settingsButton = (Button) UIManager.RootElement.Get("settings-button");
             settingsButton.Subscribe(x => UIManager.TogglePanel("Settings"));
-
-            Button helpButton = (Button) UIManager.RootElement.Get("help-button");
-            helpButton.Subscribe(x => System.Diagnostics.Process.Start("https://synthesis.autodesk.com"));
         }
 
         public override void OnPhysicsUpdate() { }

--- a/modules/SynthesisCore/UI/Windows/EntitiesWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/EntitiesWindow.cs
@@ -4,7 +4,7 @@ using SynthesisAPI.UIManager.UIComponents;
 using SynthesisAPI.UIManager.VisualElements;
 using SynthesisAPI.Utilities;
 
-namespace SynthesisCore.UI
+namespace SynthesisCore.UI.Windows
 {
     public class EntitiesWindow
     {

--- a/modules/SynthesisCore/UI/Windows/EntityItem.cs
+++ b/modules/SynthesisCore/UI/Windows/EntityItem.cs
@@ -2,7 +2,7 @@
 using SynthesisAPI.UIManager.VisualElements;
 using SynthesisAPI.Utilities;
 
-namespace SynthesisCore.UI
+namespace SynthesisCore.UI.Windows
 {
     public class EntityItem
     {

--- a/modules/SynthesisCore/UI/Windows/EnvironmentItem.cs
+++ b/modules/SynthesisCore/UI/Windows/EnvironmentItem.cs
@@ -2,7 +2,7 @@
 using SynthesisAPI.UIManager.VisualElements;
 using SynthesisAPI.Utilities;
 
-namespace SynthesisCore.UI
+namespace SynthesisCore.UI.Windows
 {
     public class EnvironmentItem
     {

--- a/modules/SynthesisCore/UI/Windows/EnvironmentsWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/EnvironmentsWindow.cs
@@ -4,7 +4,7 @@ using SynthesisAPI.UIManager.UIComponents;
 using SynthesisAPI.UIManager.VisualElements;
 using SynthesisAPI.Utilities;
 
-namespace SynthesisCore.UI
+namespace SynthesisCore.UI.Windows
 {
     public class EnvironmentsWindow
     {

--- a/modules/SynthesisCore/UI/Windows/HelpWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/HelpWindow.cs
@@ -1,0 +1,54 @@
+﻿using SynthesisAPI.AssetManager;
+using SynthesisAPI.UIManager;
+using SynthesisAPI.UIManager.UIComponents;
+using SynthesisAPI.UIManager.VisualElements;
+using SynthesisAPI.Utilities;
+
+namespace SynthesisCore.UI.Windows
+{
+    public class HelpWindow
+    {
+        public Panel Panel { get; }
+        private VisualElement Window;
+        private ListView HelpList;
+
+        public HelpWindow()
+        {
+            var helpWindowAsset = AssetManager.GetAsset<VisualElementAsset>("/modules/synthesis_core/UI/uxml/HelpWindow.uxml");
+            Panel = new Panel("Help", helpWindowAsset, OnWindowOpen);
+
+            Button helpButton = (Button)UIManager.RootElement.Get("help-button");
+            helpButton.Subscribe(x => UIManager.TogglePanel("Help"));
+        }
+
+        private void OnWindowOpen(VisualElement helpWindow)
+        {
+            Window = helpWindow;
+            HelpList = (ListView)Window.Get("module-list");
+
+            LoadWindowContents();
+            RegisterButtons();
+        }
+
+        private void LoadWindowContents()
+        {
+            Button gettingStartedButton = (Button)Window.Get("getting-started-button");
+            gettingStartedButton?.Subscribe(_ => System.Diagnostics.Process.Start("https://synthesis.autodesk.com/tutorials.html"));
+            
+            Button communityForumButton = (Button)Window.Get("community-forum-button");
+            communityForumButton?.Subscribe(_ => System.Diagnostics.Process.Start("https://forums.autodesk.com/t5/bxd-synthesis-forum/bd-p/99"));
+            
+            Button submitAnIdeaButton = (Button)Window.Get("submit-an-idea-button");
+            submitAnIdeaButton?.Subscribe(_ => System.Diagnostics.Process.Start("https://forums.autodesk.com/t5/bxd-synthesis-ideas/idb-p/104"));
+            
+            Button aboutButton = (Button)Window.Get("about-button");
+            aboutButton?.Subscribe(_ => System.Diagnostics.Process.Start("https://synthesis.autodesk.com/about.html"));
+        }
+
+        private void RegisterButtons()
+        {
+            Button closeButton = (Button)Window.Get("close-button");
+            closeButton?.Subscribe(x => UIManager.ClosePanel(Panel.Name));
+        }
+    }
+}

--- a/modules/SynthesisCore/UI/Windows/ModuleItem.cs
+++ b/modules/SynthesisCore/UI/Windows/ModuleItem.cs
@@ -2,7 +2,7 @@
 using SynthesisAPI.Modules;
 using SynthesisAPI.UIManager.VisualElements;
 
-namespace SynthesisCore.UI
+namespace SynthesisCore.UI.Windows
 {
     public class ModuleItem
     {

--- a/modules/SynthesisCore/UI/Windows/ModuleWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/ModuleWindow.cs
@@ -5,7 +5,7 @@ using SynthesisAPI.UIManager.UIComponents;
 using SynthesisAPI.UIManager.VisualElements;
 using SynthesisAPI.Utilities;
 
-namespace SynthesisCore.UI
+namespace SynthesisCore.UI.Windows
 {
     public class ModuleWindow
     {


### PR DESCRIPTION
I reworked the help button. Previously, it would just open our website, but now it opens the help panel, as shown below.

The help panel provides more direct avenues for users to get help and find information about Synthesis.

![image](https://user-images.githubusercontent.com/12960336/91212508-2d3ade80-e6c5-11ea-8d77-db54f3ada294.png)

The buttons in the above image open the following URLs:
[Getting Started](https://synthesis.autodesk.com/tutorials.html)
[Community Forum](https://forums.autodesk.com/t5/bxd-synthesis-forum/bd-p/99)
[Submit an Idea](https://forums.autodesk.com/t5/bxd-synthesis-ideas/idb-p/104)
[About](https://synthesis.autodesk.com/about.html)