### PR TITLE
API Nullable Fixes

### DIFF
--- a/api/Api/Api.csproj
+++ b/api/Api/Api.csproj
@@ -28,7 +28,9 @@ For support contact frc@autodesk.com</PackageReleaseNotes>
         <NeutralLanguage>en-US</NeutralLanguage>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
+
 
     <ItemGroup>
 

--- a/api/Api/Api.csproj
+++ b/api/Api/Api.csproj
@@ -28,7 +28,7 @@ For support contact frc@autodesk.com</PackageReleaseNotes>
         <NeutralLanguage>en-US</NeutralLanguage>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <Nullable>enable</Nullable>
+        <Nullable>disable</Nullable>
     </PropertyGroup>
 
 

--- a/api/Api/AssetManager/Asset.cs
+++ b/api/Api/AssetManager/Asset.cs
@@ -2,6 +2,8 @@
 using SynthesisAPI.VirtualFileSystem;
 using Directory = SynthesisAPI.VirtualFileSystem.Directory;
 
+#nullable enable
+
 namespace SynthesisAPI.AssetManager
 {
     /// <summary>

--- a/api/Api/AssetManager/Asset.cs
+++ b/api/Api/AssetManager/Asset.cs
@@ -25,17 +25,17 @@ namespace SynthesisAPI.AssetManager
 
         public string Name => ((IEntry)this).Name;
         public Permissions Permissions => ((IEntry)this).Permissions;
-        public Directory Parent => ((IEntry)this).Parent;
+        public Directory? Parent => ((IEntry)this).Parent;
 
         public string SourcePath { get; private set; } = "";
 
         private string _name { get; set; } = "";
         private Permissions _permissions { get; set; }
-        private Directory _parent { get; set; }
+        private Directory? _parent { get; set; }
 
         string IEntry.Name { get => _name; set => _name = value; }
         Permissions IEntry.Permissions { get => _permissions; set => _permissions = value; }
-        Directory IEntry.Parent { get => _parent; set => _parent = value; }
+        Directory? IEntry.Parent { get => _parent; set => _parent = value; }
 
         [ExposedApi]
         public virtual void Delete()

--- a/api/Api/AssetManager/AssetManager.cs
+++ b/api/Api/AssetManager/AssetManager.cs
@@ -491,6 +491,10 @@ namespace SynthesisAPI.AssetManager
 
                 if (lazyImport)
                 {
+                    if (sourceStream == null) {
+                        // I have no clue if this is true but apparently so.
+                        throw new Exception("Cannot load a lazy asset without a source stream.");
+                    }
                     LazyAsset lazyAsset = new LazyAsset(newAsset, sourceStream, targetPath);
                     return (Asset?)FileSystem.AddEntry(targetPath, lazyAsset.Load(new byte[0]));
                 }

--- a/api/Api/AssetManager/AudioClipAsset.cs
+++ b/api/Api/AssetManager/AudioClipAsset.cs
@@ -1,8 +1,5 @@
 ﻿using SynthesisAPI.VirtualFileSystem;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -10,9 +7,10 @@ namespace SynthesisAPI.AssetManager
 {
     public class AudioClipAsset : Asset
     {
-        private AudioClip? _clip;
+        private AudioClip _clip;
 
-        internal AudioClip? GetClip() => _clip;
+        // this should always return a clip but it's up to the user to decide if it's valid
+        internal AudioClip GetClip() => _clip;
 
         public AudioClipAsset(string name, Permissions perm, string sourcePath)
         {

--- a/api/Api/AssetManager/BinaryAsset.cs
+++ b/api/Api/AssetManager/BinaryAsset.cs
@@ -13,10 +13,15 @@ namespace SynthesisAPI.AssetManager
     /// </summary>
     public class BinaryAsset : Asset
     {
+        private readonly Stream _stream;
+        private SharedBinaryStream SharedStream { get; set; } = null!;
+        private readonly ReaderWriterLockSlim _rwLock;
+
         public BinaryAsset(string name, Permissions perm, string sourcePath)
         {
             Init(name, perm, sourcePath);
             _rwLock = new ReaderWriterLockSlim();
+            _stream = new MemoryStream();
         }
 
         [ExposedApi]
@@ -38,7 +43,6 @@ namespace SynthesisAPI.AssetManager
 
         public override IEntry Load(byte[] data)
         {
-            _stream = new MemoryStream();
             _stream.Write(data, 0, data.Length);
             _stream.Position = 0;
             SharedStream = new SharedBinaryStream(_stream, _rwLock);
@@ -64,9 +68,5 @@ namespace SynthesisAPI.AssetManager
             base.DeleteInner();
             _stream.Close();
         }
-
-        private Stream _stream;
-        private SharedBinaryStream SharedStream { get; set; } = null!;
-        private readonly ReaderWriterLockSlim _rwLock;
     }
 }

--- a/api/Api/AssetManager/JsonAsset.cs
+++ b/api/Api/AssetManager/JsonAsset.cs
@@ -42,6 +42,11 @@ namespace SynthesisAPI.AssetManager
             {
                 SharedStream.Seek(returnPosition.Value);
             }
+
+            if (obj == null) {
+                throw new System.Exception("Failed to deserialize a Json object!");
+            }
+
             return obj;
         }
 

--- a/api/Api/AssetManager/LazyAsset.cs
+++ b/api/Api/AssetManager/LazyAsset.cs
@@ -8,15 +8,15 @@ namespace SynthesisAPI.AssetManager
 {
     public class LazyAsset : Asset
     {
-        private Asset inner;
-        private Stream _sourceStream;
-        private string _targetPath;
+        private readonly Asset inner;
+        private readonly Stream _sourceStream;
+        private readonly string _targetPath;
 
         public LazyAsset(Asset asset, Stream sourceStream, string targetPath)
         {
             Init(asset.Name, asset.Permissions, asset.SourcePath);
             inner = asset;
-            _sourceStream = sourceStream;
+            _sourceStream = sourceStream; // this can be null technically?
             _targetPath = targetPath;
         }
 

--- a/api/Api/AssetManager/SpriteAsset.cs
+++ b/api/Api/AssetManager/SpriteAsset.cs
@@ -4,6 +4,8 @@ using SynthesisAPI.VirtualFileSystem;
 using System;
 using UnityEngine;
 
+#nullable enable
+
 namespace SynthesisAPI.AssetManager
 {
     /// <summary>

--- a/api/Api/AssetManager/SpriteAsset.cs
+++ b/api/Api/AssetManager/SpriteAsset.cs
@@ -13,6 +13,8 @@ namespace SynthesisAPI.AssetManager
     /// </summary>
     public class SpriteAsset : Asset
     {
+        internal Sprite? Sprite { get; private set; }
+
         public SpriteAsset(string name, Permissions perm, string sourcePath)
         {
             Init(name, perm, sourcePath);
@@ -27,7 +29,7 @@ namespace SynthesisAPI.AssetManager
                 throw new Exception("Failed to load image");
             }
 
-            Sprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), new UnityEngine.Vector2(.5f, .5f));
+            Sprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), new Vector2(.5f, .5f));
 
             return this;
         }
@@ -43,7 +45,5 @@ namespace SynthesisAPI.AssetManager
         {
             Sprite = Sprite.Create(texture, new Rect(MathUtil.MapVector2D(position), MathUtil.MapVector2D(size)), MathUtil.MapVector2D(pivot));
         }
-
-        internal Sprite Sprite { get; private set; }
     }
 }

--- a/api/Api/AssetManager/TextAsset.cs
+++ b/api/Api/AssetManager/TextAsset.cs
@@ -12,6 +12,12 @@ namespace SynthesisAPI.AssetManager
     /// </summary>
     public class TextAsset : Asset
     {
+        // please stop putting private members at the bottom.
+        // we get it. c++ is cool. But it's a mess and not effective unless there are headers.
+        private readonly Stream _stream;
+        protected SharedTextStream SharedStream { get; set; }
+        private readonly ReaderWriterLockSlim _rwLock;
+
         public enum WriteMode
         {
             Append,
@@ -21,8 +27,8 @@ namespace SynthesisAPI.AssetManager
         public TextAsset(string name, Permissions perm, string sourcePath)
         {
             Init(name, perm, sourcePath);
-
             _rwLock = new ReaderWriterLockSlim();
+            _stream = new MemoryStream();
             SharedStream = new SharedTextStream(new MemoryStream(), _rwLock);
         }
 
@@ -45,7 +51,6 @@ namespace SynthesisAPI.AssetManager
 
         public override IEntry Load(byte[] data)
         {
-            _stream = new MemoryStream();
             _stream.Write(data, 0, data.Length);
             _stream.Position = 0;
             SharedStream = new SharedTextStream(_stream, _rwLock)!;
@@ -71,9 +76,5 @@ namespace SynthesisAPI.AssetManager
             base.DeleteInner();
             _stream.Close();
         }
-
-        private Stream _stream;
-        protected SharedTextStream SharedStream { get; set; }
-        private readonly ReaderWriterLockSlim _rwLock;
     }
 }

--- a/api/Api/AssetManager/UssAsset.cs
+++ b/api/Api/AssetManager/UssAsset.cs
@@ -4,6 +4,8 @@ using SynthesisAPI.UIManager;
 using SynthesisAPI.Utilities;
 using SynthesisAPI.VirtualFileSystem;
 
+#nullable enable
+
 namespace SynthesisAPI.AssetManager
 {
     /// <summary>

--- a/api/Api/AssetManager/UssAsset.cs
+++ b/api/Api/AssetManager/UssAsset.cs
@@ -11,7 +11,7 @@ namespace SynthesisAPI.AssetManager
     /// </summary>
     public class UssAsset : Asset
     {
-        public StyleSheet StyleSheet { get; private set; }
+        public StyleSheet? StyleSheet { get; private set; }
         
         public UssAsset(string name, Permissions perm, string sourcePath)
         {

--- a/api/Api/AssetManager/VisualElementAsset.cs
+++ b/api/Api/AssetManager/VisualElementAsset.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System.Xml;
-using SynthesisAPI.AssetManager;
 using SynthesisAPI.UIManager;
 using SynthesisAPI.UIManager.VisualElements;
 using SynthesisAPI.VirtualFileSystem;
@@ -9,18 +8,18 @@ namespace SynthesisAPI.AssetManager
 {
     public class VisualElementAsset: Asset
     {
-        private XmlDocument? _document;
+        private XmlDocument _document;
 
         public VisualElementAsset(string name, Permissions perms, string sourcePath)
         {
             Init(name, perms, sourcePath);
+            _document = new XmlDocument();
         }
 
         public VisualElement GetElement(string name) => UIParser.CreateVisualElement(name, _document);
 
         public override IEntry Load(byte[] data)
         {
-            _document = new XmlDocument();
             MemoryStream stream = new MemoryStream();
             stream.Write(data, 0, data.Length);
             stream.Position = 0;

--- a/api/Api/EnvironmentManager/Components/AudioSource.cs
+++ b/api/Api/EnvironmentManager/Components/AudioSource.cs
@@ -1,8 +1,5 @@
 ﻿using SynthesisAPI.AssetManager;
-using SynthesisAPI.Modules.Attributes;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace SynthesisAPI.EnvironmentManager.Components
 {

--- a/api/Api/EnvironmentManager/Components/FixedJoint.cs
+++ b/api/Api/EnvironmentManager/Components/FixedJoint.cs
@@ -1,19 +1,21 @@
-﻿using SynthesisAPI.Modules.Attributes;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System.Text;
 using MathNet.Spatial.Euclidean;
 
 namespace SynthesisAPI.EnvironmentManager.Components
 {
     public class FixedJoint : IJoint
     {
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
-        protected void OnPropertyChanged([CallerMemberName] string name = null)
+        protected void OnPropertyChanged([CallerMemberName] string? name = null)
         {
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
 

--- a/api/Api/EnvironmentManager/Components/FixedJoint.cs
+++ b/api/Api/EnvironmentManager/Components/FixedJoint.cs
@@ -3,6 +3,8 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using MathNet.Spatial.Euclidean;
 
+#nullable enable
+
 namespace SynthesisAPI.EnvironmentManager.Components
 {
     public class FixedJoint : IJoint
@@ -37,16 +39,16 @@ namespace SynthesisAPI.EnvironmentManager.Components
                 OnPropertyChanged();
             }
         }
-        internal Rigidbody connectedParent = null;
-        public Rigidbody ConnectedParent {
+        internal Rigidbody? connectedParent = null;
+        public Rigidbody? ConnectedParent {
             get => connectedParent;
             set {
                 connectedParent = value;
                 OnPropertyChanged();
             }
         }
-        internal Rigidbody connectedChild = null;
-        public Rigidbody ConnectedChild {
+        internal Rigidbody? connectedChild = null;
+        public Rigidbody? ConnectedChild {
             get => connectedChild;
             set {
                 connectedChild = value;

--- a/api/Api/EnvironmentManager/Components/HingeJoint.cs
+++ b/api/Api/EnvironmentManager/Components/HingeJoint.cs
@@ -1,10 +1,6 @@
 ﻿using MathNet.Spatial.Euclidean;
-using SynthesisAPI.Modules.Attributes;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace SynthesisAPI.EnvironmentManager.Components
 {
@@ -45,16 +41,16 @@ namespace SynthesisAPI.EnvironmentManager.Components
                 OnPropertyChanged();
             }
         }
-        internal Rigidbody connectedParent = null;
-        public Rigidbody ConnectedParent {
+        internal Rigidbody? connectedParent = null;
+        public Rigidbody? ConnectedParent {
             get => connectedParent;
             set {
                 connectedParent = value;
                 OnPropertyChanged();
             }
         }
-        internal Rigidbody connectedChild = null;
-        public Rigidbody ConnectedChild {
+        internal Rigidbody? connectedChild = null;
+        public Rigidbody? ConnectedChild {
             get => connectedChild;
             set {
                 connectedChild = value;
@@ -110,9 +106,9 @@ namespace SynthesisAPI.EnvironmentManager.Components
             }
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
-        protected void OnPropertyChanged([CallerMemberName] string name = null)
+        protected void OnPropertyChanged([CallerMemberName] string? name = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }

--- a/api/Api/EnvironmentManager/Components/HingeJoint.cs
+++ b/api/Api/EnvironmentManager/Components/HingeJoint.cs
@@ -2,6 +2,8 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
+#nullable enable
+
 namespace SynthesisAPI.EnvironmentManager.Components
 {
     public class HingeJoint : IJoint

--- a/api/Api/EnvironmentManager/Components/Mesh.cs
+++ b/api/Api/EnvironmentManager/Components/Mesh.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using MathNet.Spatial.Euclidean;
-using SynthesisAPI.Modules.Attributes;
 using SynthesisAPI.Utilities;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -85,8 +84,9 @@ namespace SynthesisAPI.EnvironmentManager.Components
 		public bool Changed { get; private set; }
 		internal void ProcessedChanges() => Changed = false;
 
-		public event PropertyChangedEventHandler PropertyChanged;
-        protected void OnPropertyChanged([CallerMemberName] string name = null)
+		public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string? name = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }

--- a/api/Api/EnvironmentManager/Components/Mesh.cs
+++ b/api/Api/EnvironmentManager/Components/Mesh.cs
@@ -4,6 +4,8 @@ using SynthesisAPI.Utilities;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
+#nullable enable
+
 namespace SynthesisAPI.EnvironmentManager.Components
 {
 	public class Mesh : Component

--- a/api/Api/EnvironmentManager/Components/MeshCollider.cs
+++ b/api/Api/EnvironmentManager/Components/MeshCollider.cs
@@ -3,13 +3,15 @@ using SynthesisAPI.Utilities;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
+#nullable enable
+
 namespace SynthesisAPI.EnvironmentManager.Components
 {
     public class MeshCollider : Component
     {
         #region Properties
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         public class Collision
         {
@@ -26,9 +28,9 @@ namespace SynthesisAPI.EnvironmentManager.Components
 
         public delegate void CollisionHandler(Collision collision);
 
-        public CollisionHandler OnCollisionEnter;
-        public CollisionHandler OnCollisionStay;
-        public CollisionHandler OnCollisionExit;
+        public CollisionHandler? OnCollisionEnter;
+        public CollisionHandler? OnCollisionStay;
+        public CollisionHandler? OnCollisionExit;
 
         internal bool convex = true;
         /// <summary>
@@ -47,8 +49,8 @@ namespace SynthesisAPI.EnvironmentManager.Components
                 OnPropertyChanged();
             }
         }
-        internal Mesh sharedMesh = null; // If mesh is null, it will attempt to grab from the MeshAdapter
-        public Mesh SharedMesh {
+        internal Mesh? sharedMesh = null; // If mesh is null, it will attempt to grab from the MeshAdapter
+        public Mesh? SharedMesh {
             get => sharedMesh;
             set {
                 sharedMesh = value;

--- a/api/Api/EnvironmentManager/Components/MeshCollider.cs
+++ b/api/Api/EnvironmentManager/Components/MeshCollider.cs
@@ -74,7 +74,7 @@ namespace SynthesisAPI.EnvironmentManager.Components
 
         #endregion
 
-        protected void OnPropertyChanged([CallerMemberName] string name = null)
+        protected void OnPropertyChanged([CallerMemberName] string? name = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }

--- a/api/Api/EnvironmentManager/Components/Parent.cs
+++ b/api/Api/EnvironmentManager/Components/Parent.cs
@@ -1,12 +1,13 @@
-﻿using SynthesisAPI.Modules.Attributes;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
+
+#nullable enable
 
 namespace SynthesisAPI.EnvironmentManager.Components
 {
     public class Parent : Component
     {
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         internal Entity parentEntity = 0;
         public static implicit operator Entity(Parent p) => p.parentEntity;

--- a/api/Api/EnvironmentManager/Components/Parent.cs
+++ b/api/Api/EnvironmentManager/Components/Parent.cs
@@ -23,7 +23,7 @@ namespace SynthesisAPI.EnvironmentManager.Components
         public bool Changed { get; private set; }
         internal void ProcessedChanges() => Changed = false;
 
-        protected void OnPropertyChanged([CallerMemberName] string name = null)
+        protected void OnPropertyChanged([CallerMemberName] string? name = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }

--- a/api/Api/EnvironmentManager/Components/Rigidbody.cs
+++ b/api/Api/EnvironmentManager/Components/Rigidbody.cs
@@ -1,25 +1,23 @@
 ﻿using MathNet.Spatial.Euclidean;
-using SynthesisAPI.EnvironmentManager;
-using SynthesisAPI.Modules.Attributes;
 using System;
 using System.Collections.Generic;
-using System.Text;
-using SynthesisAPI.Utilities;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+
+#nullable enable
 
 namespace SynthesisAPI.EnvironmentManager.Components
 {
     public class Rigidbody : Component
     {
-        internal object Adapter = null;
+        internal object? Adapter = null;
 
         #region Properties
 
         public delegate void CollisionFeedback(float magn);
         public CollisionFeedback OnEnterCollision = m => { };
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         public string ExportedJointUuid { get; set; } = string.Empty;
 

--- a/api/Api/EnvironmentManager/Components/Rigidbody.cs
+++ b/api/Api/EnvironmentManager/Components/Rigidbody.cs
@@ -179,7 +179,7 @@ namespace SynthesisAPI.EnvironmentManager.Components
 
         private TResult ConvertEnum<TResult>(object i) => (TResult)Enum.Parse(typeof(TResult), i.ToString(), true);
 
-        protected void OnPropertyChanged([CallerMemberName] string name = null)
+        protected void OnPropertyChanged([CallerMemberName] string? name = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }

--- a/api/Api/EnvironmentManager/Components/Sprite.cs
+++ b/api/Api/EnvironmentManager/Components/Sprite.cs
@@ -1,7 +1,8 @@
 ﻿using SynthesisAPI.AssetManager;
-using SynthesisAPI.Modules.Attributes;
 using SynthesisAPI.Utilities;
 using System.Drawing;
+
+#nullable enable
 
 namespace SynthesisAPI.EnvironmentManager.Components
 {

--- a/api/Api/EnvironmentManager/Components/Sprite.cs
+++ b/api/Api/EnvironmentManager/Components/Sprite.cs
@@ -8,7 +8,7 @@ namespace SynthesisAPI.EnvironmentManager.Components
 	// [BuiltIn]
 	public class Sprite : Component
 	{
-		internal UnityEngine.Sprite _sprite;
+		internal UnityEngine.Sprite? _sprite;
 		internal bool _flipX = false;
 		internal bool _flipY = false;
 		internal Color _color = Color.FromArgb(255, 255, 255, 255);
@@ -67,8 +67,8 @@ namespace SynthesisAPI.EnvironmentManager.Components
 		}
 
 		public Bounds Bounds { get; internal set; } = new Bounds();
-		public int Width => _sprite.texture.width;
-		public int Height => _sprite.texture.height;
+		public int Width => _sprite != null ? 0 : _sprite!.texture.width;
+		public int Height => _sprite != null ? 0 : _sprite!.texture.height;
 
 		public bool Changed { get; private set; } = true;
 		internal void ProcessedChanges() => Changed = false;

--- a/api/Api/EnvironmentManager/Components/Transform.cs
+++ b/api/Api/EnvironmentManager/Components/Transform.cs
@@ -116,7 +116,7 @@ namespace SynthesisAPI.EnvironmentManager.Components
 			Rotation = MathUtil.LookAt((targetPosition - Position).Normalize(), upward);
 		}
 
-		protected void OnPropertyChanged([CallerMemberName] string name = null)
+		protected void OnPropertyChanged([CallerMemberName] string? name = null)
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 		}

--- a/api/Api/EnvironmentManager/Components/Transform.cs
+++ b/api/Api/EnvironmentManager/Components/Transform.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
-using SynthesisAPI.Modules.Attributes;
-using SynthesisAPI.Runtime;
 using SynthesisAPI.Utilities;
+
+#nullable enable
 
 namespace SynthesisAPI.EnvironmentManager.Components
 {
@@ -21,7 +20,7 @@ namespace SynthesisAPI.EnvironmentManager.Components
 		public RotationValidatorDelegate RotationValidator = (Quaternion rotation) => rotation.Normalized;
 		public ScaleValidatorDelegate ScaleValidator = (Vector3D scale) => scale;
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
 		internal Vector3D position = new Vector3D(0, 0, 0);
 		public Vector3D Position

--- a/api/Api/EventBus/Analytics.cs
+++ b/api/Api/EventBus/Analytics.cs
@@ -522,7 +522,7 @@ namespace SynthesisAPI.EventBus
                 StartTimes = new List<KeyValuePair<string, float>>();
             }
 
-            private static Inner? _inst;
+            private static Inner _inst;
             public static Inner InnerInstance => _inst ??= new Inner();
         }
         private static Queue<KeyValuePair<string, string>> LoggedData => Instance.LoggedData;

--- a/api/Api/EventBus/EventBus.cs
+++ b/api/Api/EventBus/EventBus.cs
@@ -181,8 +181,8 @@ namespace SynthesisAPI.EventBus
                 if (AppDomain.CurrentDomain.GetAssemblies()
                     .Any(a => a.FullName.ToLowerInvariant().StartsWith("nunit.framework")))
                 {
-                    _inst!.TypeSubscribers = new Dictionary<string, EventCallback>();
-                    _inst!.TagSubscribers = new Dictionary<string, EventCallback>();
+                    _inst.TypeSubscribers = new Dictionary<string, EventCallback>();
+                    _inst.TagSubscribers = new Dictionary<string, EventCallback>();
                 }
                 else
                 {
@@ -196,7 +196,7 @@ namespace SynthesisAPI.EventBus
                 TagSubscribers = new Dictionary<string, EventCallback>();
             }
 
-            private static Inner? _inst;
+            private static Inner _inst;
             public static Inner InnerInstance => _inst ??= new Inner();
         }
 

--- a/api/Api/GUI/GUIManager.cs
+++ b/api/Api/GUI/GUIManager.cs
@@ -6,9 +6,9 @@ namespace Api.GUI
 {
 	public class GUIManager
 	{
-		protected List<GUIInstance> _instances;
+		protected List<GUIInstance> _instances = new List<GUIInstance>();
 
-		protected Dictionary<Type, IGUIBuilderFactory> _builders;
+		protected Dictionary<Type, IGUIBuilderFactory> _builders = new Dictionary<Type, IGUIBuilderFactory>();
 
 		internal void RegisterBuilder<TGUI>(IGUIBuilderFactory builderFactory) where TGUI : GUIInstance
 		{

--- a/api/Api/InputManager/InputManager.cs
+++ b/api/Api/InputManager/InputManager.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text.RegularExpressions;
 using SynthesisAPI.EventBus;
 using SynthesisAPI.InputManager.InputEvents;
 using SynthesisAPI.InputManager.Inputs;
-using SynthesisAPI.Utilities;
 using UnityEngine;
+
+#nullable enable
 
 using Input = SynthesisAPI.InputManager.Inputs.Input;
 
@@ -29,7 +29,7 @@ namespace SynthesisAPI.InputManager
             get => new ReadOnlyDictionary<string, Analog>(_mappedValueInputs);
         }
 
-        public static void AssignDigitalInput(string name, Digital input, EventBus.EventBus.EventCallback callback = null) { // TODO remove callback argument?
+        public static void AssignDigitalInput(string name, Digital input, EventBus.EventBus.EventCallback? callback = null) { // TODO remove callback argument?
             _mappedDigitalInputs[name] = new Digital[] { input };
             if (callback != null)
                 EventBus.EventBus.NewTagListener($"input/{name}", callback);
@@ -42,7 +42,7 @@ namespace SynthesisAPI.InputManager
             EventBus.EventBus.RemoveAllTagListeners($"input/{name}");
         }
 
-        public static void AssignDigitalInputs(string name, Digital[] input, EventBus.EventBus.EventCallback callback = null) {
+        public static void AssignDigitalInputs(string name, Digital[] input, EventBus.EventBus.EventCallback? callback = null) {
             _mappedDigitalInputs[name] = input;
             if(callback != null)
                 EventBus.EventBus.NewTagListener($"input/{name}", callback);
@@ -95,7 +95,7 @@ namespace SynthesisAPI.InputManager
         }
 
         // TODO: Exclusion cases
-        public static Analog GetAny() {
+        public static Analog? GetAny() {
             foreach (var k in AllInputs) {
                 if (k.Update(true))
                     return k.WithModifier(GetModifier());
@@ -117,7 +117,7 @@ namespace SynthesisAPI.InputManager
 
         public static List<Analog> GetAll() => AllInputs.Where(k => k.Update()).ToList();
 
-        private static List<Analog> _allInputs = null;
+        private static List<Analog>? _allInputs;
         public static IReadOnlyCollection<Analog> AllInputs {
             get {
                 if (_allInputs == null) {
@@ -145,7 +145,9 @@ namespace SynthesisAPI.InputManager
                 return _allInputs;
             }
         }
-        private static List<Digital> _modifierInputs = null;
+
+        // constructors need to call this and intialize the list properly, for now this works
+        private static List<Digital>? _modifierInputs;
         public static IReadOnlyCollection<Digital> ModifierInputs {
             get {
                 if (_modifierInputs == null) {

--- a/api/Api/InputManager/Inputs.cs
+++ b/api/Api/InputManager/Inputs.cs
@@ -133,7 +133,7 @@ namespace SynthesisAPI.InputManager.Inputs
                 Value = State > 0 ? 1 : 0;
                 return State != DigitalState.None;
             }
-            catch (ArgumentException e)
+            catch (ArgumentException)
             {
                 Utilities.Logger.Log($"Key {Name} is invalid." );
                 return false;

--- a/api/Api/Mirabuf/Assembly.cs
+++ b/api/Api/Mirabuf/Assembly.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace Mirabuf {
     public partial class Assembly {
 
-        private Dictionary<string, List<string>> _partJointMap = null;
+        private Dictionary<string, List<string>>? _partJointMap = null;
 
         private void LoadPartJointMap() {
             _partJointMap = new Dictionary<string, List<string>>();
@@ -20,7 +20,8 @@ namespace Mirabuf {
         public List<string> GetPartJoints(string partInstance) {
             if (_partJointMap == null)
                 LoadPartJointMap();
-            _partJointMap.TryGetValue(partInstance, out List<string> joints);
+            // The previous line should fill this I guess ?
+            _partJointMap!.TryGetValue(partInstance, out List<string> joints);
             return joints;
         }
     }

--- a/api/Api/Mirabuf/Assembly.cs
+++ b/api/Api/Mirabuf/Assembly.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+
+#nullable enable
 
 namespace Mirabuf {
     public partial class Assembly {

--- a/api/Api/Mirabuf/TriangleMesh.cs
+++ b/api/Api/Mirabuf/TriangleMesh.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using UnityEngine;
 using UMesh = UnityEngine.Mesh;
-using UVector3 = UnityEngine.Vector3;
 
 namespace Mirabuf {
     public partial class TriangleMesh {
@@ -22,9 +21,10 @@ namespace Mirabuf {
                     try {
                         _colliderMesh = MakeMesh();
                         Physics.BakeMesh(_colliderMesh.GetInstanceID(), true);
-                    } catch (Exception e) {
+                    } catch (Exception) {
                         // TODO: Maybe don't silently fail
                         _colliderMesh = new UMesh();
+                        Debug.LogError("Failed to bake physics mesh!");
                     }
                 }
                 return _colliderMesh;

--- a/api/Api/PreferenceManager/PreferenceManager.cs
+++ b/api/Api/PreferenceManager/PreferenceManager.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using SynthesisAPI.AssetManager;
@@ -19,7 +18,7 @@ namespace SynthesisAPI.PreferenceManager
         
         private static readonly (string Directory, string Name) VirtualFilePath = ("/modules", "preferences.json");
 
-        private static JsonAsset? _asset;
+        private static JsonAsset _asset;
         private static void ImportPreferencesAsset()
         {
             _asset = AssetManager.AssetManager.Import<JsonAsset>("text/json", true, VirtualFilePath.Directory,

--- a/api/Api/PreferenceManager/PreferenceManager.cs
+++ b/api/Api/PreferenceManager/PreferenceManager.cs
@@ -6,6 +6,9 @@ using SynthesisAPI.VirtualFileSystem;
 using System.Threading.Tasks;
 using SynthesisAPI.Utilities;
 
+// This has a template that is possibly nullable 
+#nullable disable
+
 namespace SynthesisAPI.PreferenceManager
 {
     public static class PreferenceManager
@@ -109,7 +112,7 @@ namespace SynthesisAPI.PreferenceManager
                 Logger.Log($"There is no key of value \"{key}\" for module \"{moduleName}\"");
             }
             Logger.Log($"There is no module with name \"{moduleName}\"");
-            return default;
+            return default(T);
         }
 
         /// <summary>

--- a/api/Api/Runtime/ApiProvider.cs
+++ b/api/Api/Runtime/ApiProvider.cs
@@ -15,6 +15,7 @@ namespace SynthesisAPI.Runtime
 	{
 		private static IApiProvider? Instance => Inner.Instance;
 
+		// why does this exist 
 		public static void RegisterApiProvider(IApiProvider provider)
 		{
 			if (Inner.Instance != null)
@@ -33,30 +34,31 @@ namespace SynthesisAPI.Runtime
 			internal static IApiProvider? Instance;
 		}
 
-		public static void AddEntityToScene(Entity entity) => Instance?.AddEntityToScene(entity);
+		// Why would we get this far without having instance defined ?
+		// Why would the provider not just have possibly undefined function links if you are worried about unity?
+		// Why wouldn't instance be defined as a part of the construction process and make this a scoped object that stays alive and is part of a singleton ?
+		// This is very poorly designed, Blame Nick and Logan we gotta do better code reviews and teach people about nullable types.
 
-		public static void RemoveEntityFromScene(Entity entity) => Instance?.RemoveEntityFromScene(entity);
+		public static void AddEntityToScene(Entity entity) => Instance!.AddEntityToScene(entity);
 
-		public static Component? AddComponentToScene(Entity entity, Type t) => Instance?.AddComponentToScene(entity,t);
+		public static void RemoveEntityFromScene(Entity entity) => Instance!.RemoveEntityFromScene(entity);
 
-		public static void AddComponentToScene(Entity entity, Component component) => Instance?.AddComponentToScene(entity, component);
+		public static Component? AddComponentToScene(Entity entity, Type t) => Instance!.AddComponentToScene(entity,t);
 
-		public static void RemoveComponentFromScene(Entity entity, Type t) => Instance?.RemoveComponentFromScene(entity, t);
+		public static void AddComponentToScene(Entity entity, Component component) => Instance!.AddComponentToScene(entity, component);
 
-		public static void EnqueueTaskForMainThread(Action task) => Instance?.EnqueueTaskForMainThread(task);
+		public static void RemoveComponentFromScene(Entity entity, Type t) => Instance!.RemoveComponentFromScene(entity, t);
 
-		public static UnityEngine.Coroutine? StartCoroutine(IEnumerator routine) => Instance?.StartCoroutine(routine);
+		public static void EnqueueTaskForMainThread(Action task) => Instance!.EnqueueTaskForMainThread(task);
+
+		public static UnityEngine.Coroutine? StartCoroutine(IEnumerator routine) => Instance!.StartCoroutine(routine);
 		public static void StopCoroutine(IEnumerator routine) => Instance?.StopCoroutine(routine);
 
-		public static T? CreateUnityType<T>(params object[] args) where T : class => Instance?.CreateUnityType<T>(args);
+		public static T CreateUnityType<T>(params object[] args) where T : class => Instance!.CreateUnityType<T>(args);
 
-		// public static TUnityType? InstantiateFocusable<TUnityType>()
-		// 	where TUnityType : UnityEngine.UIElements.Focusable =>
-		// 	Instance?.InstantiateFocusable<TUnityType>();
-
-		public static UnityEngine.UIElements.VisualElement? GetRootVisualElement() =>
+		public static VisualElement? GetRootVisualElement() =>
 			Instance?.GetRootVisualElement();
 
-		internal static GUIManager GetGUIManager() => Instance?.GetGUIManager();
+		internal static GUIManager GetGUIManager() => Instance!.GetGUIManager();
 	}
 }

--- a/api/Api/UIManager/UIParser.cs
+++ b/api/Api/UIManager/UIParser.cs
@@ -303,7 +303,12 @@ namespace SynthesisAPI.UIManager
                 }
                 else
                 {
-                    return new StyleBackground(asset.Sprite.texture);
+                    if (asset.Sprite != null)
+                        return new StyleBackground(asset.Sprite!.texture);
+                    else {
+                        Logger.Log($"Failed to find Sprite for the given Asset : {asset.Name}", LogLevel.Warning);
+                        return new StyleBackground(StyleKeyword.Null);
+                    }
                 }
             }
             catch (Exception e)

--- a/api/Api/UIManager/VisualElements/ListView.cs
+++ b/api/Api/UIManager/VisualElements/ListView.cs
@@ -7,6 +7,8 @@ using SynthesisAPI.Runtime;
 using _SelectionType = UnityEngine.UIElements.SelectionType;
 using _UnityListView = UnityEngine.UIElements.ListView;
 
+#nullable enable
+
 namespace SynthesisAPI.UIManager.VisualElements
 {
     public class ListView: VisualElement

--- a/api/Api/UIManager/VisualElements/ListView.cs
+++ b/api/Api/UIManager/VisualElements/ListView.cs
@@ -25,7 +25,7 @@ namespace SynthesisAPI.UIManager.VisualElements
         }
         */
 
-        private EventBus.EventBus.EventCallback _callback;
+        private EventBus.EventBus.EventCallback? _callback;
 
         private protected _UnityListView Element
         {
@@ -106,20 +106,22 @@ namespace SynthesisAPI.UIManager.VisualElements
 
         public void SubscribeOnSelectionChanged(Action<IEvent> callback)
         {
-            EventBus.EventBus.RemoveTagListener(SelectedEventTag, _callback);
+            if (_callback != null)
+                EventBus.EventBus.RemoveTagListener(SelectedEventTag, _callback);
             _callback = e => callback(e);
             EventBus.EventBus.NewTagListener(SelectedEventTag, _callback);
             
-            Element.onSelectionChanged += l => EventBus.EventBus.Push(SelectedEventTag, new SelectionChangedEvent(l));
+            Element.onSelectionChange += l => EventBus.EventBus.Push(SelectedEventTag, new SelectionChangedEvent((List<object>)l));
         }
 
         public void SubscribeOnItemChosen(Action<IEvent> callback)
         {
-            EventBus.EventBus.RemoveTagListener(ItemChosenEventTag, _callback);
+            if (_callback != null)
+                EventBus.EventBus.RemoveTagListener(ItemChosenEventTag, _callback);
             _callback = e => callback(e);
             EventBus.EventBus.NewTagListener(ItemChosenEventTag, _callback);
 
-            Element.onItemChosen += o => EventBus.EventBus.Push(ItemChosenEventTag, new ItemChosenEvent(o));
+            Element.onItemsChosen += o => EventBus.EventBus.Push(ItemChosenEventTag, new ItemChosenEvent(o));
         }
 
         public override IEnumerable<Object> PostUxmlLoad()

--- a/api/Api/UIManager/VisualElements/VisualElement.cs
+++ b/api/Api/UIManager/VisualElements/VisualElement.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using UnityEngine.UIElements;
 using _UnityVisualElement = UnityEngine.UIElements.VisualElement;
 
+#nullable enable
+
 namespace SynthesisAPI.UIManager.VisualElements
 {
     public class VisualElement
@@ -201,7 +203,8 @@ namespace SynthesisAPI.UIManager.VisualElements
 
         public void SetStyleProperty(string name, string value)
         {
-            _visualElement = UIParser.ParseEntry($"{name}:{value}", _visualElement);
+            var elem = UIParser.ParseEntry($"{name}:{value}", _visualElement);
+            if (elem != null) _visualElement = elem;
         }
     }
 }

--- a/api/Api/UIManager/VisualElements/VisualElement.cs
+++ b/api/Api/UIManager/VisualElements/VisualElement.cs
@@ -64,7 +64,7 @@ namespace SynthesisAPI.UIManager.VisualElements
             get => _visualElement;
         }
 
-        public virtual IEnumerable<Object> PostUxmlLoad()
+        public virtual IEnumerable<Object>? PostUxmlLoad()
         {
             foreach (var child in _visualElement.Children())
             {
@@ -107,7 +107,7 @@ namespace SynthesisAPI.UIManager.VisualElements
             return children;
         }
 
-        public VisualElement Get(string name = null, string className = null)
+        public VisualElement? Get(string? name = null, string? className = null)
         {
             if (_visualElement == null)
                 return null;
@@ -124,9 +124,9 @@ namespace SynthesisAPI.UIManager.VisualElements
             }
         }
 
-        private Manipulator tooltipManipulator = null;
+        private Manipulator? tooltipManipulator = null;
         
-        private string tooltip;
+        private string tooltip = "";
 
         public string Tooltip
         {
@@ -159,7 +159,7 @@ namespace SynthesisAPI.UIManager.VisualElements
         }
         
         private bool isDraggable = false;
-        private Manipulator dragManipulator = null;
+        private Manipulator? dragManipulator = null;
         public bool IsDraggable
         {
             get => isDraggable;

--- a/api/Api/Utilities/ControllableState.cs
+++ b/api/Api/Utilities/ControllableState.cs
@@ -1,11 +1,6 @@
-﻿using SynthesisAPI.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using Mirabuf.Signal;
-using Mirabuf;
-using Google.Protobuf;
-using System.Net.Sockets;
 
 namespace SynthesisAPI.Utilities
 {
@@ -19,8 +14,8 @@ namespace SynthesisAPI.Utilities
     {
         private int _generation;
         private bool _isFree;
-        private Signals? _currentSignalLayout;
-        public Signals? CurrentSignalLayout
+        private Signals _currentSignalLayout;
+        public Signals CurrentSignalLayout
         {
             get => _currentSignalLayout;
             set

--- a/api/Api/Utilities/SharedTextStream.cs
+++ b/api/Api/Utilities/SharedTextStream.cs
@@ -2,6 +2,8 @@
 using System.IO;
 using System.Threading;
 
+#nullable enable
+
 namespace SynthesisAPI.Utilities
 {
     /// <summary>
@@ -131,7 +133,7 @@ namespace SynthesisAPI.Utilities
             }
             else
             {
-                throw new Exception();
+                throw new Exception("Cannot ReadLine, Thread lock timed out"); // why though and also what, should this be an empty string ?, probably should through a specific exception about the mutex lock
             }
         }
 
@@ -173,7 +175,7 @@ namespace SynthesisAPI.Utilities
             }
         }
 
-        public string TryReadToEnd()
+        public string? TryReadToEnd()
         {
             if (RwLock.TryEnterReadLock(Timeout))
             {

--- a/api/Api/Utilities/TranslatorUtil.cs
+++ b/api/Api/Utilities/TranslatorUtil.cs
@@ -1,8 +1,9 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Xml;
+
+#nullable enable
 
 /// <summary>
 /// Utility class defined in the main scope
@@ -11,7 +12,7 @@ using System.Xml;
 [assembly: InternalsVisibleTo(assemblyName: "TranslatorTest")]
 
 internal static class TranslatorUtil {
-    public static XmlNode Find(this XmlNodeList nodes, Predicate<XmlNode> condition) {
+    public static XmlNode? Find(this XmlNodeList nodes, Predicate<XmlNode> condition) {
         var enumerator = nodes.GetEnumerator();
         enumerator.Reset();
         while (enumerator.MoveNext()) {

--- a/api/Api/Utilities/UdpServer.cs
+++ b/api/Api/Utilities/UdpServer.cs
@@ -7,10 +7,8 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
-using Google;
 using Google.Protobuf;
 using SynthesisAPI.Simulation;
-using UnityEngine;
 
 namespace SynthesisAPI.Utilities
 {
@@ -24,7 +22,7 @@ namespace SynthesisAPI.Utilities
             {
                 updates = new ConcurrentQueue<UpdateSignals>();
                 _isRunning = false;
-                updateSignalTasks = new List<Task<UpdateSignals?>>();
+                // updateSignalTasks = new List<Task<UpdateSignals>>();
 
                 listenerThread = new Thread(() =>
                 {
@@ -45,9 +43,9 @@ namespace SynthesisAPI.Utilities
                             });
                         }
                     }
-                    catch (SocketException e)
+                    catch (SocketException)
                     {
-                        Logger.Log("UDP Listener Stopped Successfully", LogLevel.Debug);
+                        Logger.Log("UDP Listener Stopped Successfully", LogLevel.Debug); //lol what
                     }
                     catch (AggregateException)
                     {
@@ -118,9 +116,9 @@ namespace SynthesisAPI.Utilities
             private IPEndPoint outputIpEndPoint;
             public int outputPort;
 
-            public Dictionary<string, SimObject>? SimObjectsTarget { get; set; }
+            public Dictionary<string, SimObject> SimObjectsTarget { get; set; }
             private ConcurrentQueue<UpdateSignals> updates;
-            private List<Task<UpdateSignals?>> updateSignalTasks;
+            // private List<Task<UpdateSignals>> updateSignalTasks;
             private Thread listenerThread;
             private Thread outputThread;
             private Thread queueThread;
@@ -135,7 +133,7 @@ namespace SynthesisAPI.Utilities
                     if (!value)
                     {
                         if (outputClient != null && outputClient.Client.Connected) { outputClient.Close(); }
-                        if (listenerClient != null) { listenerClient.Close(); }
+                        listenerClient?.Close();
                         if (listenerThread != null && listenerThread.IsAlive) { listenerThread.Join(); }
                         if (outputThread != null && outputThread.IsAlive) { outputThread.Join(); }
                         if (queueThread != null && queueThread.IsAlive) { queueThread.Join(); }

--- a/api/Api/VirtualFileSystem/Directory.cs
+++ b/api/Api/VirtualFileSystem/Directory.cs
@@ -12,37 +12,29 @@ namespace SynthesisAPI.VirtualFileSystem
     /// </summary>
     public sealed class Directory : IEntry
     {
-        /// <summary>
-        /// Initialize Entry data
-        /// </summary>
-        /// <param name="name"></param>
-        /// <param name="perm"></param>
-        private void Init(string name, Permissions perm)
-        {
-            _name = name;
-            _permissions = perm;
-            _parent = null!;
-        }
-
         public string Name => ((IEntry)this).Name;
         public Permissions Permissions => ((IEntry)this).Permissions;
-        public Directory Parent => ((IEntry)this).Parent;
+        public Directory? Parent => ((IEntry)this).Parent;
 
         private string _name { get; set; }
         private Permissions _permissions { get; set; }
-        private Directory _parent { get; set; }
+        private Directory? _parent { get; set; }
 
         string IEntry.Name { get => _name; set => _name = value; }
         Permissions IEntry.Permissions { get => _permissions; set => _permissions = value; }
-        Directory IEntry.Parent { get => _parent; set => _parent = value; }
+        Directory? IEntry.Parent { get => _parent; set => _parent = value; }
 
         internal Dictionary<string, IEntry> Entries;
 
         public static readonly char DirectorySeparatorChar = '/';
 
         public Directory(string name, Permissions perm)
-        {
-            Init(name, perm);
+        { 
+            // unclear why init existed
+            _name = name;
+            _permissions = perm;
+            _parent = null!;
+
             Entries = new Dictionary<string, IEntry> {{".", this}, {"..", null!}};
         }
 
@@ -119,7 +111,7 @@ namespace SynthesisAPI.VirtualFileSystem
         internal string GetPathInner()
         {
             string path = "";
-            Directory dir = this;
+            Directory? dir = this;
             while (dir != null) {
                 path = dir.Name + DirectorySeparatorChar + path;
 
@@ -294,7 +286,8 @@ namespace SynthesisAPI.VirtualFileSystem
                 {
                     throw new DirectoryException($"Directory: adding entry \"{value.Name}\" with existing parent (entries cannot exist in multiple directories)");
                 }
-                dir.Entries[".."] = dir.Parent;
+                if (dir.Parent != null)
+                    dir.Entries[".."] = dir.Parent;
             }
 
             return Entries[value.Name];

--- a/api/Api/VirtualFileSystem/IEntry.cs
+++ b/api/Api/VirtualFileSystem/IEntry.cs
@@ -1,5 +1,6 @@
 ﻿using SynthesisAPI.Utilities;
-using System;
+
+#nullable enable
 
 namespace SynthesisAPI.VirtualFileSystem
 {

--- a/api/Api/VirtualFileSystem/IEntry.cs
+++ b/api/Api/VirtualFileSystem/IEntry.cs
@@ -23,7 +23,7 @@ namespace SynthesisAPI.VirtualFileSystem
         /// 
         /// (null if unset)
         /// </summary>
-        public Directory Parent { get; internal set; }
+        public Directory? Parent { get; internal set; }
 
         [ExposedApi]
         public void Delete();


### PR DESCRIPTION
### Description

There were a bunch of warnings about nullable types since they were about half used in the original API code. At first I enabled them everywhere but the entire codebase ignores null types and there are many many errors. So for this PR given it's my last day I fixed as many as I could and reduced the warnings to 0. 

There exists a few places where nullable types are actually fairly impossible unless we redefine the types to be optional. Such as the templated default returns. 

### Objectives
- [x] Get rid of the nullable warnings
- [ ] Have the API return the real types if it can be null 

### Testing Done
- Started Synthesis
- Drove around a bit
- Loaded Field / Robot
