### PR TITLE
README CI Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Synthesis: An Autodesk Technology](/engine/Assets/Resources/Branding/Synthesis/Synthesis-An-Autodesk-Technology-2023-lockup-Blk-OL-No-Year-stacked.png#gh-light-mode-only)
 ![Synthesis: An Autodesk Technology](/engine/Assets/Resources/Branding/Synthesis/Synthesis-An-Autodesk-Technology-2023-lockup-Wht-OL-No-Year-stacked.png#gh-dark-mode-only)
-![API](https://github.com/Autodesk/synthesis/workflows/Modules/badge.svg)
+[![Engine](https://github.com/Autodesk/synthesis/actions/workflows/Engine.yml/badge.svg?branch=master)](https://github.com/Autodesk/synthesis/actions/workflows/Engine.yml)
+[![API](https://github.com/Autodesk/synthesis/actions/workflows/API.yml/badge.svg?branch=master)](https://github.com/Autodesk/synthesis/actions/workflows/API.yml)
 
 Synthesis is a robotics simulator designed to help FIRST Robotics teams design, strategize, test, and practice. Teams can import their own robot and field designs or use preexisting ones into the simulator for a variety of uses, including:
 * Testing robot designs

--- a/api/README.md
+++ b/api/README.md
@@ -1,4 +1,6 @@
 # Synthesis API
+[![API](https://github.com/Autodesk/synthesis/actions/workflows/API.yml/badge.svg?branch=master)](https://github.com/Autodesk/synthesis/actions/workflows/API.yml)
+
 The Synthesis API contains parts of Synthesis that can remain mostly Unity abnostic. The end goal of this API is to be used to extend Synthesis'
 functionality and reused as throughout future iterations of Synthesis no matter where it may go.
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,4 +1,6 @@
 # Synthesis Engine
+[![Engine](https://github.com/Autodesk/synthesis/actions/workflows/Engine.yml/badge.svg?branch=master)](https://github.com/Autodesk/synthesis/actions/workflows/Engine.yml)
+
 This is the main Simulator aspect to Synthesis. We take the robots and fields that have been exported using our exporter, and simulate them with realtime physics within Unity.
 
 # Building


### PR DESCRIPTION
### Description
Add badges to display result of GitHub actions in READMEs

### Objectives
- [x] Add Engine and API action badges to [root README](/README.md)
- [x] Add Engine action badge to [Engine README](/engine/README.md)
- [x] Add API action badge to [API README](/api/README.md)

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1545)
