### PR TITLE
Fixed `engine/EngineDeps/setup.bat` coloring

### DIFF
--- a/engine/EngineDeps/setup.bat
+++ b/engine/EngineDeps/setup.bat
@@ -1,18 +1,14 @@
 @echo off
 
-:highlight
-    echo ^<ESC^>[32m [32m%~1[0m
-EXIT /B 0
-
-CALL :highlight "\nRemoving Existing DLLs...\n"
+CALL :highlight "Removing Existing DLLs..."
 
 DEL /S /Q /f "..\Assets\Packages\*.dll"
 
-CALL :highlight "\nBuilding Solution...\n"
+CALL :highlight "Building Solution..."
 
 dotnet build
 
-CALL :highlight "\nInstalling Dependencies...\n"
+CALL :highlight "Installing Dependencies..."
 
 COPY  "%HOMEPATH%\.nuget\packages\google.protobuf\3.23.3\lib\netstandard2.0\Google.Protobuf.dll" "..\Assets\Packages\Google.Protobuf.dll"
 COPY  "%HOMEPATH%\.nuget\packages\mathnet.numerics\4.15.0\lib\netstandard2.0\MathNet.Numerics.dll" "..\Assets\Packages\MathNet.Numerics.dll"
@@ -23,4 +19,10 @@ COPY  "%HOMEPATH%\.nuget\packages\system.memory\4.5.3\lib\netstandard2.0\System.
 COPY  "%HOMEPATH%\.nuget\packages\system.runtime.compilerservices.unsafe\6.0.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll" "..\Assets\Packages\System.Runtime.CompilerServices.Unsafe.dll"
 COPY  "%HOMEPATH%\.nuget\packages\ionic.zip\1.9.1.8\lib\Ionic.Zip.dll" "..\Assets\Packages\Ionic.Zip.dll"
 
-CALL :highlight "\n!!! Finished Copying Dependencies !!!\n"
+CALL :highlight "!!! Finished Copying Dependencies !!!"
+
+EXIT /B 0
+
+:highlight
+    echo 
+    echo [32m%~1[0m


### PR DESCRIPTION
### Description
Fixed a problem with the windows setup script related to coloring exiting the script early.
