### PR TITLE
Update Clang Format action to use clang-format-16

### DIFF
--- a/.github/workflows/ClangFormat.yml
+++ b/.github/workflows/ClangFormat.yml
@@ -14,10 +14,9 @@ jobs:
     steps:
     - name: Get Clang Format
       run: |
-        sudo apt-get update
-        sudo apt-get install --no-install-recommends -y
-        sudo apt-get install clang-format-15
-        sudo mv /usr/bin/clang-format-15 /usr/bin/clang-format
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 16
     - name: Checkout Code
       uses: actions/checkout@v2
     - name: Python Setup

--- a/.github/workflows/ClangFormat.yml
+++ b/.github/workflows/ClangFormat.yml
@@ -16,7 +16,7 @@ jobs:
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 16
+        sudo ./llvm.sh 16 all
     - name: Checkout Code
       uses: actions/checkout@v2
     - name: Python Setup

--- a/scripts/format/format_validation.py
+++ b/scripts/format/format_validation.py
@@ -5,27 +5,15 @@ import sys
 FILES_DIRS = ["engine/Assets/Scripts"]
 FILE_TARGETS = [".cs"]
 
-"""
-As of 6/23/2023, clang-format-16 is not available on Ubuntu through apt-get.
-Trying to validate these files on clang-format-15 will cause a segfault. This is the current workaround.
-"""
-IGNORED_FILES = set([
-    # "engine/Assets/Scripts/UI/Dynamic/DynamicUIManager.cs",
-    # "engine/Assets/Scripts/WebSockets/WebSocketManager.cs"
-])
-
-
 def main():
     if sys.platform != "linux":
         print("Warning: This script was designed to be run by github action linux machines")
-
-    subprocess.call(["clang-format-16", "--version"])
 
     files = []
     for dir in FILES_DIRS:
         for root, _, filenames in os.walk(dir):
             for filename in filenames:
-                if os.path.splitext(filename)[1] in FILE_TARGETS and f"{root}/{filename}" not in IGNORED_FILES:
+                if os.path.splitext(filename)[1] in FILE_TARGETS:
                     files.append(os.path.abspath(os.path.join(root, filename)))
 
     exit_code = 0

--- a/scripts/format/format_validation.py
+++ b/scripts/format/format_validation.py
@@ -19,7 +19,7 @@ def main():
     if sys.platform != "linux":
         print("Warning: This script was designed to be run by github action linux machines")
 
-    subprocess.call(["clang-format", "--version"])
+    subprocess.call(["clang-format-16", "--version"])
 
     files = []
     for dir in FILES_DIRS:
@@ -34,7 +34,7 @@ def main():
             previous_file_state = f.readlines()
 
         subprocess.call(
-            ["clang-format", "-i", "-style=file", file],
+            ["clang-format-16", "-i", "-style=file", file],
             bufsize=1,
             shell=False,
         )

--- a/scripts/format/format_validation.py
+++ b/scripts/format/format_validation.py
@@ -19,6 +19,8 @@ def main():
     if sys.platform != "linux":
         print("Warning: This script was designed to be run by github action linux machines")
 
+    subprocess.call(["clang-format", "--version"])
+
     files = []
     for dir in FILES_DIRS:
         for root, _, filenames in os.walk(dir):

--- a/scripts/format/format_validation.py
+++ b/scripts/format/format_validation.py
@@ -10,8 +10,8 @@ As of 6/23/2023, clang-format-16 is not available on Ubuntu through apt-get.
 Trying to validate these files on clang-format-15 will cause a segfault. This is the current workaround.
 """
 IGNORED_FILES = set([
-    "engine/Assets/Scripts/UI/Dynamic/DynamicUIManager.cs",
-    "engine/Assets/Scripts/WebSockets/WebSocketManager.cs"
+    # "engine/Assets/Scripts/UI/Dynamic/DynamicUIManager.cs",
+    # "engine/Assets/Scripts/WebSockets/WebSocketManager.cs"
 ])
 
 


### PR DESCRIPTION
### Description
Update Clang Format action to use clang-format-16. Homebrew only supports clang-format 8, 11, and 16 so this makes formatting easier on Mac and will let us switch to the regular clang-format-16 more easily later.

### Objectives
- [X] Install and run clang-format-16

### Testing Done
- Format files with clang-format-16 and then validate them

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1592)
