### PR TITLE
Fixed Can't Open Panel Bug

### DIFF
--- a/engine/Assets/Scripts/Gizmos/GizmoManager.cs
+++ b/engine/Assets/Scripts/Gizmos/GizmoManager.cs
@@ -118,10 +118,9 @@ namespace Synthesis.Gizmo {
         }
 
         public static void ExitGizmo() {
-            if (!_currentGizmoConfig.HasValue || _currentTargetTransform == null)
+            if (!_currentGizmoConfig.HasValue || _currentTargetTransform == null) {
                 return;
-
-            // Debug.Log("Exit Gizmo");
+            }
 
             SimulationRunner.RemoveContext(SimulationRunner.GIZMO_SIM_CONTEXT);
             

--- a/engine/Assets/Scripts/SimObjects/RobotSimObject.cs
+++ b/engine/Assets/Scripts/SimObjects/RobotSimObject.cs
@@ -265,6 +265,7 @@ public class RobotSimObject : SimObject, IPhysicsOverridable, IGizmo {
     }
 
     private void Unpossess() {
+        GizmoManager.ExitGizmo();
         BehavioursEnabled = false;
         Vector3 currentPoint = OrbitCameraMode.FocusPoint();
         OrbitCameraMode.FocusPoint = () => currentPoint;
@@ -622,6 +623,8 @@ public class RobotSimObject : SimObject, IPhysicsOverridable, IGizmo {
     public static bool RemoveRobot(string robot) {
         if (!_spawnedRobots.ContainsKey(robot))
             return false;
+        
+        GizmoManager.ExitGizmo();
 
         if (robot == CurrentlyPossessedRobot)
             CurrentlyPossessedRobot = string.Empty;


### PR DESCRIPTION
### Description
Fixed bug where when you remove the robot while still trying to place it, MissingReferenceException error message will appear and no other panels will open. 

### Objectives

- [x]  Fix Can't Open Other Panel's bug 

### Testing Done
- Removed the robot while trying to place it multiple times 

[JIRA Issue](https://jira.autodesk.com/browse/AARD-XXXX)
