### PR TITLE
Match End Options

### DIFF
--- a/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
@@ -11,7 +11,7 @@ namespace Modes.MatchMode {
     public class MatchMode : IMode {
         public static MatchResultsTracker MatchResultsTracker;
 
-        public static int CurrentFieldIndex = -1;
+        /// Integers to represent which robots the user selected in the MatchModeModal
         public static int[] SelectedRobots  = new int[6];
 
         /// Whether or not the robot should snap to a grid in positioning mode
@@ -113,6 +113,13 @@ namespace Modes.MatchMode {
                     Robots.Add(null);
                 i++;
             });
+        }
+
+        /// Resets the currently selected robots and field
+        public static void ResetMatchConfiguration()
+        {
+            Robots = new List<RobotSimObject>();
+            Array.Fill(SelectedRobots, -1);
         }
 
         public static string ParsePath(string p, char c) {

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
@@ -12,7 +12,7 @@ namespace Modes.MatchMode {
         public static MatchResultsTracker MatchResultsTracker;
 
         /// Integers to represent which robots the user selected in the MatchModeModal
-        public static int[] SelectedRobots  = new int[6];
+        public static int[] SelectedRobots = new int[6];
 
         /// Whether or not the robot should snap to a grid in positioning mode
         public static bool[] RoundSpawnLocation = new bool[6];
@@ -116,8 +116,7 @@ namespace Modes.MatchMode {
         }
 
         /// Resets the currently selected robots and field
-        public static void ResetMatchConfiguration()
-        {
+        public static void ResetMatchConfiguration() {
             Robots = new List<RobotSimObject>();
             Array.Fill(SelectedRobots, -1);
         }

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchResultsTracker.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchResultsTracker.cs
@@ -12,12 +12,8 @@ public class MatchResultsTracker {
         MatchResultEntries.Add(typeof(RedPoints), new RedPoints());
     }
 
-    public void ResetAllTrackedData()
-    {
-        MatchResultEntries.Values.ForEach(x =>
-        {
-            x.Reset();
-        });
+    public void ResetAllTrackedData() {
+        MatchResultEntries.Values.ForEach(x => { x.Reset(); });
     }
 
     /// The base interface for any tracked match statistics. Implement this to track a new statistic
@@ -38,8 +34,7 @@ public class MatchResultsTracker {
             return "Blue Points";
         }
 
-        public void Reset()
-        {
+        public void Reset() {
             Points = 0;
         }
     }
@@ -55,9 +50,8 @@ public class MatchResultsTracker {
         public string GetName() {
             return "Red Points";
         }
-        
-        public void Reset()
-        {
+
+        public void Reset() {
             Points = 0;
         }
     }

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchResultsTracker.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchResultsTracker.cs
@@ -12,9 +12,18 @@ public class MatchResultsTracker {
         MatchResultEntries.Add(typeof(RedPoints), new RedPoints());
     }
 
+    public void ResetAllTrackedData()
+    {
+        MatchResultEntries.Values.ForEach(x =>
+        {
+            x.Reset();
+        });
+    }
+
     /// The base interface for any tracked match statistics. Implement this to track a new statistic
     public interface ITrackedData {
         public string GetName();
+        public void Reset();
     }
 
     /// The number of points scored by the blue team
@@ -28,6 +37,11 @@ public class MatchResultsTracker {
         public string GetName() {
             return "Blue Points";
         }
+
+        public void Reset()
+        {
+            Points = 0;
+        }
     }
 
     /// The number of points scored by the red team
@@ -40,6 +54,11 @@ public class MatchResultsTracker {
 
         public string GetName() {
             return "Red Points";
+        }
+        
+        public void Reset()
+        {
+            Points = 0;
         }
     }
 }

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
@@ -251,6 +251,7 @@ public class MatchStateMachine {
                 }
                 i++;
             });
+            MatchMode.MatchResultsTracker.ResetAllTrackedData();
 
             // TODO: reset the match results tracker
             // TODO: reset the scoreboard and timer
@@ -271,6 +272,7 @@ public class MatchStateMachine {
             RobotSimObject.RemoveAllRobots();
             FieldSimObject.DeleteField();
             MatchMode.ResetMatchConfiguration();
+            MatchMode.MatchResultsTracker.ResetAllTrackedData();
 
             // TODO: reset the match results tracker
             // TODO: reset the scoreboard and timer

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
@@ -128,16 +128,16 @@ public class MatchStateMachine {
     public class MatchConfig : MatchState {
         public override void Start() {
             base.Start();
-            
+
             DynamicUIManager.CreateModal<MatchModeModal>();
-            
+
             ((MatchModeModal) DynamicUIManager.ActiveModal).OnAccepted += () =>
                 MatchStateMachine.Instance.SetState(StateName.RobotPositioning);
         }
 
         public override void Update() {}
 
-        public override void End() { }
+        public override void End() {}
 
         public MatchConfig() : base(StateName.MatchConfig) {}
     }
@@ -228,7 +228,7 @@ public class MatchStateMachine {
 
         public MatchResults() : base(StateName.MatchResults) {}
     }
-    
+
     /// Restarts the match with the same configuration
     public class Restart : MatchState {
         public override void Start() {
@@ -236,20 +236,18 @@ public class MatchStateMachine {
 
             // Reset robots to their selected spawn position
             int i = 0;
-            MatchMode.Robots.ForEach(x =>
-            {
-                if (x != null)
-                {
+            MatchMode.Robots.ForEach(x => {
+                if (x != null) {
                     (Vector3 position, Quaternion rotation) location = MatchMode.GetSpawnLocation(i);
-                    
+
                     Transform robot = x.RobotNode.transform;
 
                     robot.position = Vector3.zero;
                     robot.rotation = Quaternion.identity;
-                    
+
                     robot.rotation = location.rotation * Quaternion.Inverse(x.GroundedNode.transform.rotation);
-                    robot.position = location.position - x.GroundedNode.transform.localToWorldMatrix.MultiplyPoint(
-                        x.GroundedBounds.center);
+                    robot.position = location.position -
+                                     x.GroundedNode.transform.localToWorldMatrix.MultiplyPoint(x.GroundedBounds.center);
                 }
                 i++;
             });
@@ -266,7 +264,7 @@ public class MatchStateMachine {
 
         public Restart() : base(StateName.Restart) {}
     }
-    
+
     /// Resets the match and sends he user back to the MatchConfig modal
     public class Reconfigure : MatchState {
         public override void Start() {

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using Synthesis.Physics;
 using SynthesisAPI.EventBus;
 using UI.Dynamic.Modals;
+using UnityEngine.Rendering;
 using Random = UnityEngine.Random;
 
 public class MatchStateMachine {
@@ -53,6 +54,8 @@ public class MatchStateMachine {
         _matchStates.Add(StateName.Auto, new Auto());
         _matchStates.Add(StateName.Teleop, new Teleop());
         _matchStates.Add(StateName.MatchResults, new MatchResults());
+        _matchStates.Add(StateName.Restart, new Restart());
+        _matchStates.Add(StateName.Reconfigure, new Reconfigure());
 
         _currentState = _matchStates[StateName.None];
     }
@@ -125,16 +128,16 @@ public class MatchStateMachine {
     public class MatchConfig : MatchState {
         public override void Start() {
             base.Start();
+            
             DynamicUIManager.CreateModal<MatchModeModal>();
+            
             ((MatchModeModal) DynamicUIManager.ActiveModal).OnAccepted += () =>
                 MatchStateMachine.Instance.SetState(StateName.RobotPositioning);
         }
 
         public override void Update() {}
 
-        public override void End() {
-            base.End();
-        }
+        public override void End() { }
 
         public MatchConfig() : base(StateName.MatchConfig) {}
     }
@@ -203,7 +206,7 @@ public class MatchStateMachine {
         public override void Update() {
             // TEMP END CONDITION FOR STATE MACHINE TESTING
             if (Input.GetKeyDown(KeyCode.RightArrow))
-                MatchStateMachine.Instance.SetState(StateName.MatchResults);
+                Instance.SetState(StateName.MatchResults);
         }
 
         public override void End() {}
@@ -225,6 +228,63 @@ public class MatchStateMachine {
 
         public MatchResults() : base(StateName.MatchResults) {}
     }
+    
+    /// Restarts the match with the same configuration
+    public class Restart : MatchState {
+        public override void Start() {
+            base.Start();
+
+            // Reset robots to their selected spawn position
+            int i = 0;
+            MatchMode.Robots.ForEach(x =>
+            {
+                if (x != null)
+                {
+                    (Vector3 position, Quaternion rotation) location = MatchMode.GetSpawnLocation(i);
+                    
+                    Transform robot = x.RobotNode.transform;
+
+                    robot.position = Vector3.zero;
+                    robot.rotation = Quaternion.identity;
+                    
+                    robot.rotation = location.rotation * Quaternion.Inverse(x.GroundedNode.transform.rotation);
+                    robot.position = location.position - x.GroundedNode.transform.localToWorldMatrix.MultiplyPoint(
+                        x.GroundedBounds.center);
+                }
+                i++;
+            });
+
+            // TODO: reset the match results tracker
+            // TODO: reset the scoreboard and timer
+            // TODO: add a modal or panel to start the match so it doesn't instantly start
+            Instance.SetState(StateName.Auto);
+        }
+
+        public override void Update() {}
+
+        public override void End() {}
+
+        public Restart() : base(StateName.Restart) {}
+    }
+    
+    /// Resets the match and sends he user back to the MatchConfig modal
+    public class Reconfigure : MatchState {
+        public override void Start() {
+            RobotSimObject.RemoveAllRobots();
+            FieldSimObject.DeleteField();
+            MatchMode.ResetMatchConfiguration();
+
+            // TODO: reset the match results tracker
+            // TODO: reset the scoreboard and timer
+            Instance.SetState(StateName.MatchConfig);
+        }
+
+        public override void Update() {}
+
+        public override void End() {}
+
+        public Reconfigure() : base(StateName.Reconfigure) {}
+    }
 
 #endregion
 
@@ -235,6 +295,8 @@ public class MatchStateMachine {
         RobotPositioning,
         Auto,
         Teleop,
-        MatchResults
+        MatchResults,
+        Restart,
+        Reconfigure
     }
 }

--- a/engine/Assets/Scripts/SimObjects/RobotSimObject.cs
+++ b/engine/Assets/Scripts/SimObjects/RobotSimObject.cs
@@ -652,15 +652,11 @@ public class RobotSimObject : SimObject, IPhysicsOverridable, IGizmo {
     }
 
     /// Removes all spawned robots
-    public static void RemoveAllRobots()
-    {
+    public static void RemoveAllRobots() {
         string[] robots = new string[_spawnedRobots.Keys.Count];
         _spawnedRobots.Keys.CopyTo(robots, 0);
-        
-        robots.ForEach(x =>
-        {
-            RemoveRobot(x);
-        });
+
+        robots.ForEach(x => { RemoveRobot(x); });
     }
 
     private Dictionary<Rigidbody, (bool isKine, Vector3 vel, Vector3 angVel)> _preFreezeStates =

--- a/engine/Assets/Scripts/SimObjects/RobotSimObject.cs
+++ b/engine/Assets/Scripts/SimObjects/RobotSimObject.cs
@@ -651,6 +651,18 @@ public class RobotSimObject : SimObject, IPhysicsOverridable, IGizmo {
         return SimulationManager.RemoveSimObject(robot);
     }
 
+    /// Removes all spawned robots
+    public static void RemoveAllRobots()
+    {
+        string[] robots = new string[_spawnedRobots.Keys.Count];
+        _spawnedRobots.Keys.CopyTo(robots, 0);
+        
+        robots.ForEach(x =>
+        {
+            RemoveRobot(x);
+        });
+    }
+
     private Dictionary<Rigidbody, (bool isKine, Vector3 vel, Vector3 angVel)> _preFreezeStates =
         new Dictionary<Rigidbody, (bool isKine, Vector3 vel, Vector3 angVel)>();
     // clang-format off

--- a/engine/Assets/Scripts/UI/Dynamic/DynamicUIComponents.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/DynamicUIComponents.cs
@@ -155,27 +155,27 @@ namespace Synthesis.UI.Dynamic {
 
         private Button? _middleButton;
 
-        protected Button MiddleButton
-        {
-            get
-            {
-                if (_middleButton == null)
-                {
-                    GameObject buttonPrefab = SynthesisAssetCollection.GetUIPrefab("dynamic-modal-base").transform
-                        .Find("Footer").Find("Accept").gameObject;
-                    RectTransform buttonTransform = GameObject.Instantiate(buttonPrefab, Footer).GetComponent<RectTransform>();
-            
+        protected Button MiddleButton {
+            get {
+                if (_middleButton == null) {
+                    GameObject buttonPrefab = SynthesisAssetCollection.GetUIPrefab("dynamic-modal-base")
+                                                  .transform.Find("Footer")
+                                                  .Find("Accept")
+                                                  .gameObject;
+                    RectTransform buttonTransform =
+                        GameObject.Instantiate(buttonPrefab, Footer).GetComponent<RectTransform>();
+
                     buttonTransform.anchorMin = new Vector2(0.5f, 0f);
                     buttonTransform.anchorMax = new Vector2(0.5f, 0f);
-                    buttonTransform.pivot = new Vector2(1f, 0f);
+                    buttonTransform.pivot     = new Vector2(1f, 0f);
 
-                    buttonTransform.localPosition = new Vector3(buttonTransform.rect.width/2f,
-                        AcceptButton.RootGameObject.transform.localPosition.y, 0);
+                    buttonTransform.localPosition = new Vector3(
+                        buttonTransform.rect.width / 2f, AcceptButton.RootGameObject.transform.localPosition.y, 0);
 
                     Button middleButton = new Button(null!, buttonTransform.gameObject, null);
                     middleButton.Image.SetColor(ColorManager.SYNTHESIS_ACCEPT);
                     middleButton.Label?.SetColor(ColorManager.TryGetColor(ColorManager.SYNTHESIS_ORANGE_CONTRAST_TEXT));
-                    
+
                     _middleButton = middleButton;
                     return middleButton;
                 }
@@ -207,7 +207,7 @@ namespace Synthesis.UI.Dynamic {
             _description = new Label(null, header.Find("Description").gameObject, null);
             _description.SetColor(ColorManager.TryGetColor(ColorManager.SYNTHESIS_WHITE));
 
-            _footer = _unityObject.transform.Find("Footer");
+            _footer       = _unityObject.transform.Find("Footer");
             var footerRt  = _footer.GetComponent<RectTransform>();
             _cancelButton = new Button(null!, _footer.Find("Cancel").gameObject, null);
             _cancelButton.AddOnClickedEvent(b => {

--- a/engine/Assets/Scripts/UI/Dynamic/DynamicUIComponents.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/DynamicUIComponents.cs
@@ -148,9 +148,41 @@ namespace Synthesis.UI.Dynamic {
         protected Label Title => _title;
         private Label _description;
         protected Label Description => _description;
-
+        private Transform _footer;
+        protected Transform Footer => _footer;
         private Content _mainContent;
         protected Content MainContent => _mainContent;
+
+        private Button? _middleButton;
+
+        protected Button MiddleButton
+        {
+            get
+            {
+                if (_middleButton == null)
+                {
+                    GameObject buttonPrefab = SynthesisAssetCollection.GetUIPrefab("dynamic-modal-base").transform
+                        .Find("Footer").Find("Accept").gameObject;
+                    RectTransform buttonTransform = GameObject.Instantiate(buttonPrefab, Footer).GetComponent<RectTransform>();
+            
+                    buttonTransform.anchorMin = new Vector2(0.5f, 0f);
+                    buttonTransform.anchorMax = new Vector2(0.5f, 0f);
+                    buttonTransform.pivot = new Vector2(1f, 0f);
+
+                    buttonTransform.localPosition = new Vector3(buttonTransform.rect.width/2f,
+                        AcceptButton.RootGameObject.transform.localPosition.y, 0);
+
+                    Button middleButton = new Button(null!, buttonTransform.gameObject, null);
+                    middleButton.Image.SetColor(ColorManager.SYNTHESIS_ACCEPT);
+                    middleButton.Label?.SetColor(ColorManager.TryGetColor(ColorManager.SYNTHESIS_ORANGE_CONTRAST_TEXT));
+                    
+                    _middleButton = middleButton;
+                    return middleButton;
+                }
+
+                return _middleButton;
+            }
+        }
 
         protected ModalDynamic(Vector2 mainContentSize) {
             _mainContentSize = mainContentSize;
@@ -175,16 +207,16 @@ namespace Synthesis.UI.Dynamic {
             _description = new Label(null, header.Find("Description").gameObject, null);
             _description.SetColor(ColorManager.TryGetColor(ColorManager.SYNTHESIS_WHITE));
 
-            var footer    = _unityObject.transform.Find("Footer");
-            var footerRt  = footer.GetComponent<RectTransform>();
-            _cancelButton = new Button(null!, footer.Find("Cancel").gameObject, null);
+            _footer = _unityObject.transform.Find("Footer");
+            var footerRt  = _footer.GetComponent<RectTransform>();
+            _cancelButton = new Button(null!, _footer.Find("Cancel").gameObject, null);
             _cancelButton.AddOnClickedEvent(b => {
                 if (!DynamicUIManager.CloseActiveModal())
                     Logger.Log("Failed to Close Modal", LogLevel.Error);
             });
             _cancelButton.Image.SetColor(ColorManager.SYNTHESIS_CANCEL);
             _cancelButton.Label.SetColor(ColorManager.TryGetColor(ColorManager.SYNTHESIS_ORANGE_CONTRAST_TEXT));
-            _acceptButton = new Button(null!, footer.Find("Accept").gameObject, null);
+            _acceptButton = new Button(null!, _footer.Find("Accept").gameObject, null);
             _acceptButton.Image.SetColor(ColorManager.SYNTHESIS_ACCEPT);
             _acceptButton.Label.SetColor(ColorManager.TryGetColor(ColorManager.SYNTHESIS_ORANGE_CONTRAST_TEXT));
 

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/MatchResultsModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/MatchResultsModal.cs
@@ -44,10 +44,12 @@ namespace UI.Dynamic.Modals {
             CancelButton
                 .AddOnClickedEvent(x => {
                     SimulationRunner.InSim = false;
-                    DynamicUIManager.CloseAllPanels(true);
                     ModeManager.CurrentMode = null;
-                    SceneManager.LoadScene("GridMenuScene", LoadSceneMode.Single);
+
+                    DynamicUIManager.CloseAllPanels(true);
                     DynamicUIManager.CloseActiveModal();
+                    
+                    SceneManager.LoadScene("GridMenuScene", LoadSceneMode.Single);
                 })
                 .StepIntoLabel(l => l.SetText("Exit"));
             
@@ -57,7 +59,7 @@ namespace UI.Dynamic.Modals {
                     DynamicUIManager.CloseActiveModal();
                     MatchStateMachine.Instance.SetState(MatchStateMachine.StateName.Reconfigure);
                 })
-                .StepIntoLabel(l => l.SetText("Reconfigure"));
+                .StepIntoLabel(l => l.SetText("Configure"));
             
             AcceptButton
                 .AddOnClickedEvent(x => {

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/MatchResultsModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/MatchResultsModal.cs
@@ -40,34 +40,31 @@ namespace UI.Dynamic.Modals {
             Title.SetText("Match Results");
             Description.SetText("Statistics about the match");
 
-            
             CancelButton
                 .AddOnClickedEvent(x => {
-                    SimulationRunner.InSim = false;
+                    SimulationRunner.InSim  = false;
                     ModeManager.CurrentMode = null;
 
                     DynamicUIManager.CloseAllPanels(true);
                     DynamicUIManager.CloseActiveModal();
-                    
+
                     SceneManager.LoadScene("GridMenuScene", LoadSceneMode.Single);
                 })
                 .StepIntoLabel(l => l.SetText("Exit"));
-            
+
             MiddleButton
-                .AddOnClickedEvent(x =>
-                {
+                .AddOnClickedEvent(x => {
                     DynamicUIManager.CloseActiveModal();
                     MatchStateMachine.Instance.SetState(MatchStateMachine.StateName.Reconfigure);
                 })
                 .StepIntoLabel(l => l.SetText("Configure"));
-            
+
             AcceptButton
                 .AddOnClickedEvent(x => {
                     DynamicUIManager.CloseActiveModal();
                     MatchStateMachine.Instance.SetState(MatchStateMachine.StateName.Restart);
                 })
                 .StepIntoLabel(l => l.SetText("Restart"));
-            
 
             CreateScrollMenu();
         }
@@ -104,9 +101,7 @@ namespace UI.Dynamic.Modals {
             });
         }
 
-        public override void Update()
-        {
-        }
+        public override void Update() {}
 
         public override void Delete() {}
     }

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/MatchResultsModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/MatchResultsModal.cs
@@ -41,15 +41,27 @@ namespace UI.Dynamic.Modals {
 
             AcceptButton
                 .AddOnClickedEvent(x => {
-                    MatchStateMachine.Instance.SetState(MatchStateMachine.StateName.None);
-                    DynamicUIManager.CreateModal<ExitSynthesisModal>();
+                    
                 })
-                .StepIntoLabel(l => l.SetText("Exit"));
+                .StepIntoLabel(l => l.SetText("3"));
+            
+            MiddleButton
+                .AddOnClickedEvent(x =>
+                {
 
-            CancelButton.RootGameObject.SetActive(false);
+                })
+                .StepIntoLabel(l => l.SetText("2"));
+
+            CancelButton
+                .AddOnClickedEvent(x => {
+                    
+                })
+                .StepIntoLabel(l => l.SetText("1"));
 
             CreateScrollMenu();
         }
+
+        private RectTransform _middleButtonObject;
 
         /// Creates the main scroll menu and adds all of the match result entries
         public void CreateScrollMenu() {
@@ -81,7 +93,9 @@ namespace UI.Dynamic.Modals {
             });
         }
 
-        public override void Update() {}
+        public override void Update()
+        {
+        }
 
         public override void Delete() {}
     }

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/MatchResultsModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/MatchResultsModal.cs
@@ -1,5 +1,6 @@
 using System;
 using Modes.MatchMode;
+using Synthesis.Runtime;
 using Synthesis.UI;
 using Synthesis.UI.Dynamic;
 using UnityEngine;
@@ -39,24 +40,32 @@ namespace UI.Dynamic.Modals {
             Title.SetText("Match Results");
             Description.SetText("Statistics about the match");
 
-            AcceptButton
+            
+            CancelButton
                 .AddOnClickedEvent(x => {
-                    
+                    SimulationRunner.InSim = false;
+                    DynamicUIManager.CloseAllPanels(true);
+                    ModeManager.CurrentMode = null;
+                    SceneManager.LoadScene("GridMenuScene", LoadSceneMode.Single);
+                    DynamicUIManager.CloseActiveModal();
                 })
-                .StepIntoLabel(l => l.SetText("3"));
+                .StepIntoLabel(l => l.SetText("Exit"));
             
             MiddleButton
                 .AddOnClickedEvent(x =>
                 {
-
+                    DynamicUIManager.CloseActiveModal();
+                    MatchStateMachine.Instance.SetState(MatchStateMachine.StateName.Reconfigure);
                 })
-                .StepIntoLabel(l => l.SetText("2"));
-
-            CancelButton
+                .StepIntoLabel(l => l.SetText("Reconfigure"));
+            
+            AcceptButton
                 .AddOnClickedEvent(x => {
-                    
+                    DynamicUIManager.CloseActiveModal();
+                    MatchStateMachine.Instance.SetState(MatchStateMachine.StateName.Restart);
                 })
-                .StepIntoLabel(l => l.SetText("1"));
+                .StepIntoLabel(l => l.SetText("Restart"));
+            
 
             CreateScrollMenu();
         }

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/Spawning/MatchModeModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/Spawning/MatchModeModal.cs
@@ -83,19 +83,19 @@ public class MatchModeModal : ModalDynamic {
 
     public IEnumerator LoadMatch() {
         yield return new WaitForSeconds(0.05f);
-        
-            if (FieldSimObject.CurrentField != null)
-                FieldSimObject.DeleteField();
 
-            FieldSimObject.SpawnField(_fieldFiles[_fieldIndex], false);
+        if (FieldSimObject.CurrentField != null)
+            FieldSimObject.DeleteField();
 
-            DynamicUIManager.CloseActiveModal();
+        FieldSimObject.SpawnField(_fieldFiles[_fieldIndex], false);
+
+        DynamicUIManager.CloseActiveModal();
         DynamicUIManager.CreatePanel<SpawnLocationPanel>();
     }
 
     public override void Update() {}
 
-    public override void Delete() { }
+    public override void Delete() {}
 
     public static string ParsePath(string p, char c) {
         string[] a = p.Split(c);

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/Spawning/MatchModeModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/Spawning/MatchModeModal.cs
@@ -83,21 +83,19 @@ public class MatchModeModal : ModalDynamic {
 
     public IEnumerator LoadMatch() {
         yield return new WaitForSeconds(0.05f);
-
-        if (MatchMode.CurrentFieldIndex != _fieldIndex) {
+        
             if (FieldSimObject.CurrentField != null)
                 FieldSimObject.DeleteField();
-            FieldSimObject.SpawnField(_fieldFiles[_fieldIndex], false);
-            MatchMode.CurrentFieldIndex = _fieldIndex;
-        }
 
-        DynamicUIManager.CloseActiveModal();
+            FieldSimObject.SpawnField(_fieldFiles[_fieldIndex], false);
+
+            DynamicUIManager.CloseActiveModal();
         DynamicUIManager.CreatePanel<SpawnLocationPanel>();
     }
 
     public override void Update() {}
 
-    public override void Delete() {}
+    public override void Delete() { }
 
     public static string ParsePath(string p, char c) {
         string[] a = p.Split(c);

--- a/engine/Assets/Scripts/UI/Dynamic/Panels/SpawnLocationPanel.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Panels/SpawnLocationPanel.cs
@@ -41,7 +41,6 @@ namespace Synthesis.UI.Dynamic {
 
         private readonly Button[] buttons             = new Button[6];
         private readonly Transform[] _robotHighlights = new Transform[6];
-        private readonly Vector3[] _robotOffsets      = new Vector3[6];
 
         private readonly Func<Button, Button> DisabledTemplate = b =>
             b.StepIntoImage(i => i.SetColor(ColorManager.SYNTHESIS_BLACK_ACCENT))
@@ -124,9 +123,6 @@ namespace Synthesis.UI.Dynamic {
                 RobotSimObject simObject = MatchMode.Robots[i];
                 if (simObject != null) {
                     obj.transform.localScale = MatchMode.Robots[i].RobotBounds.size;
-                    _robotOffsets[i] =
-                        simObject.RobotNode.transform.localToWorldMatrix.MultiplyPoint(simObject.RobotBounds.center) +
-                        Vector3.down * 0.496f;
                 }
 
                 _robotHighlights[i] = obj.transform;


### PR DESCRIPTION
### Description
On the match results panel, there are now 3 options. Exit will quit to the main menu, restart will restart the match with the same settings, and configure will reset all of the robots and fields then open the match configuration menu. MiddleButton in ModalDynamic creates the unity object in a getter by calling instantiate with the accept button as a prefab.

### Objectives
- [x] Add a 3rd button to the match results panel
- [x] Add functionality to the buttons

### Testing Done
- Tested loading in multiple robots then clicking configure or restart
- Tested configure and restart with no robots spawned in
- Restarted and reconfigured the match multiple times

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1559)
