### PR TITLE
Fixed issue with custom wheels

### DIFF
--- a/engine/Assets/Scripts/SimulationRunner.cs
+++ b/engine/Assets/Scripts/SimulationRunner.cs
@@ -173,8 +173,9 @@ namespace Synthesis.Runtime {
         /// </summary>
         public static void SimKill() {
             FieldSimObject.DeleteField();
-            if (RobotSimObject.CurrentlyPossessedRobot != string.Empty)
-                SimulationManager.RemoveSimObject(RobotSimObject.GetCurrentlyPossessedRobot());
+            List<string> robotIDs = new List<string>(RobotSimObject.SpawnedRobots.Count);
+            RobotSimObject.SpawnedRobots.ForEach(x => robotIDs.Add(x.Name));
+            robotIDs.ForEach(x => RobotSimObject.RemoveRobot(x));
 
             if (OnSimKill != null)
                 OnSimKill();

--- a/engine/Assets/Scripts/SimulationRunner.cs
+++ b/engine/Assets/Scripts/SimulationRunner.cs
@@ -176,6 +176,7 @@ namespace Synthesis.Runtime {
             List<string> robotIDs = new List<string>(RobotSimObject.SpawnedRobots.Count);
             RobotSimObject.SpawnedRobots.ForEach(x => robotIDs.Add(x.Name));
             robotIDs.ForEach(x => RobotSimObject.RemoveRobot(x));
+            OrbitCameraMode.FocusPoint = () => Vector3.zero;
 
             if (OnSimKill != null)
                 OnSimKill();


### PR DESCRIPTION
### Description
Fixed issue where an error message would appear if at least two robots are spawned and the user exits to the main menu then re-enters synthesis. 

### Objectives

- [ ] Fix issue 

### Testing Done

- Tested the steps to repeat the bug, with two, three, four and five robots spawned. 

[JIRA Issue](https://jira.autodesk.com/browse/AARD-XXXX)
