### PR TITLE
Double Counted Scoring

### DIFF
--- a/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
@@ -141,7 +141,12 @@ namespace Modes.MatchMode {
             }
         }
 
-        public void End() {}
+        public void End()
+        {
+            Scoring.redScore = 0;
+            Scoring.blueScore = 0;
+            EventBus.RemoveTypeListener<OnScoreUpdateEvent>(HandleScoreEvent);
+        }
 
         public void OpenMenu() {}
 

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
@@ -142,7 +142,7 @@ namespace Modes.MatchMode {
         }
 
         public void End() {
-            Scoring.redScore = 0;
+            Scoring.redScore  = 0;
             Scoring.blueScore = 0;
             EventBus.RemoveTypeListener<OnScoreUpdateEvent>(HandleScoreEvent);
         }

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
@@ -141,8 +141,7 @@ namespace Modes.MatchMode {
             }
         }
 
-        public void End()
-        {
+        public void End() {
             Scoring.redScore = 0;
             Scoring.blueScore = 0;
             EventBus.RemoveTypeListener<OnScoreUpdateEvent>(HandleScoreEvent);

--- a/engine/Assets/Scripts/Modes/PracticeMode.cs
+++ b/engine/Assets/Scripts/Modes/PracticeMode.cs
@@ -162,7 +162,7 @@ public class PracticeMode : IMode {
 
     public void End() {
         InputManager._mappedValueInputs.Remove(TOGGLE_ESCAPE_MENU_INPUT);
-        Scoring.redScore = 0;
+        Scoring.redScore  = 0;
         Scoring.blueScore = 0;
         EventBus.RemoveTypeListener<OnScoreUpdateEvent>(HandleScoreEvent);
     }

--- a/engine/Assets/Scripts/Modes/PracticeMode.cs
+++ b/engine/Assets/Scripts/Modes/PracticeMode.cs
@@ -91,7 +91,7 @@ public class PracticeMode : IMode {
             }
         });
 
-        EventBus.NewTypeListener<OnScoreUpdateEvent>(HandleScoreEvent);
+//        EventBus.NewTypeListener<OnScoreUpdateEvent>(HandleScoreEvent);
     }
 
     private void HandleScoreEvent(IEvent e) {

--- a/engine/Assets/Scripts/Modes/PracticeMode.cs
+++ b/engine/Assets/Scripts/Modes/PracticeMode.cs
@@ -162,6 +162,9 @@ public class PracticeMode : IMode {
 
     public void End() {
         InputManager._mappedValueInputs.Remove(TOGGLE_ESCAPE_MENU_INPUT);
+        Scoring.redScore = 0;
+        Scoring.blueScore = 0;
+        EventBus.RemoveTypeListener<OnScoreUpdateEvent>(HandleScoreEvent);
     }
 
     public static void ConfigureGamepieceSpawnpoint() {

--- a/engine/Assets/Scripts/Modes/PracticeMode.cs
+++ b/engine/Assets/Scripts/Modes/PracticeMode.cs
@@ -90,8 +90,6 @@ public class PracticeMode : IMode {
                     DynamicUIManager.CreatePanel<ScoringZonesPanel>();
             }
         });
-
-//        EventBus.NewTypeListener<OnScoreUpdateEvent>(HandleScoreEvent);
     }
 
     private void HandleScoreEvent(IEvent e) {


### PR DESCRIPTION
### Description
Fixed many bugs related to scoring such as doubled counted scoring in practice mode, the score not getting reset when switching modes, and TypeListeners stacking when you change modes. 

### Objectives
- [x] Prevent double counted scoring
- [x] Set scores to zero when exiting a mode
- [x] Remove TypeListeners when exiting a mode 

### Testing Done
- Tested scoring points in practice mode
- Changed modes to see if scores would be set back to zero 
- Exited and entered practice mode to see if TypeListeners would stack and 

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1581)
