### PR TITLE
Fixed swerve turning backwards

### DIFF
--- a/engine/Assets/Scripts/Behaviors/SwerveDriveBehaviour.cs
+++ b/engine/Assets/Scripts/Behaviors/SwerveDriveBehaviour.cs
@@ -34,7 +34,6 @@ namespace Synthesis {
             _robot = robot;
             _fieldForward = Vector3.forward;
 
-
             _moduleDrivers.ForEach(x => {
 
                 if (x.azimuth.IsReserved) {

--- a/engine/Assets/Scripts/Behaviors/SwerveDriveBehaviour.cs
+++ b/engine/Assets/Scripts/Behaviors/SwerveDriveBehaviour.cs
@@ -34,6 +34,7 @@ namespace Synthesis {
             _robot = robot;
             _fieldForward = Vector3.forward;
 
+
             _moduleDrivers.ForEach(x => {
 
                 if (x.azimuth.IsReserved) {
@@ -99,7 +100,7 @@ namespace Synthesis {
         }
 
         public override void Update() {
-            
+
             if (Mathf.Abs(InputManager.MappedValueInputs[RESET_FIELD_FORWARD].Value) > 0.5f)
                 _fieldForward = _robot.GroundedNode.transform.forward;
 
@@ -117,7 +118,7 @@ namespace Synthesis {
 
             float forward = Mathf.Abs(forwardInput.Value) - Mathf.Abs(backwardInput.Value);
             float strafe = Mathf.Abs(rightInput.Value) - Mathf.Abs(leftInput.Value);
-            float turn = Mathf.Abs(turnLeftInput.Value) - Mathf.Abs(turnRightInput.Value);
+            float turn = Mathf.Abs(turnRightInput.Value) - Mathf.Abs(turnLeftInput.Value);
             
             forward = Diff(forward, 0f, 0.1f) ? 0f : forward;
             strafe = Diff(strafe, 0f, 0.1f) ? 0f : strafe;

--- a/engine/Assets/Scripts/SimObjects/RobotSimObject.cs
+++ b/engine/Assets/Scripts/SimObjects/RobotSimObject.cs
@@ -525,6 +525,9 @@ public class RobotSimObject : SimObject, IPhysicsOverridable, IGizmo {
 
     public bool ConfigureSwerveDrivetrain() {
 
+        // Sets wheels rotating forward
+        GetLeftRightWheels();
+
         (RotationalDriver azimuth, WheelDriver driver)[] modules;
 
         try {


### PR DESCRIPTION
### Description
The swerve robot would either have correct translation or correct rotation at seemingly random upon spawning. This code ensures forward/right is positive for each forward, strafe, and turn to get the three to all be correct/incorrect together. To make sure they are always correct, it also resets left and right wheels upon swerve configuration.

### Objectives
- [x] Fix bug that made swerve robots drive and turn in the opposite direction

### Testing Done
- Drove (both translation and rotation) swerve robots on different runs, with multiple robots, and respawning after removal

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1503)
