### PR TITLE
Beta bugs

### DIFF
--- a/engine/Assets/Prefabs/MainMenu/MenuPanel.prefab
+++ b/engine/Assets/Prefabs/MainMenu/MenuPanel.prefab
@@ -35,7 +35,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 203.942, y: 124.5}
+  m_AnchoredPosition: {x: 203.94238, y: 124.5}
   m_SizeDelta: {x: 164.613, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1515119109010333078
@@ -518,7 +518,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -96, y: -45}
+  m_AnchoredPosition: {x: -96, y: -35}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4982241176548875976
@@ -584,7 +584,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -2927,6 +2927,7 @@ GameObject:
   - component: {fileID: 7650142357145042731}
   - component: {fileID: 8299766618362973656}
   - component: {fileID: 5918555264457123375}
+  - component: {fileID: 3742070991845310211}
   m_Layer: 5
   m_Name: SocialsButton
   m_TagString: Untagged
@@ -2951,7 +2952,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 45}
+  m_AnchoredPosition: {x: 0, y: 55}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7650142357145042731
@@ -3073,7 +3074,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -3107,6 +3108,20 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &3742070991845310211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6467115307618636652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b4beff8dfc316ef46af2e567d41144e1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sizeStart: 0
+  sizeEnd: 30
 --- !u!1 &6705991427988994757
 GameObject:
   m_ObjectHideFlags: 0
@@ -3292,7 +3307,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -280, y: -45}
+  m_AnchoredPosition: {x: -280, y: -35}
   m_SizeDelta: {x: 250, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1316101759688776880
@@ -3360,7 +3375,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -3876,7 +3891,6 @@ GameObject:
   - component: {fileID: 4758894416657705936}
   - component: {fileID: 7455120067468898109}
   - component: {fileID: 5092367183751081367}
-  - component: {fileID: 6136904902320570529}
   - component: {fileID: 7556145504087482516}
   m_Layer: 5
   m_Name: MakeAnythingImage
@@ -3884,7 +3898,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &4758894416657705936
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3902,8 +3916,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -330, y: 0}
-  m_SizeDelta: {x: -540, y: 0}
+  m_AnchoredPosition: {x: -319.08887, y: 0}
+  m_SizeDelta: {x: -536.1231, y: -30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7455120067468898109
 CanvasRenderer:
@@ -3943,50 +3957,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &6136904902320570529
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7692753560248411300}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 5092367183751081367}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &7556145504087482516
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3994,11 +3964,12 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7692753560248411300}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 862bef5238d6776428229d7d3793632e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _maxRatio: 1.5
 --- !u!1 &7861776554651449354
 GameObject:
   m_ObjectHideFlags: 0
@@ -5498,7 +5469,7 @@ RectTransform:
   - {fileID: 3042156332687130133}
   - {fileID: 4675518427868541470}
   m_Father: {fileID: 0}
-  m_RootOrder: -1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -7194,7 +7165,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -660, y: -45}
+  m_AnchoredPosition: {x: -660, y: -35}
   m_SizeDelta: {x: 250, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1008696145373591341
@@ -7260,7 +7231,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/engine/Assets/Scenes/GridMenuScene.unity
+++ b/engine/Assets/Scenes/GridMenuScene.unity
@@ -6170,6 +6170,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 817081843}
     m_Modifications:
+    - target: {fileID: 386305692573586000, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 203.94238
+      objectReference: {fileID: 0}
     - target: {fileID: 583234295272538043, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -35
@@ -6186,6 +6190,46 @@ PrefabInstance:
       propertyPath: m_VerticalAlignment
       value: 512
       objectReference: {fileID: 0}
+    - target: {fileID: 4758894416657705936, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4758894416657705936, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4758894416657705936, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4758894416657705936, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4758894416657705936, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -536.1231
+      objectReference: {fileID: 0}
+    - target: {fileID: 4758894416657705936, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: -30
+      objectReference: {fileID: 0}
+    - target: {fileID: 4758894416657705936, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -319.08887
+      objectReference: {fileID: 0}
+    - target: {fileID: 4758894416657705936, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4927816837996252186, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5092367183751081367, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_PreserveAspect
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5918555264457123375, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
       propertyPath: m_VerticalAlignment
       value: 512
@@ -6193,6 +6237,18 @@ PrefabInstance:
     - target: {fileID: 6530344004465475894, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -35
+      objectReference: {fileID: 0}
+    - target: {fileID: 7556145504087482516, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: _maxRatio
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7556145504087482516, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7692753560248411300, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8178300921806933670, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
       propertyPath: m_Name
@@ -6290,7 +6346,8 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -35
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6136904902320570529, guid: a164eb99c8d3069438923ac0c0b61657, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:

--- a/engine/Assets/Scenes/GridMenuScene.unity
+++ b/engine/Assets/Scenes/GridMenuScene.unity
@@ -2090,10 +2090,10 @@ RectTransform:
   m_Father: {fileID: 1049252815}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &738148807
 GameObject:

--- a/engine/Assets/Scripts/Gizmos/GizmoManager.cs
+++ b/engine/Assets/Scripts/Gizmos/GizmoManager.cs
@@ -16,7 +16,7 @@ namespace Synthesis.Gizmo {
         public static GizmoConfig? CurrentGizmoConfig => _currentGizmoConfig;
         private static Transform? _currentTargetTransform;
 
-        static GizmoManager() {
+        public static void Setup() {
             SimulationRunner.OnUpdate += UpdateGizmo;
 
             InputManager.AssignDigitalInput(

--- a/engine/Assets/Scripts/GodMode.cs
+++ b/engine/Assets/Scripts/GodMode.cs
@@ -60,7 +60,7 @@ public class GodMode : MonoBehaviour {
                 if (hit) {
                     grabbedObject = GetGameObjectWithRigidbody(hitInfo.collider.gameObject);
                     if (grabbedObject != null) {
-                        _pointer       = new GameObject("GODMODE_POINTER_RB");
+                        _pointer                 = new GameObject("GODMODE_POINTER_RB");
                         _pointerBody             = _pointer.AddComponent<Rigidbody>();
                         _pointerBody.isKinematic = true;
 
@@ -102,7 +102,7 @@ public class GodMode : MonoBehaviour {
             Destroy(_pointerBody);
             if (_pointer != null)
                 Destroy(_pointer);
-            
+
             _pointerBody                                     = null;
             grabbedObject.GetComponent<Rigidbody>().velocity = _speed;
             grabbedObject                                    = null;

--- a/engine/Assets/Scripts/GodMode.cs
+++ b/engine/Assets/Scripts/GodMode.cs
@@ -46,6 +46,8 @@ public class GodMode : MonoBehaviour {
     private float _lastUpdate = float.NaN;
     private Vector3 _speed, _lastPosition;
 
+    private GameObject _pointer;
+
     private void Update() {
         bool godModeKeyDown = InputManager.MappedValueInputs[ENABLED_GOD_MODE_INPUT].Value == 1.0F;
         bool mouseDown      = InputManager.MappedValueInputs[GOD_MODE_DRAG_INPUT].Value == 1.0F;
@@ -58,8 +60,8 @@ public class GodMode : MonoBehaviour {
                 if (hit) {
                     grabbedObject = GetGameObjectWithRigidbody(hitInfo.collider.gameObject);
                     if (grabbedObject != null) {
-                        GameObject gameObj       = new GameObject("GODMODE_POINTER_RB");
-                        _pointerBody             = gameObj.AddComponent<Rigidbody>();
+                        _pointer       = new GameObject("GODMODE_POINTER_RB");
+                        _pointerBody             = _pointer.AddComponent<Rigidbody>();
                         _pointerBody.isKinematic = true;
 
                         _lastUpdate   = Time.realtimeSinceStartup;
@@ -98,6 +100,9 @@ public class GodMode : MonoBehaviour {
         if (!mouseDown && grabJoint != null) {
             Destroy(grabJoint);
             Destroy(_pointerBody);
+            if (_pointer != null)
+                Destroy(_pointer);
+            
             _pointerBody                                     = null;
             grabbedObject.GetComponent<Rigidbody>().velocity = _speed;
             grabbedObject                                    = null;

--- a/engine/Assets/Scripts/Modes/Aether/ServerTestMode.cs
+++ b/engine/Assets/Scripts/Modes/Aether/ServerTestMode.cs
@@ -51,6 +51,7 @@ public class ServerTestMode : IMode {
         _ghost.Freeze();
 
         SimulationRunner.OnGameObjectDestroyed += End;
+        MainHUD.RemoveAllItemsFromDrawer();
     }
 
     public void KillClient(int i) {
@@ -63,7 +64,14 @@ public class ServerTestMode : IMode {
         }
     }
 
+    private bool _isFrozen = false;
+
     public void Update() {
+        if (_ghost is not null && !_isFrozen) {
+            _ghost.Freeze();
+            _isFrozen = true;
+        }
+
         var transformsList = new List<ServerTransforms>();
         if (_ghost is null || _host is null)
             return;

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
@@ -11,6 +11,9 @@ using Logger = SynthesisAPI.Utilities.Logger;
 
 namespace Modes.MatchMode {
     public class MatchMode : IMode {
+
+        public static float MatchTime = 15f;
+        
         public static MatchResultsTracker MatchResultsTracker;
 
         /// Integers to represent which robots the user selected in the MatchModeModal
@@ -93,7 +96,7 @@ namespace Modes.MatchMode {
             if (_stateMachine != null) {
                 _stateMachine.Update();
 
-                if (Scoring.targetTime <= 0 && _stateMachine.CurrentState.StateName is >=
+                if (MatchTime <= 0 && _stateMachine.CurrentState.StateName is >=
                                                    MatchStateMachine.StateName.Auto and <=
                                                    MatchStateMachine.StateName.Endgame)
                     _stateMachine.AdvanceState();

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
@@ -32,7 +32,7 @@ namespace Modes.MatchMode {
         }
 
         public static List<RobotSimObject> Robots = new List<RobotSimObject>();
-        
+
         public const string PREVIOUS_SPAWN_LOCATION = "Previous Spawn Location";
         public const string PREVIOUS_SPAWN_ROTATION = "Previous Spawn Rotation";
 

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
@@ -32,10 +32,7 @@ namespace Modes.MatchMode {
         }
 
         public static List<RobotSimObject> Robots = new List<RobotSimObject>();
-
-        private int _redScore  = 0;
-        private int _blueScore = 0;
-
+        
         public const string PREVIOUS_SPAWN_LOCATION = "Previous Spawn Location";
         public const string PREVIOUS_SPAWN_ROTATION = "Previous Spawn Rotation";
 
@@ -79,16 +76,14 @@ namespace Modes.MatchMode {
         public void SetupMatchResultTracking() {
             MatchResultsTracker = new MatchResultsTracker();
 
-            SynthesisAPI.EventBus.EventBus.NewTypeListener<OnScoreUpdateEvent>(e => {
+            EventBus.NewTypeListener<OnScoreUpdateEvent>(e => {
                 ScoringZone zone = ((OnScoreUpdateEvent) e).Zone;
                 switch (zone.Alliance) {
                     case Alliance.Blue:
                         ((BluePoints) MatchResultsTracker.MatchResultEntries[typeof(BluePoints)]).Points += zone.Points;
-                        _blueScore += zone.Points;
                         break;
                     case Alliance.Red:
                         ((RedPoints) MatchResultsTracker.MatchResultEntries[typeof(RedPoints)]).Points += zone.Points;
-                        _redScore += zone.Points;
                         break;
                 }
             });

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchMode.cs
@@ -11,9 +11,8 @@ using Logger = SynthesisAPI.Utilities.Logger;
 
 namespace Modes.MatchMode {
     public class MatchMode : IMode {
-
         public static float MatchTime = 15f;
-        
+
         public static MatchResultsTracker MatchResultsTracker;
 
         /// Integers to represent which robots the user selected in the MatchModeModal
@@ -96,9 +95,8 @@ namespace Modes.MatchMode {
             if (_stateMachine != null) {
                 _stateMachine.Update();
 
-                if (MatchTime <= 0 && _stateMachine.CurrentState.StateName is >=
-                                                   MatchStateMachine.StateName.Auto and <=
-                                                   MatchStateMachine.StateName.Endgame)
+                if (MatchTime <= 0 && _stateMachine.CurrentState.StateName is >= MatchStateMachine.StateName.Auto and <=
+                                          MatchStateMachine.StateName.Endgame)
                     _stateMachine.AdvanceState();
             }
         }

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
@@ -168,7 +168,7 @@ namespace Modes.MatchMode {
 
             public override void End() {
                 base.End();
-                
+
                 if (Camera.main != null) {
                     Camera.main.GetComponent<CameraController>().CameraMode = CameraController.CameraModes["Orbit"];
                 }
@@ -188,7 +188,6 @@ namespace Modes.MatchMode {
                     DynamicUIManager.CreateModal<ConfirmModal>("Start Match?");
                     DynamicUIManager.ActiveModal.OnAccepted += () => {
                         DynamicUIManager.CloseActiveModal();
-                        DynamicUIManager.CreatePanel<ScoreboardPanel>(true, true);
                         Instance.SetState(StateName.Auto);
                     };
                     DynamicUIManager.ActiveModal.OnCancelled += () => {

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
@@ -317,6 +317,9 @@ namespace Modes.MatchMode {
             public override void Start() {
                 base.Start();
 
+                DynamicUIManager.CloseActiveModal();
+                DynamicUIManager.CloseAllPanels(true);
+                
                 // Reset robots to their selected spawn position
                 int i = 0;
                 MatchMode.Robots.ForEach(x => {
@@ -335,10 +338,15 @@ namespace Modes.MatchMode {
                     i++;
                 });
 
-                // TODO: reset the match results tracker
-                // TODO: reset the scoreboard and timer
-                // TODO: add a modal or panel to start the match so it doesn't instantly start
-                Instance.SetState(StateName.Auto);
+                DynamicUIManager.CreateModal<ConfirmModal>("Start Match?");
+                DynamicUIManager.ActiveModal.OnAccepted += () => {
+                    DynamicUIManager.CloseActiveModal();
+                    Instance.SetState(StateName.Auto);
+                };
+                DynamicUIManager.ActiveModal.OnCancelled += () => {
+                    DynamicUIManager.CloseActiveModal();
+                    Instance.SetState(StateName.Reconfigure);
+                };
             }
 
             public override void Update() {}
@@ -351,12 +359,13 @@ namespace Modes.MatchMode {
         /// Resets the match and sends he user back to the MatchConfig modal
         public class Reconfigure : MatchState {
             public override void Start() {
+                DynamicUIManager.CloseActiveModal();
+                DynamicUIManager.CloseAllPanels(true);
+                
                 RobotSimObject.RemoveAllRobots();
                 FieldSimObject.DeleteField();
                 MatchMode.ResetMatchConfiguration();
-
-                // TODO: reset the match results tracker
-                // TODO: reset the scoreboard and timer
+                
                 Instance.SetState(StateName.MatchConfig);
             }
 

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
@@ -150,7 +150,6 @@ namespace Modes.MatchMode {
             public override void Start() {
                 base.Start();
 
-                
                 PhysicsManager.IsFrozen = true;
                 MatchMode.SpawnAllRobots();
 
@@ -220,7 +219,7 @@ namespace Modes.MatchMode {
                 PhysicsManager.IsFrozen = false;
             }
 
-            public override void Update() { }
+            public override void Update() {}
 
             public override void End() {
                 base.End();

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
@@ -168,9 +168,7 @@ namespace Modes.MatchMode {
 
             public override void End() {
                 base.End();
-
-                PhysicsManager.IsFrozen = false;
-
+                
                 if (Camera.main != null) {
                     Camera.main.GetComponent<CameraController>().CameraMode = CameraController.CameraModes["Orbit"];
                 }
@@ -219,6 +217,7 @@ namespace Modes.MatchMode {
 
                 AnalyticsManager.LogCustomEvent(
                     AnalyticsEvent.MatchStarted, ("NumRobots", RobotSimObject.SpawnedRobots.Count));
+                PhysicsManager.IsFrozen = false;
             }
 
             public override void Update() {}

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
@@ -319,7 +319,7 @@ namespace Modes.MatchMode {
 
                 DynamicUIManager.CloseActiveModal();
                 DynamicUIManager.CloseAllPanels(true);
-                
+
                 // Reset robots to their selected spawn position
                 int i = 0;
                 MatchMode.Robots.ForEach(x => {
@@ -361,11 +361,11 @@ namespace Modes.MatchMode {
             public override void Start() {
                 DynamicUIManager.CloseActiveModal();
                 DynamicUIManager.CloseAllPanels(true);
-                
+
                 RobotSimObject.RemoveAllRobots();
                 FieldSimObject.DeleteField();
                 MatchMode.ResetMatchConfiguration();
-                
+
                 Instance.SetState(StateName.MatchConfig);
             }
 

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
@@ -211,7 +211,7 @@ namespace Modes.MatchMode {
             public override void Start() {
                 base.Start();
 
-                Scoring.targetTime = 15;
+                MatchMode.MatchTime = 15;
                 DynamicUIManager.CreatePanel<ScoreboardPanel>(true, true);
 
                 AnalyticsManager.LogCustomEvent(
@@ -239,7 +239,7 @@ namespace Modes.MatchMode {
                 base.Start();
                 _possessed                             = RobotSimObject.CurrentlyPossessedRobot;
                 RobotSimObject.CurrentlyPossessedRobot = string.Empty;
-                Scoring.targetTime                     = 135;
+                MatchMode.MatchTime                    = 135;
                 _timer                                 = 3;
             }
 
@@ -266,7 +266,7 @@ namespace Modes.MatchMode {
             }
 
             public override void Update() {
-                if (Scoring.targetTime <= 30)
+                if (MatchMode.MatchTime <= 30)
                     Instance.AdvanceState();
             }
 

--- a/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
+++ b/engine/Assets/Scripts/Modes/MatchMode/MatchStateMachine.cs
@@ -150,6 +150,7 @@ namespace Modes.MatchMode {
             public override void Start() {
                 base.Start();
 
+                
                 PhysicsManager.IsFrozen = true;
                 MatchMode.SpawnAllRobots();
 
@@ -219,7 +220,7 @@ namespace Modes.MatchMode {
                 PhysicsManager.IsFrozen = false;
             }
 
-            public override void Update() {}
+            public override void Update() { }
 
             public override void End() {
                 base.End();

--- a/engine/Assets/Scripts/Modes/ModeManager.cs
+++ b/engine/Assets/Scripts/Modes/ModeManager.cs
@@ -33,7 +33,6 @@ public class ModeManager {
     public static void Start() {
         if (CurrentMode == null) {
             if (isSinglePlayer) {
-                Debug.Log("Sim runner start create modal");
                 DynamicUIManager.CreateModal<ChooseSingleplayerModeModal>();
             } else {
                 DynamicUIManager.CreateModal<ChooseMultiplayerModeModal>();

--- a/engine/Assets/Scripts/Modes/ModeManager.cs
+++ b/engine/Assets/Scripts/Modes/ModeManager.cs
@@ -33,6 +33,7 @@ public class ModeManager {
     public static void Start() {
         if (CurrentMode == null) {
             if (isSinglePlayer) {
+                Debug.Log("Sim runner start create modal");
                 DynamicUIManager.CreateModal<ChooseSingleplayerModeModal>();
             } else {
                 DynamicUIManager.CreateModal<ChooseMultiplayerModeModal>();

--- a/engine/Assets/Scripts/ModuleLoader/Api.cs
+++ b/engine/Assets/Scripts/ModuleLoader/Api.cs
@@ -43,8 +43,12 @@ namespace Engine.ModuleLoader {
 
         public void Start() // Must happen after ResourceLedger is initialized (in Awake)
         {
-            if (Instance == null)
+            if (Instance == null) {
                 Instance = this;
+            } else {
+                Destroy(gameObject);
+                return;
+            }
 
             SetupApplication(); // Always do this first
 
@@ -101,6 +105,10 @@ namespace Engine.ModuleLoader {
 
             // GameObject.Find("Screen").GetComponent<PanelScaler>().scaleMode =
             // PanelScaler.ScaleMode.ConstantPhysicalSize;
+        }
+
+        private void OnDestroy() {
+            Instance = null;
         }
 
         private class LoggerImpl : SynthesisAPI.Utilities.ILogger {

--- a/engine/Assets/Scripts/Physics/PhysicsManager.cs
+++ b/engine/Assets/Scripts/Physics/PhysicsManager.cs
@@ -79,6 +79,10 @@ namespace Synthesis.Physics {
             }
         }
 
+        public static void SetFrozenCounter(int value) {
+            _frozenCounter = value;
+        }
+
         public static void FixedUpdate() {
             RobotSimObject.SpawnedRobots.ForEach(x => { x.UpdateWheels(); });
         }

--- a/engine/Assets/Scripts/Scoring/Scoring.cs
+++ b/engine/Assets/Scripts/Scoring/Scoring.cs
@@ -4,12 +4,10 @@ using UnityEngine;
 public static class Scoring {
     public static int redScore     = 0;
     public static int blueScore    = 0;
-    public static float targetTime = 15;
 
     public static void ResetScore() {
         redScore   = 0;
         blueScore  = 0;
-        targetTime = 15;
     }
 
     public static List<GameObject> CreatePowerupScoreZones() {

--- a/engine/Assets/Scripts/Scoring/Scoring.cs
+++ b/engine/Assets/Scripts/Scoring/Scoring.cs
@@ -2,12 +2,12 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public static class Scoring {
-    public static int redScore     = 0;
-    public static int blueScore    = 0;
+    public static int redScore  = 0;
+    public static int blueScore = 0;
 
     public static void ResetScore() {
-        redScore   = 0;
-        blueScore  = 0;
+        redScore  = 0;
+        blueScore = 0;
     }
 
     public static List<GameObject> CreatePowerupScoreZones() {

--- a/engine/Assets/Scripts/Scoring/ScoringZone.cs
+++ b/engine/Assets/Scripts/Scoring/ScoringZone.cs
@@ -88,6 +88,7 @@ public class ScoringZone : IPhysicsOverridable {
         _meshRenderer = GameObject.GetComponent<MeshRenderer>();
 
         _collider.isTrigger = true;
+        Alliance = alliance;
 
         PhysicsManager.Register(this);
         UpdateColor();

--- a/engine/Assets/Scripts/Scoring/ScoringZone.cs
+++ b/engine/Assets/Scripts/Scoring/ScoringZone.cs
@@ -88,7 +88,7 @@ public class ScoringZone : IPhysicsOverridable {
         _meshRenderer = GameObject.GetComponent<MeshRenderer>();
 
         _collider.isTrigger = true;
-        Alliance = alliance;
+        Alliance            = alliance;
 
         PhysicsManager.Register(this);
         UpdateColor();

--- a/engine/Assets/Scripts/Scoring/ScoringZone.cs
+++ b/engine/Assets/Scripts/Scoring/ScoringZone.cs
@@ -90,6 +90,7 @@ public class ScoringZone : IPhysicsOverridable {
         _collider.isTrigger = true;
 
         PhysicsManager.Register(this);
+        UpdateColor();
     }
 
     public ScoringZone(ScoringZoneData data) {

--- a/engine/Assets/Scripts/SimulationRunner.cs
+++ b/engine/Assets/Scripts/SimulationRunner.cs
@@ -159,7 +159,7 @@ namespace Synthesis.Runtime {
                 OnSimKill();
 
             OnSimKill = null;
-            OnUpdate = null;
+            OnUpdate  = null;
 
             PhysicsManager.Reset();
             ReplayManager.Teardown();

--- a/engine/Assets/Scripts/SimulationRunner.cs
+++ b/engine/Assets/Scripts/SimulationRunner.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Synthesis.Import;
 using System.Linq;
+using Synthesis.Gizmo;
 using Synthesis.PreferenceManager;
 using Synthesis.UI.Dynamic;
 using SynthesisAPI.InputManager;
@@ -67,6 +68,7 @@ namespace Synthesis.Runtime {
             ModeManager.Start();
             RobotSimObject.Setup();
             WebSocketManager.Init();
+            GizmoManager.Setup();
 
             OnUpdate += DynamicUIManager.Update;
             OnUpdate += ModeManager.Update;

--- a/engine/Assets/Scripts/SimulationRunner.cs
+++ b/engine/Assets/Scripts/SimulationRunner.cs
@@ -159,6 +159,7 @@ namespace Synthesis.Runtime {
                 OnSimKill();
 
             OnSimKill = null;
+            OnUpdate = null;
 
             PhysicsManager.Reset();
             ReplayManager.Teardown();

--- a/engine/Assets/Scripts/UI/Dynamic/DynamicUIComponents.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/DynamicUIComponents.cs
@@ -68,11 +68,7 @@ namespace Synthesis.UI.Dynamic {
             set {
                 if (value != _hidden) {
                     _hidden = value;
-                    if (_hidden) {
-                        _unityObject.SetActive(false);
-                    } else {
-                        _unityObject.SetActive(true);
-                    }
+                    if (_unityObject != null) _unityObject.SetActive(!_hidden);
                     OnVisibilityChange();
                 }
             }

--- a/engine/Assets/Scripts/UI/Dynamic/DynamicUIComponents.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/DynamicUIComponents.cs
@@ -181,6 +181,29 @@ namespace Synthesis.UI.Dynamic {
         public void Delete_Internal() {
             GameObject.Destroy(_unityObject);
         }
+
+        protected Content Strip(Vector2? newContentSize = null, float leftPadding = 0f, float rightPadding = 0f,
+            float topPadding = 0f, float bottomPadding = 0f) {
+            CancelButton.RootGameObject.SetActive(false);
+            AcceptButton.RootGameObject.SetActive(false);
+            Title.RootGameObject.SetActive(false);
+            PanelIcon.RootGameObject.SetActive(false);
+
+            var panel = new Content(null, UnityObject, null);
+            if (newContentSize.HasValue) {
+                panel.SetSize<Content>(new Vector2(newContentSize.Value.x + leftPadding + rightPadding,
+                    newContentSize.Value.y + topPadding + bottomPadding));
+            }
+            panel.SetAnchors<Content>(new Vector2(0.5f, 0.0f), new Vector2(0.5f, 0.0f));
+            panel.SetPivot<Content>(new Vector2(0.5f, 0.0f));
+            panel.SetAnchoredPosition<Content>(new Vector2(0.0f, 10.0f));
+            var newMainContent =
+                panel.CreateSubContent(newContentSize ?? new Vector2(panel.Size.x - (rightPadding + leftPadding),
+                                                             panel.Size.y - (topPadding + bottomPadding)));
+            newMainContent.SetStretch<Content>(leftPadding, rightPadding, topPadding, bottomPadding);
+
+            return newMainContent;
+        }
     }
 
     public abstract class ModalDynamic {
@@ -573,6 +596,11 @@ namespace Synthesis.UI.Dynamic {
             }
 
             return (this as T)!;
+        }
+
+        public T? CheckIfNull<T>()
+            where T : UIComponent {
+            return RootGameObject == null ? null : (this as T)!;
         }
     }
 

--- a/engine/Assets/Scripts/UI/Dynamic/DynamicUIComponents.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/DynamicUIComponents.cs
@@ -68,7 +68,8 @@ namespace Synthesis.UI.Dynamic {
             set {
                 if (value != _hidden) {
                     _hidden = value;
-                    if (_unityObject != null) _unityObject.SetActive(!_hidden);
+                    if (_unityObject != null)
+                        _unityObject.SetActive(!_hidden);
                     OnVisibilityChange();
                 }
             }

--- a/engine/Assets/Scripts/UI/Dynamic/DynamicUIManager.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/DynamicUIManager.cs
@@ -261,7 +261,7 @@ namespace Synthesis.UI.Dynamic {
                     SubScreenSpaceContent.RootGameObject.SetActive(true);
                 }
             }
-            
+
             // Unfreeze physics no matter what because it has a counter
             PhysicsManager.IsFrozen = false;
 

--- a/engine/Assets/Scripts/UI/Dynamic/DynamicUIManager.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/DynamicUIManager.cs
@@ -253,9 +253,6 @@ namespace Synthesis.UI.Dynamic {
                 modal.Delete();
                 modal.Delete_Internal();
 
-                // Unfreeze physics no matter what because it has a counter
-                PhysicsManager.IsFrozen = false;
-
                 if (modal == ActiveModal) {
                     ActiveModal = null;
 
@@ -264,6 +261,9 @@ namespace Synthesis.UI.Dynamic {
                     SubScreenSpaceContent.RootGameObject.SetActive(true);
                 }
             }
+            
+            // Unfreeze physics no matter what because it has a counter
+            PhysicsManager.IsFrozen = false;
 
             if (showPersistentPanels)
                 ShowAllPanels();

--- a/engine/Assets/Scripts/UI/Dynamic/DynamicUIManager.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/DynamicUIManager.cs
@@ -267,7 +267,7 @@ namespace Synthesis.UI.Dynamic {
 
             if (showPersistentPanels)
                 ShowAllPanels();
-            
+
             MainHUD.Collapsed = false;
             AnalyticsManager.LogCustomEvent(AnalyticsEvent.ActiveModalClosed, ("UIType", modal.GetType().Name));
             return true;

--- a/engine/Assets/Scripts/UI/Dynamic/DynamicUIManager.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/DynamicUIManager.cs
@@ -90,11 +90,11 @@ namespace Synthesis.UI.Dynamic {
 
         public static bool CreateModal<T>(params object[] args)
             where T : ModalDynamic {
-            CloseAllPanels();
+            CloseAllPanels(false);
             HideAllPanels();
             GizmoManager.ExitGizmo();
             if (ActiveModal != null)
-                CloseActiveModal();
+                CloseActiveModal(false);
 
             return CreateModal_Internal<T>(args);
         }
@@ -221,7 +221,7 @@ namespace Synthesis.UI.Dynamic {
             return true;
         }
 
-        public static bool CloseActiveModal() {
+        public static bool CloseActiveModal(bool showPersistentPanels = true) {
             var modal = ActiveModal;
 
             if (modal == null) {
@@ -265,7 +265,9 @@ namespace Synthesis.UI.Dynamic {
                 }
             }
 
-            ShowAllPanels();
+            if (showPersistentPanels)
+                ShowAllPanels();
+            
             MainHUD.Collapsed = false;
             AnalyticsManager.LogCustomEvent(AnalyticsEvent.ActiveModalClosed, ("UIType", modal.GetType().Name));
             return true;

--- a/engine/Assets/Scripts/UI/Dynamic/MainHUD.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/MainHUD.cs
@@ -41,16 +41,23 @@ public static class MainHUD {
             if (!_isSetup)
                 return;
 
-            _enabled = value;
-            if (_enabled) {
-                Collapsed = false;
+            if (value) {
+                if (_enabled != value) {
+                    Collapsed = false;
+                }
+
                 _tabDrawerContent.RootGameObject.SetActive(true);
                 // _accordionButton.RootGameObject.SetActive(true);
             } else {
-                Collapsed = true;
+                if (_enabled != value) {
+                    Collapsed = true;
+                }
+
                 _tabDrawerContent.RootGameObject.SetActive(false);
                 _accordionButton.RootGameObject.SetActive(false);
             }
+
+            _enabled = value;
         }
     }
 

--- a/engine/Assets/Scripts/UI/Dynamic/MainHUD.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/MainHUD.cs
@@ -26,7 +26,7 @@ public static class MainHUD {
     private const string EXPAND_TWEEN   = "expand";
 
     private static Action<SynthesisTween.SynthesisTweenStatus> collapseTweenProgress = s => {
-        _tabDrawerContent?.SetAnchoredPosition<Content>(
+        _tabDrawerContent.CheckIfNull<Content>()?.SetAnchoredPosition<Content>(
             new Vector2(s.CurrentValue<int>(), _tabDrawerContent.RootRectTransform.anchoredPosition.y));
     };
 
@@ -41,17 +41,15 @@ public static class MainHUD {
             if (!_isSetup)
                 return;
 
-            if (_enabled != value) {
-                _enabled = value;
-                if (_enabled) {
-                    Collapsed = false;
-                    _tabDrawerContent.RootGameObject.SetActive(true);
-                    // _accordionButton.RootGameObject.SetActive(true);
-                } else {
-                    Collapsed = true;
-                    _tabDrawerContent.RootGameObject.SetActive(false);
-                    _accordionButton.RootGameObject.SetActive(false);
-                }
+            _enabled = value;
+            if (_enabled) {
+                Collapsed = false;
+                _tabDrawerContent.RootGameObject.SetActive(true);
+                // _accordionButton.RootGameObject.SetActive(true);
+            } else {
+                Collapsed = true;
+                _tabDrawerContent.RootGameObject.SetActive(false);
+                _accordionButton.RootGameObject.SetActive(false);
             }
         }
     }

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/Configuring/ChooseMultiplayerModeModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/Configuring/ChooseMultiplayerModeModal.cs
@@ -35,12 +35,12 @@ public class ChooseMultiplayerModeModal : ModalDynamic {
             });
 
         var comingSoonButton = MainContent.CreateButton()
-            .StepIntoLabel(l => l.SetText("Coming Soon"))
-            .ApplyTemplate(VerticalLayout)
-            .StepIntoImage(i => i.SetColor(ColorManager.SynthesisColor.InteractiveBackground))
-                .StepIntoLabel(l => l.SetColor(ColorManager.SynthesisColor.InteractiveElementText))
-                .DisableEvents<Button>();
-        
+                                   .StepIntoLabel(l => l.SetText("Coming Soon"))
+                                   .ApplyTemplate(VerticalLayout)
+                                   .StepIntoImage(i => i.SetColor(ColorManager.SynthesisColor.InteractiveBackground))
+                                   .StepIntoLabel(l => l.SetColor(ColorManager.SynthesisColor.InteractiveElementText))
+                                   .DisableEvents<Button>();
+
         Object.Destroy(comingSoonButton.RootGameObject.transform.Find("Button").GetComponent<HoverEventListener>());
     }
 

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/Configuring/ChooseMultiplayerModeModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/Configuring/ChooseMultiplayerModeModal.cs
@@ -12,7 +12,7 @@ public class ChooseMultiplayerModeModal : ModalDynamic {
         return u;
     };
 
-    public ChooseMultiplayerModeModal() : base(new Vector2(230, 300)) {}
+    public ChooseMultiplayerModeModal() : base(new Vector2(230, 130)) {}
 
     public override void Create() {
         Title.SetText("Choose Mode");

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/Configuring/ChooseMultiplayerModeModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/Configuring/ChooseMultiplayerModeModal.cs
@@ -2,8 +2,11 @@ using System;
 using Modes.MatchMode;
 using Synthesis.UI;
 using Synthesis.UI.Dynamic;
+using UI.EventListeners;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using Utilities.ColorManager;
+using Object = UnityEngine.Object;
 
 public class ChooseMultiplayerModeModal : ModalDynamic {
     readonly Func<UIComponent, UIComponent> VerticalLayout = (u) => {
@@ -12,7 +15,7 @@ public class ChooseMultiplayerModeModal : ModalDynamic {
         return u;
     };
 
-    public ChooseMultiplayerModeModal() : base(new Vector2(230, 130)) {}
+    public ChooseMultiplayerModeModal() : base(new Vector2(230, 80)) {}
 
     public override void Create() {
         Title.SetText("Choose Mode");
@@ -31,23 +34,14 @@ public class ChooseMultiplayerModeModal : ModalDynamic {
                     SceneManager.LoadScene("MainScene");
             });
 
-        MainContent.CreateButton()
-            .StepIntoLabel(l => l.SetText("Host a Server"))
+        var comingSoonButton = MainContent.CreateButton()
+            .StepIntoLabel(l => l.SetText("Coming Soon"))
             .ApplyTemplate(VerticalLayout)
-            .AddOnClickedEvent(b => {
-                if (SceneManager.GetActiveScene().name != "MainScene")
-                    SceneManager.LoadScene("MainScene");
-                ModeManager.CurrentMode = new ServerHostingMode();
-            });
-
-        MainContent.CreateButton()
-            .StepIntoLabel(l => l.SetText("Connect to a Server"))
-            .ApplyTemplate(VerticalLayout)
-            .AddOnClickedEvent(b => {
-                if (SceneManager.GetActiveScene().name != "MainScene")
-                    SceneManager.LoadScene("MainScene");
-                ModeManager.CurrentMode = new ConnectToMultiplayerMode();
-            });
+            .StepIntoImage(i => i.SetColor(ColorManager.SynthesisColor.InteractiveBackground))
+                .StepIntoLabel(l => l.SetColor(ColorManager.SynthesisColor.InteractiveElementText))
+                .DisableEvents<Button>();
+        
+        Object.Destroy(comingSoonButton.RootGameObject.transform.Find("Button").GetComponent<HoverEventListener>());
     }
 
     public override void Update() {}

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/Configuring/ChooseSingleplayerModeModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/Configuring/ChooseSingleplayerModeModal.cs
@@ -12,7 +12,7 @@ public class ChooseSingleplayerModeModal : ModalDynamic {
         return u;
     };
 
-    public ChooseSingleplayerModeModal() : base(new Vector2(230, 200)) {}
+    public ChooseSingleplayerModeModal() : base(new Vector2(230, 80)) {}
 
     public override void Create() {
         Title.SetText("Choose Mode");

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/Configuring/ConfigMotorModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/Configuring/ConfigMotorModal.cs
@@ -138,7 +138,7 @@ public class ConfigMotorModal : ModalDynamic {
         CreateEntry("Drive", (_motors[0].driver as WheelDriver).Motor.targetVelocity, x => ChangeDriveVelocity(x));
         if (_robotISSwerve) {
             CreateEntry("Turn", (_motors[driveMotorCount].driver as RotationalDriver).Motor.targetVelocity,
-                x => ChangeTurnVelocity(x));
+                x => ChangeTurnVelocity(x), "RPM", 10.0f);
         }
 
         // original target velocities for each motor and entry in scrollview for other motors
@@ -170,16 +170,16 @@ public class ConfigMotorModal : ModalDynamic {
 
     public override void Delete() {}
 
-    private void CreateEntry(string name, float currVel, Action<float> onClick, string units = "RPM") {
+    private void CreateEntry(
+        string name, float currVel, Action<float> onClick, string units = "RPM", float max = 150.0f) {
         (Content nameContent, Content velContent) =
             _scrollView.Content.CreateSubContent(new Vector2(_scrollViewWidth, 40f))
                 .SetTopStretch<Content>(0, 0, 0)
                 .ApplyTemplate<Content>(VerticalLayout)
                 .SplitLeftRight(NAME_WIDTH, PADDING);
+        if (currVel < 5.0f && max > 50.0f)
+            max = 50.0f;
         nameContent.CreateLabel().SetText(name).SetTopStretch(0, PADDING, PADDING + _scrollView.HeightOfChildren);
-        float max = 150;
-        if (currVel < 5)
-            max = 50f;
         velContent.CreateSlider(units, minValue: 0f, maxValue: max, currentValue: currVel)
             .SetTopStretch<Slider>(PADDING, PADDING, _scrollView.HeightOfChildren)
             .AddOnValueChangedEvent((s, v) => { onClick(v); });

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/Configuring/SettingsModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/Configuring/SettingsModal.cs
@@ -216,9 +216,13 @@ namespace Synthesis.UI.Dynamic {
         private static void Save() => PreferenceManager.PreferenceManager.Save();
 
         public static void MaximizeScreen() {
+#if UNITY_STANDALONE_WIN
             // auto maximizes if its a window and the resolution is maximum.
             if (!Screen.fullScreen && !Application.isEditor)
                 ShowWindowAsync(GetActiveWindow().ToInt32(), 3);
+#else
+            Debug.LogWarning("No Supported")
+#endif
         }
     }
 }

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/ExitSynthesisModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/ExitSynthesisModal.cs
@@ -21,9 +21,15 @@ namespace Synthesis.UI.Dynamic {
                     if (isOnMainMenu) {
                         Application.Quit();
                     } else {
+                        if (ModeManager.CurrentMode!.GetType() == typeof(MatchMode)) {
+                            RobotSimObject.RemoveAllRobots();
+                            FieldSimObject.DeleteField();
+                            MatchMode.ResetMatchConfiguration();
+                        }
+                        
                         SimulationRunner.InSim = false;
                         DynamicUIManager.CloseAllPanels(true);
-                        MatchMode.ResetMatchConfiguration();
+                        
                         ModeManager.CurrentMode = null;
                         SceneManager.LoadScene("GridMenuScene", LoadSceneMode.Single);
 

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/ExitSynthesisModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/ExitSynthesisModal.cs
@@ -26,10 +26,10 @@ namespace Synthesis.UI.Dynamic {
                             FieldSimObject.DeleteField();
                             MatchMode.ResetMatchConfiguration();
                         }
-                        
+
                         SimulationRunner.InSim = false;
                         DynamicUIManager.CloseAllPanels(true);
-                        
+
                         ModeManager.CurrentMode = null;
                         SceneManager.LoadScene("GridMenuScene", LoadSceneMode.Single);
 

--- a/engine/Assets/Scripts/UI/Dynamic/Modals/MatchResultsModal.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Modals/MatchResultsModal.cs
@@ -41,13 +41,8 @@ namespace UI.Dynamic.Modals {
 
             CancelButton
                 .AddOnClickedEvent(x => {
-                    MatchStateMachine.Instance.SetState(MatchStateMachine.StateName.None);
-                    SimulationRunner.InSim = false;
-                    DynamicUIManager.CloseAllPanels(true);
-                    ModeManager.CurrentMode = null;
-                    DynamicUIManager.CloseActiveModal();
-
-                    SceneManager.LoadScene("GridMenuScene", LoadSceneMode.Single);
+                    DynamicUIManager.CreateModal<ExitSynthesisModal>();
+                    DynamicUIManager.ActiveModal.OnCancelled = () => DynamicUIManager.CreateModal<MatchResultsModal>();
                 })
                 .StepIntoLabel(l => l.SetText("Exit"));
 

--- a/engine/Assets/Scripts/UI/Dynamic/Panels/Configuring/Scoring/ScoringZonesPanel.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Panels/Configuring/Scoring/ScoringZonesPanel.cs
@@ -149,7 +149,9 @@ public class ScoringZonesPanel : PanelDynamic {
     public override void Update() {}
 
     public override void Delete() {
-        FieldSimObject.CurrentField.ScoringZones.ForEach(x => x.VisibilityCounter--);
+        FieldSimObject.CurrentField.ScoringZones.ForEach(x => {
+            if (x != null) x.VisibilityCounter--;
+        });
         PhysicsManager.IsFrozen = false;
     }
 }

--- a/engine/Assets/Scripts/UI/Dynamic/Panels/Configuring/Scoring/ScoringZonesPanel.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Panels/Configuring/Scoring/ScoringZonesPanel.cs
@@ -141,7 +141,7 @@ public class ScoringZonesPanel : PanelDynamic {
     }
 
     private void OpenScoringZoneGizmo(ScoringZone zone = null) {
-        DynamicUIManager.CreatePanel<ZoneConfigPanel>(persistent: false, zone);
+        DynamicUIManager.CreatePanel<ZoneConfigPanel>(persistent: true, zone);
         ZoneConfigPanel panel = DynamicUIManager.GetPanel<ZoneConfigPanel>();
         panel.SetCallback(AddZoneEntry);
     }

--- a/engine/Assets/Scripts/UI/Dynamic/Panels/Configuring/Scoring/ScoringZonesPanel.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Panels/Configuring/Scoring/ScoringZonesPanel.cs
@@ -150,7 +150,8 @@ public class ScoringZonesPanel : PanelDynamic {
 
     public override void Delete() {
         FieldSimObject.CurrentField.ScoringZones.ForEach(x => {
-            if (x != null) x.VisibilityCounter--;
+            if (x != null)
+                x.VisibilityCounter--;
         });
         PhysicsManager.IsFrozen = false;
     }

--- a/engine/Assets/Scripts/UI/Dynamic/Panels/Information/ScoreboardPanel.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Panels/Information/ScoreboardPanel.cs
@@ -51,7 +51,7 @@ public class ScoreboardPanel : PanelDynamic {
 
             time = topContent.CreateLabel(topHeight)
                        .SetStretch<Label>()
-                       .SetText(Scoring.targetTime.ToString())
+                       .SetText(MatchMode.MatchTime.ToString())
                        .SetHorizontalAlignment(HorizontalAlignmentOptions.Center)
                        .SetVerticalAlignment(VerticalAlignmentOptions.Middle)
                        .SetFontSize(40);
@@ -113,8 +113,8 @@ public class ScoreboardPanel : PanelDynamic {
             // state advances in MatchMode update
             if (MatchStateMachine.Instance.CurrentState.StateName is >= MatchStateMachine.StateName.Auto and <=
                 MatchStateMachine.StateName.Endgame and not MatchStateMachine.StateName.Transition) {
-                Scoring.targetTime -= Time.deltaTime;
-                time.SetText(Mathf.RoundToInt(Scoring.targetTime).ToString());
+                MatchMode.MatchTime -= Time.deltaTime;
+                time.SetText(Mathf.RoundToInt(MatchMode.MatchTime).ToString());
             }
         }
 

--- a/engine/Assets/Scripts/UI/Dynamic/Panels/Information/ScoreboardPanel.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Panels/Information/ScoreboardPanel.cs
@@ -7,9 +7,14 @@ using TMPro;
 using UnityEngine;
 
 public class ScoreboardPanel : PanelDynamic {
+    private const float PANEL_HEIGHT_WITHOUT_TIMER = 100;
+    private const float PANEL_HEIGHT_WITH_TIMER    = 150;
+
     private const float VERTICAL_PADDING = 10f;
-    private static readonly float WIDTH  = 200f;
-    private static float HEIGHT;
+    private const float INSET_PADDING    = 10f;
+
+    private const float PANEL_WIDTH = 200f;
+    private float PANEL_HEIGHT;
 
     private readonly bool _showTimer;
 
@@ -22,41 +27,36 @@ public class ScoreboardPanel : PanelDynamic {
         return u;
     };
 
-    public ScoreboardPanel(bool showTimer = true) : base(new Vector2(WIDTH, showTimer ? 150 : 100)) {
-        _showTimer = showTimer;
-        HEIGHT     = showTimer ? 150f : 100f;
+    public ScoreboardPanel(bool showTimer = true)
+        : base(new Vector2(PANEL_WIDTH, showTimer ? PANEL_HEIGHT_WITH_TIMER : PANEL_HEIGHT_WITHOUT_TIMER)) {
+        _showTimer   = showTimer;
+        PANEL_HEIGHT = showTimer ? PANEL_HEIGHT_WITH_TIMER : PANEL_HEIGHT_WITHOUT_TIMER;
     }
 
     public override bool Create() {
         TweenDirection = Vector2.down;
 
-        CancelButton.RootGameObject.SetActive(false);
-        AcceptButton.RootGameObject.SetActive(false);
-        Title.RootGameObject.SetActive(false);
-        PanelIcon.RootGameObject.SetActive(false);
+        var newMainContent = Strip(new Vector2(PANEL_WIDTH, PANEL_HEIGHT + (_showTimer ? VERTICAL_PADDING : 0)),
+            leftPadding: INSET_PADDING, rightPadding: INSET_PADDING, topPadding: INSET_PADDING,
+            bottomPadding: INSET_PADDING);
 
-        var panel = new Content(null, UnityObject, null);
-        panel.SetBottomStretch<Content>(Screen.width / 2 - WIDTH / 2, Screen.width / 2 - WIDTH / 2);
-
-        float bottomHeight = HEIGHT;
+        float bottomHeight = PANEL_HEIGHT;
 
         if (_showTimer) {
             float topHeight = 50f;
             bottomHeight -= topHeight;
-            (topContent, bottomContent) = MainContent.SplitTopBottom(topHeight, 0f);
+            (topContent, bottomContent) = newMainContent.SplitTopBottom(topHeight, VERTICAL_PADDING);
 
-            topContent.SetAnchoredPosition<Content>(new Vector2(0, -topHeight / 2));
-            bottomContent.SetAnchoredPosition<Content>(new Vector2(0, -topHeight / 2));
+            bottomContent.SetHeight<Content>(bottomHeight);
+
             time = topContent.CreateLabel(topHeight)
                        .SetStretch<Label>()
-                       .ApplyTemplate(VerticalLayout)
-                       .SetAnchors<Label>(new Vector2(0, 0.5f), new Vector2(1, 0.5f))
-                       .SetAnchoredPosition<Label>(new Vector2(0, topHeight / 2))
                        .SetText(Scoring.targetTime.ToString())
                        .SetHorizontalAlignment(HorizontalAlignmentOptions.Center)
+                       .SetVerticalAlignment(VerticalAlignmentOptions.Middle)
                        .SetFontSize(40);
         } else {
-            bottomContent = MainContent;
+            bottomContent = newMainContent;
         }
 
         float leftRightPadding              = 8;

--- a/engine/Assets/Scripts/UI/Dynamic/Panels/SpawnLocationPanel.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Panels/SpawnLocationPanel.cs
@@ -108,7 +108,9 @@ namespace Synthesis.UI.Dynamic {
         }
 
         public override void Delete() {
-            _robotHighlights.ForEach(x => Object.Destroy(x.gameObject));
+            _robotHighlights.ForEach(x => {
+                if (x != null) Object.Destroy(x.gameObject);
+            });
         }
 
         /// <summary>

--- a/engine/Assets/Scripts/UI/Dynamic/Panels/SpawnLocationPanel.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Panels/SpawnLocationPanel.cs
@@ -44,7 +44,7 @@ namespace Synthesis.UI.Dynamic {
         private readonly Transform[] _robotHighlights = new Transform[6];
 
         private readonly Func<Button, Button> DisabledTemplate = b =>
-            b.StepIntoImage(i => i.SetColor(ColorManager.SynthesisColor.InteractiveBackground))
+            b.StepIntoImage(i => i.SetColor(ColorManager.SynthesisColor.BackgroundSecondary))
                 .StepIntoLabel(l => l.SetColor(ColorManager.SynthesisColor.MainText));
 
         public readonly Func<UIComponent, UIComponent> VerticalLayout = (u) => {

--- a/engine/Assets/Scripts/UI/Dynamic/Panels/SpawnLocationPanel.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Panels/SpawnLocationPanel.cs
@@ -109,7 +109,8 @@ namespace Synthesis.UI.Dynamic {
 
         public override void Delete() {
             _robotHighlights.ForEach(x => {
-                if (x != null) Object.Destroy(x.gameObject);
+                if (x != null)
+                    Object.Destroy(x.gameObject);
             });
         }
 

--- a/engine/Assets/Scripts/UI/Dynamic/Toaster.cs
+++ b/engine/Assets/Scripts/UI/Dynamic/Toaster.cs
@@ -229,7 +229,8 @@ namespace Synthesis.Util {
                 var xPos =
                     Mathf.SmoothStep(0f, (Toaster.TOAST_CONTAINER_WIDTH + 1) - Toaster.TOAST_CONTAINER_OFFSET.x, t);
 
-                _toastMainContent.RootRectTransform.anchoredPosition = new Vector2(xPos, height);
+                if (_toastMainContent.RootRectTransform != null)
+                    _toastMainContent.RootRectTransform.anchoredPosition = new Vector2(xPos, height);
             }
         }
 

--- a/engine/Assets/Scripts/UI/MainMenu/LinksTween.cs
+++ b/engine/Assets/Scripts/UI/MainMenu/LinksTween.cs
@@ -21,9 +21,10 @@ public class LinksTween : MonoBehaviour, IPointerEnterHandler, IPointerExitHandl
     public void OnPointerEnter(PointerEventData eventData) {
         text      = gameObject.GetComponent<TMP_Text>();
         sizeStart = text.fontSize;
-        SynthesisTween.MakeTween(_growKey, text.fontSize, sizeEnd, 1f,
-            (t, a, b) => SynthesisTweenInterpolationFunctions.FloatInterp(t, (float) a, (float) b),
-            SynthesisTweenScaleFunctions.EaseOutCubic, TweenUp);
+        if (!SynthesisTween.TweenExists(_growKey))
+            SynthesisTween.MakeTween(_growKey, text.fontSize, sizeEnd, 1f,
+                (t, a, b) => SynthesisTweenInterpolationFunctions.FloatInterp(t, (float) a, (float) b),
+                SynthesisTweenScaleFunctions.EaseOutCubic, TweenUp);
     }
 
     public void OnPointerExit(PointerEventData eventData) {

--- a/engine/Assets/Scripts/UI/MainMenu/MenuGraphic.cs
+++ b/engine/Assets/Scripts/UI/MainMenu/MenuGraphic.cs
@@ -2,7 +2,9 @@ using UnityEngine;
 
 [ExecuteAlways]
 public class MenuGraphic : MonoBehaviour {
-    [SerializeField] private float _maxRatio;
+    [SerializeField]
+    private float _maxRatio;
+
     public void OnRectTransformDimensionsChange() {
         float rat = (float) Screen.width / (float) Screen.height;
         this.gameObject.SetActive(rat > _maxRatio);

--- a/engine/Assets/Scripts/UI/MainMenu/MenuGraphic.cs
+++ b/engine/Assets/Scripts/UI/MainMenu/MenuGraphic.cs
@@ -1,8 +1,10 @@
 using UnityEngine;
 
+[ExecuteAlways]
 public class MenuGraphic : MonoBehaviour {
-    public void Start() {
+    [SerializeField] private float _maxRatio;
+    public void OnRectTransformDimensionsChange() {
         float rat = (float) Screen.width / (float) Screen.height;
-        this.gameObject.SetActive(rat > 1.7);
+        this.gameObject.SetActive(rat > _maxRatio);
     }
 }

--- a/engine/Assets/Scripts/Utilities/Tween/SynthesisTween.cs
+++ b/engine/Assets/Scripts/Utilities/Tween/SynthesisTween.cs
@@ -69,6 +69,10 @@ public static class SynthesisTween {
             CurrentProgress = prog;
         }
     }
+
+    public static Boolean TweenExists(string key) {
+        return _tweens.ContainsKey(key);
+    }
 }
 
 public static class SynthesisTweenScaleFunctions {

--- a/engine/ProjectSettings/ProjectSettings.asset
+++ b/engine/ProjectSettings/ProjectSettings.asset
@@ -102,7 +102,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  fullscreenMode: 1
+  fullscreenMode: 2
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Components.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Components.py
@@ -122,9 +122,12 @@ def __parseChildOccurrence(
         part.skip_collider = True
 
     if occurrence.appearance:
-        part.appearance = "{}_{}".format(
-            occurrence.appearance.name, occurrence.appearance.id
-        )
+        try:
+            part.appearance = "{}_{}".format(
+                occurrence.appearance.name, occurrence.appearance.id
+            )
+        except:
+            part.appearance = 'default'
         # TODO: Add phyical_material parser
 
     if occurrence.component.material:

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Components.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Components.py
@@ -127,7 +127,7 @@ def __parseChildOccurrence(
                 occurrence.appearance.name, occurrence.appearance.id
             )
         except:
-            part.appearance = 'default'
+            part.appearance = "default"
         # TODO: Add phyical_material parser
 
     if occurrence.component.material:


### PR DESCRIPTION
### Description
Fixed to lots of bugs found in the beta build

### Bugs
- [x] Opening settings or something while editing a score zone closes the panel and deletes any changes. After doing this, trying to edit the same zone again will give a null exception. **Solution: made the zone config panel persistent**
- [x] If you have a persistent panel (driverstation), then open the spawn modal it goes away like it should, but then when you click robots or fields it appears again early. **Solution: don't open persistent panels when you close a modal immediately before opening a new one**
- [x] Sometimes the logo on the start screen would not show up (maybe a resolution issue). **Solution: increased the allowed aspect ratio for the logo to work with 16:10**
- [x] Make anything logo is a button. **Solution: removed the button component**
- [x] Exiting server test mode causes a lot of errors
- [x] Toast can spawn on the main menu in the wrong spot
- [x] The scoreboard in match mode appears then instantly disappears
- [x] Scoreboard background scales wrong with screen aspect ratio
- [x] Using config mode on swerve motors completely breaks the drivetrain
- [x] Buttons on robot positioning panel change background color when selected then deselected. **Solution: button backgrounds were getting set to the wrong color in Create()**
- [x] God mode creates a new game object that does not get destroyed (No visible effect on build) **Solution: store a reference to the pointer and destroy it when the mouse is up**
- [x] Choose mode modal is too big **Solution: reduced modal height**
- [x] If you exit and then re-enter the sim, the main hud spawns during the choose mode modal
- [x] Pressing ‘cancel’ on match mode start match modal still enables physics. **Solution: unfreeze physics when auto starts, not when match config ends**
- [x] Score zone color initially wrong material
- [x] Match mode timer speeds up? **Solution: make sure sim manager update action gets reset**
- [x] Removed the host and join server buttons on choose multiplayer mode modal
- [x] Ghost bot colliding with actual bot in server test mode
- [x] Restart button at the end of match mode does not work
- [x] After a couple rounds, when you try to play match mode, the bot falls through the group to some degree after you start the match. **Solution: make sure physics freezes/unfreezes when a modal is first closed, not when the close animation finishes**
- [x] Hovering over the socials button on the main menu after clicking launch simulator causes tween errors (also happens when entering the simulator then backing out to the main menu)
- [x] Sometimes if you have your synthesis set to windowed mode entering the simulator will cause dll not found errors and set synthesis back to fullscreen
- [x] API GameObject is created multiple times

