### PR TITLE
Implemented Native File Explorer Calls

### DIFF
--- a/modules/SynthesisCore/Assets/UI/uxml/Entities.uxml
+++ b/modules/SynthesisCore/Assets/UI/uxml/Entities.uxml
@@ -10,7 +10,7 @@
         </ui:VisualElement>
         <ui:VisualElement name="bottom-button-panel" class="window-bottom-button-panel">
             <ui:VisualElement name="left" class="button-panel-left-container">
-                <ui:Button text="Import..." name="import-button" class="window-button" />
+                <ui:Button text="Open Files" name="import-button" class="window-button" />
             </ui:VisualElement>
             <ui:VisualElement name="right" class="button-panel-right-container">
                 <ui:Button text="OK" name="ok-button" class="window-button-blue" />

--- a/modules/SynthesisCore/Assets/UI/uxml/Environments.uxml
+++ b/modules/SynthesisCore/Assets/UI/uxml/Environments.uxml
@@ -10,7 +10,7 @@
         </ui:VisualElement>
         <ui:VisualElement name="bottom-button-panel" class="window-bottom-button-panel">
             <ui:VisualElement name="left" class="button-panel-left-container">
-                <ui:Button text="Import..." name="import-button" class="window-button" />
+                <ui:Button text="Open Files" name="import-button" class="window-button" />
             </ui:VisualElement>
             <ui:VisualElement name="right" class="button-panel-right-container">
                 <ui:Button text="OK" name="ok-button" class="window-button-blue" />

--- a/modules/SynthesisCore/Assets/UI/uxml/Modules.uxml
+++ b/modules/SynthesisCore/Assets/UI/uxml/Modules.uxml
@@ -11,7 +11,7 @@
         </ui:VisualElement>
         <ui:VisualElement name="bottom-button-panel" class="window-bottom-button-panel">
             <ui:VisualElement name="left" class="button-panel-left-container">
-                <ui:Button text="Import..." name="import-button" class="window-button" />
+                <ui:Button text="Open Files" name="import-button" class="window-button" />
             </ui:VisualElement>
             <ui:VisualElement name="right" class="button-panel-right-container">
                 <ui:Button text="OK" name="ok-button" class="window-button-blue" />

--- a/modules/SynthesisCore/UI/Windows/EntitiesWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/EntitiesWindow.cs
@@ -53,16 +53,13 @@ namespace SynthesisCore.UI.Windows
             {
                 try
                 {
+                    Directory.CreateDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Entities);
                     System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
                     {
                         FileName = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Entities,
                         UseShellExecute = true,
                         Verb = "open"
                     });
-                }
-                catch(System.ComponentModel.Win32Exception)
-                {
-                    Directory.CreateDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Entities);
                 }
                 catch(Exception)
                 {

--- a/modules/SynthesisCore/UI/Windows/EntitiesWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/EntitiesWindow.cs
@@ -46,17 +46,28 @@ namespace SynthesisCore.UI.Windows
 
         private void RegisterButtons()
         {
-            // TODO: save / apply changes implementation?
+            string Entities = "Robots";
 
             Button importButton = (Button) Window.Get("import-button");
             importButton?.Subscribe(x =>
             {
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+                try
                 {
-                    FileName = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Robots",
-                    UseShellExecute = true,
-                    Verb = "open"
-                });
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+                    {
+                        FileName = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Entities,
+                        UseShellExecute = true,
+                        Verb = "open"
+                    });
+                }
+                catch(System.ComponentModel.Win32Exception)
+                {
+                    Directory.CreateDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Entities);
+                }
+                catch(Exception)
+                {
+                    Logger.Log(Entities + " directory not found", LogLevel.Warning);
+                }
             });
             
             Button okButton = (Button) Window.Get("ok-button");

--- a/modules/SynthesisCore/UI/Windows/EntitiesWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/EntitiesWindow.cs
@@ -3,6 +3,8 @@ using SynthesisAPI.UIManager;
 using SynthesisAPI.UIManager.UIComponents;
 using SynthesisAPI.UIManager.VisualElements;
 using SynthesisAPI.Utilities;
+using System;
+using System.IO;
 
 namespace SynthesisCore.UI.Windows
 {
@@ -47,7 +49,15 @@ namespace SynthesisCore.UI.Windows
             // TODO: save / apply changes implementation?
 
             Button importButton = (Button) Window.Get("import-button");
-            importButton?.Subscribe(x => Logger.Log("TODO: Import"));
+            importButton?.Subscribe(x =>
+            {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+                {
+                    FileName = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Robots",
+                    UseShellExecute = true,
+                    Verb = "open"
+                });
+            });
             
             Button okButton = (Button) Window.Get("ok-button");
             okButton?.Subscribe(x => UIManager.ClosePanel(Panel.Name));

--- a/modules/SynthesisCore/UI/Windows/EnvironmentsWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/EnvironmentsWindow.cs
@@ -53,16 +53,13 @@ namespace SynthesisCore.UI.Windows
             {
                 try
                 {
+                    Directory.CreateDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Environments);
                     System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
                     {
                         FileName = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Environments,
                         UseShellExecute = true,
                         Verb = "open"
                     });
-                }
-                catch(System.ComponentModel.Win32Exception)
-                {
-                    Directory.CreateDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Environments);
                 }
                 catch(Exception)
                 {

--- a/modules/SynthesisCore/UI/Windows/EnvironmentsWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/EnvironmentsWindow.cs
@@ -46,17 +46,28 @@ namespace SynthesisCore.UI.Windows
 
         private void RegisterButtons()
         {
-            // TODO: save / apply changes implementation?
+            string Environments = "Environments";
 
             Button importButton = (Button) Window.Get("import-button");
             importButton?.Subscribe(x =>
             {
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+                try
                 {
-                    FileName = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Environments",
-                    UseShellExecute = true,
-                    Verb = "open"
-                });
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+                    {
+                        FileName = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Environments,
+                        UseShellExecute = true,
+                        Verb = "open"
+                    });
+                }
+                catch(System.ComponentModel.Win32Exception)
+                {
+                    Directory.CreateDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Environments);
+                }
+                catch(Exception)
+                {
+                    Logger.Log(Environments + " directory not found", LogLevel.Warning);
+                }
             });
             
             Button okButton = (Button) Window.Get("ok-button");

--- a/modules/SynthesisCore/UI/Windows/EnvironmentsWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/EnvironmentsWindow.cs
@@ -3,6 +3,8 @@ using SynthesisAPI.UIManager;
 using SynthesisAPI.UIManager.UIComponents;
 using SynthesisAPI.UIManager.VisualElements;
 using SynthesisAPI.Utilities;
+using System;
+using System.IO;
 
 namespace SynthesisCore.UI.Windows
 {
@@ -47,7 +49,15 @@ namespace SynthesisCore.UI.Windows
             // TODO: save / apply changes implementation?
 
             Button importButton = (Button) Window.Get("import-button");
-            importButton?.Subscribe(x => Logger.Log("TODO: Import"));
+            importButton?.Subscribe(x =>
+            {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+                {
+                    FileName = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Environments",
+                    UseShellExecute = true,
+                    Verb = "open"
+                });
+            });
             
             Button okButton = (Button) Window.Get("ok-button");
             okButton?.Subscribe(x => UIManager.ClosePanel(Panel.Name));

--- a/modules/SynthesisCore/UI/Windows/ModuleWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/ModuleWindow.cs
@@ -4,6 +4,8 @@ using SynthesisAPI.UIManager;
 using SynthesisAPI.UIManager.UIComponents;
 using SynthesisAPI.UIManager.VisualElements;
 using SynthesisAPI.Utilities;
+using System;
+using System.IO;
 
 namespace SynthesisCore.UI.Windows
 {
@@ -49,7 +51,15 @@ namespace SynthesisCore.UI.Windows
         {
             // TODO: save / apply changes implementation?
             Button importButton = (Button) Window.Get("import-button");
-            importButton?.Subscribe(x => Logger.Log("TODO: Module import"));
+            importButton?.Subscribe(x =>
+            {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+                {
+                    FileName = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Modules",
+                    UseShellExecute = true,
+                    Verb = "open"
+                });
+            });
             
             Button okButton = (Button) Window.Get("ok-button");
             okButton?.Subscribe(x => UIManager.ClosePanel(Panel.Name));

--- a/modules/SynthesisCore/UI/Windows/ModuleWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/ModuleWindow.cs
@@ -55,16 +55,13 @@ namespace SynthesisCore.UI.Windows
             {
                 try
                 {
+                    Directory.CreateDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Modules);
                     System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
                     {
                         FileName = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Modules,
                         UseShellExecute = true,
                         Verb = "open"
                     });
-                }
-                catch(System.ComponentModel.Win32Exception)
-                {
-                    Directory.CreateDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Modules);
                 }
                 catch(Exception)
                 {

--- a/modules/SynthesisCore/UI/Windows/ModuleWindow.cs
+++ b/modules/SynthesisCore/UI/Windows/ModuleWindow.cs
@@ -49,16 +49,27 @@ namespace SynthesisCore.UI.Windows
 
         private void RegisterButtons()
         {
-            // TODO: save / apply changes implementation?
+            string Modules = "Modules";
             Button importButton = (Button) Window.Get("import-button");
             importButton?.Subscribe(x =>
             {
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+                try
                 {
-                    FileName = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + "Modules",
-                    UseShellExecute = true,
-                    Verb = "open"
-                });
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+                    {
+                        FileName = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Modules,
+                        UseShellExecute = true,
+                        Verb = "open"
+                    });
+                }
+                catch(System.ComponentModel.Win32Exception)
+                {
+                    Directory.CreateDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + Path.DirectorySeparatorChar + "Autodesk" + Path.DirectorySeparatorChar + "Synthesis" + Path.DirectorySeparatorChar + Modules);
+                }
+                catch(Exception)
+                {
+                    Logger.Log(Modules + " directory not found", LogLevel.Warning);
+                }
             });
             
             Button okButton = (Button) Window.Get("ok-button");


### PR DESCRIPTION
Replaces the `Import...` button on all forms with an `Open Files` button which opens the operating system's native file browser directly to the specified %appdata% directory, a.k.a. `Environment.SpecialFolder.ApplicationData`. 

This simply passes a shell execution argument to the .NET `Diagnostics.Process.Start` library, specifying `open` as the verb parameter and allowing for cross-platform support. Closes #602 

UXML Forms Affected:
- Modules
- Entities
- Environments