### PR TITLE
Auto request reviews update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
 # This file is used to auto request reviews for a pull request
-# For each new dev team this file needs to be updated
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# 2023 Dev Team
-* @a-crowell @BrandonPacewic @KyroVibe @PepperLola @LucaHaverty
+* @synthesis-dev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file is used to auto request reviews for a pull request
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @synthesis-dev
+* @synthesis-devs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file is used to auto request reviews for a pull request
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @synthesis-devs
+* @autodesk/synthesis-devs


### PR DESCRIPTION
We are now using a team within the Autodesk organization to auto request reviews.

Currently only 2 synthesis members will be requested for each review, round robin style.

Any updates to included members or changes to how reviews should be requested now need to be directed to the @autodesk/synthesis-devs settings page.