### PR TITLE
Updated Exporter Default Values

### DIFF
--- a/exporter/SynthesisFusionGltfExporter/gltf/utils/FusionUtils.py
+++ b/exporter/SynthesisFusionGltfExporter/gltf/utils/FusionUtils.py
@@ -68,12 +68,8 @@ def getPBRSettingsFromAppearance(fusionAppearance: adsk.core.Appearance, exportW
     metallicFactor = 0.1 # never 0 and certainly never 1
     roughnessFactor = 0.1
 
-    try:
-        roughnessProp = props.itemById("surface_roughness")
-        roughnessFactor = roughnessProp.value
-    except: # This is a pass-through (usually bad practice but it looks like this might be a fusion bug of some kind)
-        pass 
-
+    roughnessProp = props.itemById("surface_roughness")
+    roughnessFactor = roughnessProp.value
     baseColor = None
 
     modelItem = props.itemById("interior_model")

--- a/exporter/SynthesisFusionGltfExporter/gltf/utils/FusionUtils.py
+++ b/exporter/SynthesisFusionGltfExporter/gltf/utils/FusionUtils.py
@@ -65,9 +65,14 @@ def getPBRSettingsFromAppearance(fusionAppearance: adsk.core.Appearance, exportW
 
     transparent = False
     emissiveColorFactor = None
-    metallicFactor = 0.0
-    roughnessProp = props.itemById("surface_roughness")
-    roughnessFactor = roughnessProp.value if roughnessProp is not None else 0.1
+    metallicFactor = 0.1 # never 0 and certainly never 1
+    roughnessFactor = 0.1
+
+    try:
+        roughnessProp = props.itemById("surface_roughness")
+        roughnessFactor = roughnessProp.value
+    except: # This is a pass-through (usually bad practice but it looks like this might be a fusion bug of some kind)
+        pass 
 
     baseColor = None
 
@@ -76,12 +81,13 @@ def getPBRSettingsFromAppearance(fusionAppearance: adsk.core.Appearance, exportW
         return None
     matModelType = modelItem.value
 
+
     if matModelType == 0:  # Opaque
         baseColor = props.itemById("opaque_albedo").value
         if props.itemById("opaque_emission").value:
             emissiveColorFactor = fusionColorToRGBAArray(props.itemById("opaque_luminance_modifier").value)[:3]
-    elif matModelType == 1:  # Metal
-        metallicFactor = 1.0
+    elif matModelType == 1:  # Metal - even metal should be set at most to about .2-.5
+        metallicFactor = 0.3
         baseColor = props.itemById("metal_f0").value
     elif matModelType == 2:  # Layered
         baseColor = props.itemById("layered_diffuse").value


### PR DESCRIPTION
### PR for Fusion 360 Exporter

#### Reason 

When I saw the default values for the materials in the exported GLTF models I noticed lots of reflectivity indicating incorrect default mappings for Metallic properties in a default normal material so I updated the the material properties to reflect more realistic values.

#### Changes 

See Below for references

#### ScreenShots
**OLD DEFAULT**

![old](https://user-images.githubusercontent.com/6741771/93694656-56337100-fac3-11ea-9af5-09553621258a.PNG)

**NEW DEFAULTS**

![new](https://user-images.githubusercontent.com/6741771/93694658-5f244280-fac3-11ea-9668-a3c533279bb1.PNG)

#### Notes
I also used the PR to investigate the exception that happens during the export but I could not find no good solution.

I tried isolating the section of the code throwing the runtime exception as well as attempted to force Pass Through exceptions but none of that worked and in general the exception happened after the current function had already been completed which indicates some strange malpractice to investigated later.

My entire IV Robot has an exception for each of the materials - Not sure TBD later 