### PR TITLE
Add build documentation for Synthesis

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -1,8 +1,29 @@
 # Engine
 
-## Building 
+## Setup Instructions
 
-*Note*:
-This is under construction for a new build system, there is no expectation or guarantee that this will build without following a rigid build structure that we will detail in the future and as of right now it is uncertain if it will remain the same.
+### Requirements
+- Unity Hub with Unity 2019.4.0f1 (Required)
+- Visual Studio 2019 (Recommended)
 
-Simply opening the file in unity will not successfully build this project
+### Downloading Synthesis
+1. Use git to clone Synthesis from our repository.
+
+### Compiling the Synthesis API
+1. Navigate to your local copy of Synthesis, and enter the `api` folder.
+2. Open `api.sln` in Visual Studio.
+3. Build the solution from the Visual Studio toolbar.
+
+### Setting Up Modules
+1. Navigate to your local copy of Synthesis, and enter the `modules` folder.
+2. Open `modules.sln` in Visual Studio.
+3. Build the solution from the Visual Studio toolbar.
+4. Set up the modules by running one of the following scripts:
+	- For Windows users, run `update_modules.ps1` using PowerShell.
+	- Linux and Mac scripts are under construction.
+
+### Setting Up the Unity Project
+1. Open Unity Hub, click the Add button, and navigate to your local copy of Synthesis. Enter the `engine` folder, and click "Select Folder."
+2. Open the engine project that has been added to your Unity Hub.
+3. From the Project Window within the Unity Editor, navigate to `Assets/Scenes` and open the `MainSim` scene.
+4. Play the scene by hitting the play button at the top of the Editor. 

--- a/modules/update_modules.ps1
+++ b/modules/update_modules.ps1
@@ -1,0 +1,19 @@
+$MODULES_DIR = $env:APPDATA + "\Autodesk\Synthesis\modules"
+$SYNTHESIS_DIR = (Get-Item .).FullName
+
+New-Item $MODULES_DIR -ItemType Directory -ErrorAction SilentlyContinue
+CD $MODULES_DIR
+
+New-Item Controller -ItemType Directory -ErrorAction SilentlyContinue
+cp -r $SYNTHESIS_DIR/Controller/Assets/* Controller/ -Force
+cp -r $SYNTHESIS_DIR/Controller/bin/Debug/netstandard2.0/Controller.dll Controller/ -Force -ErrorAction SilentlyContinue
+
+New-Item SynthesisCore -ItemType Directory -ErrorAction SilentlyContinue
+cp -r $SYNTHESIS_DIR/SynthesisCore/Assets/* SynthesisCore/ -Force -ErrorAction SilentlyContinue
+cp -r $SYNTHESIS_DIR/SynthesisCore/bin/Debug/netstandard2.0/SynthesisCore.dll SynthesisCore/ -Force -ErrorAction SilentlyContinue
+
+rm Controller.zip -Force -ErrorAction SilentlyContinue
+rm SynthesisCore.zip -Force -ErrorAction SilentlyContinue
+
+zip -r Controller.zip Controller
+zip -r SynthesisCore.zip SynthesisCore

--- a/modules/update_modules.sh
+++ b/modules/update_modules.sh
@@ -1,0 +1,22 @@
+#/bin/bash -e
+
+# TODO This is a work in progress
+
+MODULES_DIR=~/.config/autodesk/synthesis/modules
+SYNTHESIS_DIR=$(pwd)
+
+mkdir -p $MODULES_DIR
+cd $MODULES_DIR
+
+mkdir -p Controller
+cp -r $SYNTHESIS_DIR/Controller/Assets/* Controller/
+cp $SYNTHESIS_DIR/Controller/bin/Debug/netstandard2.0/Controller.dll Controller/
+
+mkdir -p SynthesisCore
+cp -r $SYNTHESIS_DIR/SynthesisCore/Assets/* SynthesisCore/
+cp $SYNTHESIS_DIR/SynthesisCore/bin/Debug/netstandard2.0/SynthesisCore.dll SynthesisCore/
+
+rm -f Controller.zip SynthesisCore.zip
+
+zip -r Controller.zip Controller
+zip -r SynthesisCore.zip SynthesisCore


### PR DESCRIPTION
Update the engine README to describe how to download Synthesis, build and setup the API and modules, and run the engine with the Controller and SynthesisEngine modules. I also added a PowerShell script that will automatically update the user's modules in their AppData folder. I haven't been able to test the Linux script yet, but I appropriately labeled it as a work in progress. 