### PR TITLE
Driver Station Camera Mode

### DIFF
--- a/engine/Assets/Scripts/Camera/CameraController.cs
+++ b/engine/Assets/Scripts/Camera/CameraController.cs
@@ -1,10 +1,10 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Synthesis.UI.Panels.Variant;
 using Synthesis.PreferenceManager;
 
-public class CameraController : MonoBehaviour
-{
+public class CameraController : MonoBehaviour {
     private ICameraMode _cameraMode;
     public ICameraMode CameraMode
     {
@@ -17,7 +17,6 @@ public class CameraController : MonoBehaviour
             }
             var previous = _cameraMode;
             _cameraMode = value;
-            _cameraMode.Start(this, previous);
         }
     }
     
@@ -28,6 +27,7 @@ public class CameraController : MonoBehaviour
         CameraModes.Add("Orbit", new OrbitCameraMode());
         CameraModes.Add("Freecam", new FreeCameraMode());
         CameraModes.Add("Overview", new OverviewCameraMode());
+        CameraModes.Add("Driver Station", new DriverStationCameraMode());
     }
 
     public static bool isOverGizmo = false;
@@ -70,6 +70,10 @@ public class CameraController : MonoBehaviour
         //     transform.parent = FollowTransform;
 
         CameraMode.Update(this);
+    }
+
+    public void FixedUpdate() {
+        CameraMode.FixedUpdate(this);
     }
 
     public void LateUpdate() {

--- a/engine/Assets/Scripts/Camera/CameraController.cs
+++ b/engine/Assets/Scripts/Camera/CameraController.cs
@@ -17,6 +17,7 @@ public class CameraController : MonoBehaviour {
             }
             var previous = _cameraMode;
             _cameraMode = value;
+            _cameraMode.Start(this, previous);
         }
     }
     
@@ -71,11 +72,6 @@ public class CameraController : MonoBehaviour {
 
         CameraMode.Update(this);
     }
-
-    public void FixedUpdate() {
-        CameraMode.FixedUpdate(this);
-    }
-
     public void LateUpdate() {
         CameraMode.LateUpdate(this);
     }

--- a/engine/Assets/Scripts/Camera/DriverStationCameraMode.cs
+++ b/engine/Assets/Scripts/Camera/DriverStationCameraMode.cs
@@ -1,0 +1,47 @@
+using System;
+using Synthesis.Gizmo;
+using UnityEngine;
+using Screen = UnityEngine.Device.Screen;
+
+public class DriverStationCameraMode : ICameraMode {
+    private Vector3 _origin = Vector3.zero;
+    private Vector3 _target = Vector3.zero;
+    private Vector3 _currentTarget = Vector3.zero;
+    private Vector3 _offset = Vector3.zero;
+    public const float EDGE_BUFFER = 400f; 
+    private static readonly AnimationCurve CURVE = AnimationCurve.EaseInOut(0, 0, 1, 1);
+
+    public void Configure<T>(CameraController cam, T previousCam, Action<CameraController, T> onEnd) where T : ICameraMode {
+        GizmoManager.SpawnGizmo(
+            Vector3.zero,
+            t => {},
+            t => {
+                _origin = t.Position;
+                onEnd.Invoke(cam, previousCam);
+            });
+    }
+    
+    public void Start<T>(CameraController cam, T previousCam) where T : ICameraMode {
+        cam.gameObject.transform.position = _origin;
+    }
+    
+    public void Update(CameraController cam) {
+        RobotSimObject currentRobot = RobotSimObject.GetCurrentlyPossessedRobot();
+        _target = currentRobot is null ? Vector3.zero : currentRobot.GroundedNode.transform.TransformPoint(currentRobot.GroundedBounds.center);
+    }
+
+    public void FixedUpdate(CameraController cam) {
+        
+    }
+    
+    public void LateUpdate(CameraController cam) {
+        cam.transform.position = _origin;
+
+        var relativePos = _target - cam.transform.position;
+        var targetRotation = Quaternion.LookRotation(relativePos);
+        cam.transform.rotation = Quaternion.Lerp(cam.transform.rotation, targetRotation, Time.deltaTime * 2);
+    }
+    public void End(CameraController cam) {
+        
+    }
+}

--- a/engine/Assets/Scripts/Camera/DriverStationCameraMode.cs
+++ b/engine/Assets/Scripts/Camera/DriverStationCameraMode.cs
@@ -79,28 +79,28 @@ public class DriverStationCameraMode : ICameraMode {
             p = -CameraController.PitchSensitivity * Input.GetAxis("Mouse Y");
             y = CameraController.YawSensitivity * Input.GetAxis("Mouse X");
         }
-
-        // make it so the user can't rotate the camera upside down
-        TargetPitch = Mathf.Clamp(TargetPitch + p, -90, 90);
-        TargetYaw += y;
-        TargetZoom = Mathf.Clamp(TargetZoom + z, cam.ZoomLowerLimit, cam.ZoomUpperLimit);
         
-        float orbitLerpFactor = Mathf.Clamp((cam.OrbitalAcceleration * Time.deltaTime) / 0.018f, 0.01f, 1.0f);
-        ActualPitch = Mathf.Lerp(ActualPitch, TargetPitch, orbitLerpFactor);
-        ActualYaw = Mathf.Lerp(ActualYaw, TargetYaw, orbitLerpFactor);
-        float zoomLerpFactor = Mathf.Clamp((cam.ZoomAcceleration * Time.deltaTime) / 0.018f, 0.01f, 1.0f);
-        ActualZoom = Mathf.Lerp(ActualZoom, TargetZoom, zoomLerpFactor);
-
         var t = cam.transform;
 
-        float speed = 10.0F;
-        
+        float speed = 5.0F;
+
         // transform forwards and backwards when forward and backward inputs are pressed
         // left and right when left and right are pressed
 
         Vector3 forward = Vector3.zero, right = Vector3.zero;
 
         if (isActive) {
+            // make it so the user can't rotate the camera upside down
+            TargetPitch = Mathf.Clamp(TargetPitch + p, -90, 90);
+            TargetYaw += y;
+            TargetZoom = Mathf.Clamp(TargetZoom + z, cam.ZoomLowerLimit, cam.ZoomUpperLimit);
+        
+            float orbitLerpFactor = Mathf.Clamp((cam.OrbitalAcceleration * Time.deltaTime) / 0.018f, 0.01f, 1.0f);
+            ActualPitch = Mathf.Lerp(ActualPitch, TargetPitch, orbitLerpFactor);
+            ActualYaw = Mathf.Lerp(ActualYaw, TargetYaw, orbitLerpFactor);
+            float zoomLerpFactor = Mathf.Clamp((cam.ZoomAcceleration * Time.deltaTime) / 0.018f, 0.01f, 1.0f);
+            ActualZoom = Mathf.Lerp(ActualZoom, TargetZoom, zoomLerpFactor);
+            
             forward = t.forward * (InputManager.MappedDigitalInputs[FORWARD_KEY][0].Value -
                                         InputManager.MappedDigitalInputs[BACK_KEY][0].Value) +
                             t.forward * (TargetZoom - ActualZoom) * CameraController.ZoomSensitivity;
@@ -115,7 +115,7 @@ public class DriverStationCameraMode : ICameraMode {
 
             t.localRotation = Quaternion.Euler(ActualPitch, ActualYaw, 0.0f);
         }
-        
+
         RobotSimObject currentRobot = RobotSimObject.GetCurrentlyPossessedRobot();
         _target = currentRobot is null ? Vector3.zero : currentRobot.GroundedNode.transform.TransformPoint(currentRobot.GroundedBounds.center);
     }
@@ -127,6 +127,8 @@ public class DriverStationCameraMode : ICameraMode {
             if (relativePos.magnitude == 0) return;
             var targetRotation = Quaternion.LookRotation(relativePos);
             cam.transform.rotation = Quaternion.Lerp(cam.transform.rotation, targetRotation, Time.deltaTime * 5);
+            TargetPitch = ActualPitch = cam.transform.rotation.eulerAngles.x;
+            TargetYaw = ActualYaw = cam.transform.rotation.eulerAngles.y;
         }
     }
 

--- a/engine/Assets/Scripts/Camera/DriverStationCameraMode.cs
+++ b/engine/Assets/Scripts/Camera/DriverStationCameraMode.cs
@@ -38,6 +38,7 @@ public class DriverStationCameraMode : ICameraMode {
         cam.transform.position = _origin;
 
         var relativePos = _target - cam.transform.position;
+        if (relativePos.magnitude == 0) return;
         var targetRotation = Quaternion.LookRotation(relativePos);
         cam.transform.rotation = Quaternion.Lerp(cam.transform.rotation, targetRotation, Time.deltaTime * 2);
     }

--- a/engine/Assets/Scripts/Camera/DriverStationCameraMode.cs
+++ b/engine/Assets/Scripts/Camera/DriverStationCameraMode.cs
@@ -1,48 +1,151 @@
 using System;
 using Synthesis.Gizmo;
+using Synthesis.UI.Dynamic;
+using SynthesisAPI.InputManager;
+using SynthesisAPI.InputManager.Inputs;
 using UnityEngine;
+using Input = UnityEngine.Input;
 using Screen = UnityEngine.Device.Screen;
 
 public class DriverStationCameraMode : ICameraMode {
-    private Vector3 _origin = Vector3.zero;
     private Vector3 _target = Vector3.zero;
-    private Vector3 _currentTarget = Vector3.zero;
-    private Vector3 _offset = Vector3.zero;
-    public const float EDGE_BUFFER = 400f; 
-    private static readonly AnimationCurve CURVE = AnimationCurve.EaseInOut(0, 0, 1, 1);
-
-    public void Configure<T>(CameraController cam, T previousCam, Action<CameraController, T> onEnd) where T : ICameraMode {
-        GizmoManager.SpawnGizmo(
-            Vector3.zero,
-            t => {},
-            t => {
-                _origin = t.Position;
-                onEnd.Invoke(cam, previousCam);
-            });
-    }
     
-    public void Start<T>(CameraController cam, T previousCam) where T : ICameraMode {
-        cam.gameObject.transform.position = _origin;
+    public float TargetZoom { get; private set; } = 15.0f;
+    public float TargetPitch { get; private set; } = 10.0f;
+    public float TargetYaw { get; private set; } = 135.0f;
+    public float ActualZoom { get; private set; } = 15.0f;
+    public float ActualPitch { get; private set; } = 10.0f;
+    public float ActualYaw { get; private set; } = 135.0f;
+
+    private const string FORWARD_KEY = "FREECAM_FORWARD";
+    private const string BACK_KEY = "FREECAM_BACK";
+    private const string LEFT_KEY = "FREECAM_LEFT";
+    private const string RIGHT_KEY = "FREECAM_RIGHT";
+    private const string LEFT_YAW_KEY = "FREECAM_LEFT_YAW";
+    private const string RIGHT_YAW_KEY = "FREECAM_RIGHT_YAW";
+    private const string DOWN_PITCH_KEY = "FREECAM_DOWN_PITCH";
+    private const string UP_PITCH_KEY = "FREECAM_UP_PITCH";
+
+    private bool isActive = false;
+
+    public void Start<T>(CameraController cam, T? previousCam) where T : ICameraMode {
+        
+        // only assign inputs once
+        if (!InputManager.MappedDigitalInputs.ContainsKey(FORWARD_KEY)) {
+            InputManager.AssignDigitalInput(FORWARD_KEY, new Digital("W"));
+            InputManager.AssignDigitalInput(BACK_KEY, new Digital("S"));
+            InputManager.AssignDigitalInput(LEFT_KEY, new Digital("A"));
+            InputManager.AssignDigitalInput(RIGHT_KEY, new Digital("D"));
+            // InputManager.AssignValueInput(LEFT_YAW_KEY, new Digital("Q"));
+            // InputManager.AssignValueInput(RIGHT_YAW_KEY, new Digital("E"));
+            // InputManager.AssignValueInput(DOWN_PITCH_KEY, new Digital("Z"));
+            // InputManager.AssignValueInput(UP_PITCH_KEY, new Digital("X"));
+        }
+
+        if (previousCam != null && previousCam.GetType() == typeof(OrbitCameraMode)) {
+            OrbitCameraMode orbitCam = (previousCam as OrbitCameraMode)!;
+            TargetPitch = orbitCam.TargetPitch;
+            TargetYaw = orbitCam.TargetYaw;
+            ActualPitch = orbitCam.ActualPitch;
+            ActualYaw = orbitCam.ActualYaw;
+        }
     }
     
     public void Update(CameraController cam) {
+        if (Input.GetKeyDown(KeyCode.Mouse1)) {
+            SetActive(true);
+        } else if (Input.GetKeyUp(KeyCode.Mouse1)) {
+            SetActive(false);
+        }
+
+        // don't allow camera movement when a modal is open
+        if (DynamicUIManager.ActiveModal != null) return;
+        float p = 0.0f;
+        float y = 0.0f;
+        float z = 0.0f;
+        
+        // in old synthesis freecam mode, scrolling down zooms in and scrolling up zooms out
+        // z = cam.ZoomSensitivity * Input.mouseScrollDelta.y;
+        
+        // float yawMod = InputManager.MappedValueInputs.ContainsKey(LEFT_YAW_KEY) && InputManager.MappedValueInputs.ContainsKey(RIGHT_YAW_KEY) ? 
+        //     cam.YawSensitivity / 8 * (InputManager.MappedValueInputs[RIGHT_YAW_KEY].Value - InputManager.MappedValueInputs[LEFT_YAW_KEY].Value) : 0;
+        // float pitchMod = InputManager.MappedValueInputs.ContainsKey(UP_PITCH_KEY) && InputManager.MappedValueInputs.ContainsKey(DOWN_PITCH_KEY) ? 
+        //     cam.PitchSensitivity / 4 * (InputManager.MappedValueInputs[UP_PITCH_KEY].Value - InputManager.MappedValueInputs[DOWN_PITCH_KEY].Value) : 0;
+        
+        // p -= pitchMod;
+        // y += yawMod;
+
+        if (isActive) {
+            p = -CameraController.PitchSensitivity * Input.GetAxis("Mouse Y");
+            y = CameraController.YawSensitivity * Input.GetAxis("Mouse X");
+        }
+
+        // make it so the user can't rotate the camera upside down
+        TargetPitch = Mathf.Clamp(TargetPitch + p, -90, 90);
+        TargetYaw += y;
+        TargetZoom = Mathf.Clamp(TargetZoom + z, cam.ZoomLowerLimit, cam.ZoomUpperLimit);
+        
+        float orbitLerpFactor = Mathf.Clamp((cam.OrbitalAcceleration * Time.deltaTime) / 0.018f, 0.01f, 1.0f);
+        ActualPitch = Mathf.Lerp(ActualPitch, TargetPitch, orbitLerpFactor);
+        ActualYaw = Mathf.Lerp(ActualYaw, TargetYaw, orbitLerpFactor);
+        float zoomLerpFactor = Mathf.Clamp((cam.ZoomAcceleration * Time.deltaTime) / 0.018f, 0.01f, 1.0f);
+        ActualZoom = Mathf.Lerp(ActualZoom, TargetZoom, zoomLerpFactor);
+
+        var t = cam.transform;
+
+        float speed = 10.0F;
+        
+        // transform forwards and backwards when forward and backward inputs are pressed
+        // left and right when left and right are pressed
+
+        Vector3 forward = Vector3.zero, right = Vector3.zero;
+
+        if (isActive) {
+            forward = t.forward * (InputManager.MappedDigitalInputs[FORWARD_KEY][0].Value -
+                                        InputManager.MappedDigitalInputs[BACK_KEY][0].Value) +
+                            t.forward * (TargetZoom - ActualZoom) * CameraController.ZoomSensitivity;
+            
+            right = t.right * (InputManager.MappedDigitalInputs[RIGHT_KEY][0].Value -
+                                    InputManager.MappedDigitalInputs[LEFT_KEY][0].Value);
+            
+            t.Translate(Time.deltaTime * speed * (forward + right),Space.World);
+
+            // we don't want the user to be able to move the camera under the map or so high they can't see the field
+            t.position = new Vector3(t.position.x, Mathf.Clamp(t.position.y, 0, 100), t.position.z);
+
+            t.localRotation = Quaternion.Euler(ActualPitch, ActualYaw, 0.0f);
+        }
+        
         RobotSimObject currentRobot = RobotSimObject.GetCurrentlyPossessedRobot();
         _target = currentRobot is null ? Vector3.zero : currentRobot.GroundedNode.transform.TransformPoint(currentRobot.GroundedBounds.center);
     }
-
-    public void FixedUpdate(CameraController cam) {
-        
-    }
     
     public void LateUpdate(CameraController cam) {
-        cam.transform.position = _origin;
-
-        var relativePos = _target - cam.transform.position;
-        if (relativePos.magnitude == 0) return;
-        var targetRotation = Quaternion.LookRotation(relativePos);
-        cam.transform.rotation = Quaternion.Lerp(cam.transform.rotation, targetRotation, Time.deltaTime * 2);
+        cam.GroundRenderer.material.SetVector("FOCUS_POINT", cam.transform.position);
+        if (!isActive) {
+            var relativePos = _target - cam.transform.position;
+            if (relativePos.magnitude == 0) return;
+            var targetRotation = Quaternion.LookRotation(relativePos);
+            cam.transform.rotation = Quaternion.Lerp(cam.transform.rotation, targetRotation, Time.deltaTime * 5);
+        }
     }
+
+    public void SetActive(bool active) {
+        isActive = active;
+        if (active) {
+            Cursor.lockState = CursorLockMode.Locked;
+            Cursor.visible = false;
+            if (RobotSimObject.CurrentlyPossessedRobot != string.Empty)
+                RobotSimObject.GetCurrentlyPossessedRobot().BehavioursEnabled = false;
+        } else {
+            Cursor.lockState = CursorLockMode.None;
+            Cursor.visible = true;
+            if (RobotSimObject.CurrentlyPossessedRobot != string.Empty)
+                RobotSimObject.GetCurrentlyPossessedRobot().BehavioursEnabled = true;
+        }
+    }
+
     public void End(CameraController cam) {
-        
+        SetActive(false);
     }
 }

--- a/engine/Assets/Scripts/Camera/DriverStationCameraMode.cs.meta
+++ b/engine/Assets/Scripts/Camera/DriverStationCameraMode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8ba731027e064a609b9b1dacac847670
+timeCreated: 1687969529

--- a/engine/Assets/Scripts/Camera/FreeCameraMode.cs
+++ b/engine/Assets/Scripts/Camera/FreeCameraMode.cs
@@ -41,12 +41,20 @@ public class FreeCameraMode : ICameraMode
             // InputManager.AssignValueInput(UP_PITCH_KEY, new Digital("X"));
         }
 
-        if (previousCam != null && previousCam.GetType() == typeof(OrbitCameraMode)) {
-            OrbitCameraMode orbitCam = (previousCam as OrbitCameraMode)!;
-            TargetPitch = orbitCam.TargetPitch;
-            TargetYaw = orbitCam.TargetYaw;
-            ActualPitch = orbitCam.ActualPitch;
-            ActualYaw = orbitCam.ActualYaw;
+        if (previousCam != null) {
+            if (previousCam.GetType() == typeof(OrbitCameraMode)) {
+                OrbitCameraMode orbitCam = (previousCam as OrbitCameraMode)!;
+                TargetPitch = orbitCam.TargetPitch;
+                TargetYaw = orbitCam.TargetYaw;
+                ActualPitch = orbitCam.ActualPitch;
+                ActualYaw = orbitCam.ActualYaw;
+            } else if (previousCam.GetType() == typeof(DriverStationCameraMode)) {
+                DriverStationCameraMode driverStationCam = (previousCam as DriverStationCameraMode)!;
+                TargetPitch = driverStationCam.TargetPitch;
+                TargetYaw = driverStationCam.TargetYaw;
+                ActualPitch = driverStationCam.ActualPitch;
+                ActualYaw = driverStationCam.ActualYaw;
+            }
         }
     }
     

--- a/engine/Assets/Scripts/Camera/FreeCameraMode.cs
+++ b/engine/Assets/Scripts/Camera/FreeCameraMode.cs
@@ -106,27 +106,18 @@ public class FreeCameraMode : ICameraMode
             
             right = t.right * (InputManager.MappedDigitalInputs[RIGHT_KEY][0].Value -
                                     InputManager.MappedDigitalInputs[LEFT_KEY][0].Value);
+            
+            t.Translate(Time.deltaTime * speed * (forward + right),Space.World);
+
+            // we don't want the user to be able to move the camera under the map or so high they can't see the field
+            t.position = new Vector3(t.position.x, Mathf.Clamp(t.position.y, 0, 100), t.position.z);
+
+            t.localRotation = Quaternion.Euler(ActualPitch, ActualYaw, 0.0f);
         }
-
-        t.Translate(Time.deltaTime * speed * (forward + right),Space.World);
-
-        // we don't want the user to be able to move the camera under the map or so high they can't see the field
-        t.position = new Vector3(t.position.x, Mathf.Clamp(t.position.y, 0, 100), t.position.z);
-
-        t.localRotation = Quaternion.Euler(ActualPitch, ActualYaw, 0.0f);
     }
-
-    public void FixedUpdate(CameraController cam) {
-        
-    }
-
+    
     public void LateUpdate(CameraController cam) {
-
         cam.GroundRenderer.material.SetVector("FOCUS_POINT", cam.transform.position);
-
-        // // don't allow camera movement when a modal is open
-        // if (DynamicUIManager.ActiveModal != null) return;
-        
     }
 
     public void SetActive(bool active) {
@@ -146,6 +137,5 @@ public class FreeCameraMode : ICameraMode
 
     public void End(CameraController cam) {
         SetActive(false);
-        // RobotSimObject.GetCurrentlyPossessedRobot().InputFrozen = _wasFrozen;
     }
 }

--- a/engine/Assets/Scripts/Camera/FreeCameraMode.cs
+++ b/engine/Assets/Scripts/Camera/FreeCameraMode.cs
@@ -116,6 +116,10 @@ public class FreeCameraMode : ICameraMode
         t.localRotation = Quaternion.Euler(ActualPitch, ActualYaw, 0.0f);
     }
 
+    public void FixedUpdate(CameraController cam) {
+        
+    }
+
     public void LateUpdate(CameraController cam) {
 
         cam.GroundRenderer.material.SetVector("FOCUS_POINT", cam.transform.position);

--- a/engine/Assets/Scripts/Camera/ICameraMode.cs
+++ b/engine/Assets/Scripts/Camera/ICameraMode.cs
@@ -6,12 +6,8 @@ using UnityEngine;
 
 public interface ICameraMode
 {
-    public void Configure<T>(CameraController cam, T? previousCam, Action<CameraController, T?>? onEnd = null) where T : ICameraMode {
-        onEnd?.Invoke(cam, previousCam);
-    }
     public void Start<T>(CameraController cam, T? previousCam) where T : ICameraMode;
     public void Update(CameraController cam);
-    public void FixedUpdate(CameraController cam);
     public void LateUpdate(CameraController cam);
     public void End(CameraController cam);
 }

--- a/engine/Assets/Scripts/Camera/ICameraMode.cs
+++ b/engine/Assets/Scripts/Camera/ICameraMode.cs
@@ -1,11 +1,17 @@
+using System;
+using UnityEditor;
 using UnityEngine;
 
 #nullable enable
 
 public interface ICameraMode
 {
+    public void Configure<T>(CameraController cam, T? previousCam, Action<CameraController, T?>? onEnd = null) where T : ICameraMode {
+        onEnd?.Invoke(cam, previousCam);
+    }
     public void Start<T>(CameraController cam, T? previousCam) where T : ICameraMode;
     public void Update(CameraController cam);
+    public void FixedUpdate(CameraController cam);
     public void LateUpdate(CameraController cam);
     public void End(CameraController cam);
 }

--- a/engine/Assets/Scripts/Camera/OrbitCameraMode.cs
+++ b/engine/Assets/Scripts/Camera/OrbitCameraMode.cs
@@ -18,7 +18,7 @@ public class OrbitCameraMode : ICameraMode
     public float ActualPitch { get; private set; } = 0.0f;
     public float ActualYaw { get; private set; } = 0.0f;
     private bool _useOrbit = false;
-
+    
     public void Start<T>(CameraController cam, T? previousCam) where T : ICameraMode {
         if (previousCam != null && previousCam.GetType() == typeof(FreeCameraMode)) {
             FreeCameraMode freeCam = (previousCam as FreeCameraMode)!;
@@ -79,6 +79,10 @@ public class OrbitCameraMode : ICameraMode
         ActualYaw = Mathf.Lerp(ActualYaw, TargetYaw, orbitLerpFactor);
         float zoomLerpFactor = Mathf.Clamp((cam.ZoomAcceleration * Time.deltaTime) / 0.018f, 0.01f, 1.0f);
         ActualZoom = Mathf.Lerp(ActualZoom, TargetZoom, zoomLerpFactor);
+    }
+    
+    public void FixedUpdate(CameraController cam) {
+        
     }
 
     public void LateUpdate(CameraController cam)

--- a/engine/Assets/Scripts/Camera/OrbitCameraMode.cs
+++ b/engine/Assets/Scripts/Camera/OrbitCameraMode.cs
@@ -80,10 +80,6 @@ public class OrbitCameraMode : ICameraMode
         float zoomLerpFactor = Mathf.Clamp((cam.ZoomAcceleration * Time.deltaTime) / 0.018f, 0.01f, 1.0f);
         ActualZoom = Mathf.Lerp(ActualZoom, TargetZoom, zoomLerpFactor);
     }
-    
-    public void FixedUpdate(CameraController cam) {
-        
-    }
 
     public void LateUpdate(CameraController cam)
     {

--- a/engine/Assets/Scripts/Camera/OrbitCameraMode.cs
+++ b/engine/Assets/Scripts/Camera/OrbitCameraMode.cs
@@ -20,10 +20,16 @@ public class OrbitCameraMode : ICameraMode
     private bool _useOrbit = false;
     
     public void Start<T>(CameraController cam, T? previousCam) where T : ICameraMode {
-        if (previousCam != null && previousCam.GetType() == typeof(FreeCameraMode)) {
-            FreeCameraMode freeCam = (previousCam as FreeCameraMode)!;
-            ActualPitch = freeCam.ActualPitch;
-            ActualYaw = freeCam.ActualYaw;
+        if (previousCam != null) {
+            if (previousCam.GetType() == typeof(FreeCameraMode)) {
+                FreeCameraMode freeCam = (previousCam as FreeCameraMode)!;
+                ActualPitch = freeCam.ActualPitch;
+                ActualYaw = freeCam.ActualYaw;
+            } else if (previousCam.GetType() == typeof(DriverStationCameraMode)) {
+                DriverStationCameraMode driverCam = (previousCam as DriverStationCameraMode)!;
+                ActualPitch = driverCam.ActualPitch;
+                ActualYaw = driverCam.ActualYaw;
+            }
         }
     }
 

--- a/engine/Assets/Scripts/Camera/OverviewCameraMode.cs
+++ b/engine/Assets/Scripts/Camera/OverviewCameraMode.cs
@@ -31,9 +31,6 @@ public class OverviewCameraMode : ICameraMode
         // user can't go under the field or too far above that they can't see it
         cam.transform.position = new Vector3(position.x, Mathf.Clamp(position.y, 0, 100), position.z);
     }
-    public void FixedUpdate(CameraController cam) {
-        
-    }
 
     public void LateUpdate(CameraController cam)
     {

--- a/engine/Assets/Scripts/Camera/OverviewCameraMode.cs
+++ b/engine/Assets/Scripts/Camera/OverviewCameraMode.cs
@@ -31,6 +31,9 @@ public class OverviewCameraMode : ICameraMode
         // user can't go under the field or too far above that they can't see it
         cam.transform.position = new Vector3(position.x, Mathf.Clamp(position.y, 0, 100), position.z);
     }
+    public void FixedUpdate(CameraController cam) {
+        
+    }
 
     public void LateUpdate(CameraController cam)
     {

--- a/engine/Assets/Scripts/Gizmos/GizmoManager.cs
+++ b/engine/Assets/Scripts/Gizmos/GizmoManager.cs
@@ -107,6 +107,7 @@ namespace Synthesis.Gizmo {
             _currentTargetTransform.rotation = _currentGizmoConfig.Value.Transform.Rotation;
             
             var gizmo = GameObject.Instantiate(SynthesisAssetCollection.GizmoPrefabStatic, _currentTargetTransform);
+            gizmo.name = "GIZMO";
         }
 
         private static void UpdateGizmo() {
@@ -126,6 +127,7 @@ namespace Synthesis.Gizmo {
             
             _currentGizmoConfig.Value.EndCallback(_currentTargetTransform);
             GameObject.Destroy(_currentTargetTransform.gameObject);
+            // GameObject.Destroy(gizmo);
 
             _currentGizmoConfig = null;
             _currentTargetTransform = null;
@@ -139,6 +141,13 @@ namespace Synthesis.Gizmo {
         public Vector3 Position;
         public Quaternion Rotation;
 
+        public static implicit operator TransformData(Vector3 position)
+            => new TransformData { Position = position, Rotation = Quaternion.identity };
+        public static implicit operator TransformData(Quaternion rotation)
+            => new TransformData {
+                Position = Vector3.zero,
+                Rotation = rotation
+            };
         public static implicit operator TransformData((Vector3, Quaternion) data)
             => new TransformData { Position = data.Item1, Rotation = data.Item2 };
         public static implicit operator TransformData(Transform t)

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/ChangeViewModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/ChangeViewModal.cs
@@ -1,8 +1,5 @@
-using System.Collections.Generic;
 using System.Linq;
-using UnityEditor;
 using UnityEngine;
-
 namespace Synthesis.UI.Dynamic
 {
     public class ChangeViewModal : ModalDynamic
@@ -46,8 +43,11 @@ namespace Synthesis.UI.Dynamic
             AcceptButton
                 .AddOnClickedEvent(b =>
                 {
-                    controller.CameraMode = CameraController.CameraModes[_selectedView];
                     DynamicUIManager.CloseActiveModal();
+                    var oldMode = controller.CameraMode;
+                    ICameraMode newMode = CameraController.CameraModes[_selectedView];
+                    controller.CameraMode = newMode;
+                    newMode.Configure(controller, oldMode, newMode.Start);
                 });
         }
 

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/ChangeViewModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/ChangeViewModal.cs
@@ -43,11 +43,8 @@ namespace Synthesis.UI.Dynamic
             AcceptButton
                 .AddOnClickedEvent(b =>
                 {
+                    controller.CameraMode = CameraController.CameraModes[_selectedView];
                     DynamicUIManager.CloseActiveModal();
-                    var oldMode = controller.CameraMode;
-                    ICameraMode newMode = CameraController.CameraModes[_selectedView];
-                    controller.CameraMode = newMode;
-                    newMode.Configure(controller, oldMode, newMode.Start);
                 });
         }
 


### PR DESCRIPTION
### Description
Lets the user go into driver station view from the view selector modal. It uses freecam movement to position the camera, and the camera will then smoothly follow the robot (rotation-wise; its location is fixed) when not holding RMB, defaulting to (0, 0, 0) when there is no robot possessed.

### Objectives
- [X] Let the user configure the location of the camera
- [X] Camera smoothly follows robot and stays fixed in place

### Testing Done
- Switch between many camera modes
- Spawn multiple robots, switch possession, delete them

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1529)
