### PR TITLE
Fixed COM

### DIFF
--- a/engine/Assets/Scripts/Importer/MirabufLive.cs
+++ b/engine/Assets/Scripts/Importer/MirabufLive.cs
@@ -497,10 +497,13 @@ namespace Synthesis.Import {
                         live._state = MirabufFileState.DuplicateParts;
                         continue;
                     }
-
+                    
                     var partInstance   = part.Value;
                     var partDefinition = assembly.Data.Parts.PartDefinitions[partInstance.PartDefinitionReference];
-                    collectivePhysData.Add((partInstance.GlobalTransform.UnityMatrix, partDefinition.PhysicalData));
+                    
+                    if (partDefinition.Bodies.Any()) {
+                        collectivePhysData.Add((partInstance.GlobalTransform.UnityMatrix, partDefinition.PhysicalData));
+                    }
                 }
 
                 var combPhysProps = CombinePhysicalProperties(collectivePhysData);

--- a/engine/Assets/Scripts/Importer/MirabufLive.cs
+++ b/engine/Assets/Scripts/Importer/MirabufLive.cs
@@ -497,10 +497,10 @@ namespace Synthesis.Import {
                         live._state = MirabufFileState.DuplicateParts;
                         continue;
                     }
-                    
+
                     var partInstance   = part.Value;
                     var partDefinition = assembly.Data.Parts.PartDefinitions[partInstance.PartDefinitionReference];
-                    
+
                     if (partDefinition.Bodies.Any()) {
                         collectivePhysData.Add((partInstance.GlobalTransform.UnityMatrix, partDefinition.PhysicalData));
                     }


### PR DESCRIPTION
### Description
Removed Physical Properties of Part definitions that have no bodies.
### Test
Verified on TestArm for Mix and Match that Luca and I discovered had the issue with the center of mass being off.

Fusion COM:
![image](https://github.com/Autodesk/synthesis/assets/20159878/f40b4ecb-6b66-4e38-9f52-cafb844e44ae)

Broken Unity COM:
![image](https://github.com/Autodesk/synthesis/assets/20159878/a5200741-263d-43fa-aad2-f55ecc393406)

Fixed Unity COM:
![image](https://github.com/Autodesk/synthesis/assets/20159878/36c3909a-e891-421b-8014-b22f5d59589d)
