### PR TITLE
Assign a robots parent object to the correct layer

### DIFF
--- a/engine/Assets/Scripts/Importer/MirabufLive.cs
+++ b/engine/Assets/Scripts/Importer/MirabufLive.cs
@@ -120,6 +120,8 @@ namespace Synthesis.Import {
 		        if (dynamicLayers.Count == 0)
 			        throw new Exception("No more dynamic layers");
 		        dynamicLayer = dynamicLayers.Dequeue();
+		        
+		        assemblyContainer.layer = dynamicLayer;
 		        assemblyContainer.AddComponent<DynamicLayerReserver>();
 	        }
 
@@ -154,6 +156,7 @@ namespace Synthesis.Import {
 
 				#endregion
 
+				
 				if (!MiraAssembly.Dynamic && !isGamepiece) {
 					groupObject.transform.GetComponentsInChildren<UnityEngine.Transform>().ForEach(x => x.gameObject.layer = FIELD_LAYER);
 				} else if (MiraAssembly.Dynamic && physics) {


### PR DESCRIPTION
### Description
Fixed a bug where an error would occur when removing a robot then spawning another one. It was caused by the wrong physics layer being added to the dynamic layers queue when a robot was removed. I fixed it by assigning a robots parent object to the correct physics layer when it is spawned.
### Objectives

- [x] Fix issue

### Testing Done
- Tested a lot of different combinations of spawning and removing robots
[JIRA Issue](https://jira.autodesk.com/browse/AARD-XXXX)
