### PR TITLE
Changed default export path

### DIFF
--- a/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
+++ b/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
@@ -3,6 +3,7 @@
 """
 
 from enum import Enum
+import platform
 from ..general_imports import *
 from ..configure import NOTIFIED, write_configuration
 from ..Analytics.alert import showAnalyticsAlert
@@ -934,6 +935,7 @@ class ConfigureCommandCreatedHandler(adsk.core.CommandCreatedEventHandler):
             """
             Instantiating all the event handlers
             """
+
             onExecute = ConfigureCommandExecuteHandler(
                 json.dumps(
                     previous, default=lambda o: o.__dict__, sort_keys=True, indent=1
@@ -1172,12 +1174,31 @@ class ConfigureCommandExecuteHandler(adsk.core.CommandEventHandler):
             # defaultPath = self.fp
             # defaultPath = os.getenv()
 
-            if mode == 5:
-                savepath = FileDialogConfig.SaveFileDialog(
-                    defaultPath=self.fp, ext="Synthesis File (*.synth)"
-                )
+            # if mode == 5:
+            #     savepath = FileDialogConfig.SaveFileDialog(
+            #         defaultPath=self.fp, ext="Synthesis File (*.synth)"
+            #     )
+            # else:
+            #     savepath = FileDialogConfig.SaveFileDialog(defaultPath=self.fp)
+
+            processedFileName = gm.app.activeDocument.name.replace(' ', '_')
+            dropdownExportMode = INPUTS_ROOT.itemById("mode")
+            if dropdownExportMode.selectedItem.index == 0:
+                isRobot = True
+            elif dropdownExportMode.selectedItem.index == 1:
+                isRobot = False
+
+            if platform.system() == "Windows":
+                if isRobot:
+                    savepath = os.getenv("APPDATA") + "\\Autodesk\\Synthesis\\Mira\\" + processedFileName + ".mira"
+                else:
+                    savepath = os.getenv("APPDATA") + "\\Autodesk\\Synthesis\\Mira\\Fields\\" + processedFileName + ".mira"
             else:
-                savepath = FileDialogConfig.SaveFileDialog(defaultPath=self.fp)
+                if isRobot:
+                    savepath = "~/Applications/Autodesk/Synthesis/Mira/" + processedFileName + ".mira"
+                else:
+                    savepath = "~/Applications/Autodesk/Synthesis/Mira/Fields" + processedFileName + ".mira"
+
 
             if savepath == False:
                 # save was canceled


### PR DESCRIPTION
## Exporter
I removed the file browser and defaulted the location to where the files are exported to.

For Windows, it exports to `%AppData%\Autodesk\Synthesis\Mira[\Fields]`
For Mac, it exports to `~/Applications/Autodesk/Synthesis/Mira[/Fields]`

### Issues
I have no idea if this works for Mac, or if that's actually the correct location (Though I'm pretty sure it is).