### PR TITLE
Physics & Suspension

### DIFF
--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -68,8 +68,10 @@ class PhysicsSystem extends WorldSystem {
             new THREE.Vector3(0.0, -2.0, 0.0),
             undefined
         )
+        ground.SetFriction(0.7);
         this._joltBodyInterface.AddBody(ground.GetID(), JOLT.EActivation_Activate)
     }
+    
 
     /**
      * TEMPORARY
@@ -453,11 +455,11 @@ class PhysicsSystem extends WorldSystem {
         wheelSettings.mSuspensionMaxLength = 0.0000006
         wheelSettings.mInertia = 1
 
-        const friction = new JOLT.LinearCurve()
-        friction.Clear()
-        friction.AddPoint(1, 1)
-        friction.AddPoint(0, 1)
-        wheelSettings.mLongitudinalFriction = friction
+        // const friction = new JOLT.LinearCurve()
+        // friction.Clear()
+        // friction.AddPoint(1, 1)
+        // friction.AddPoint(0, 1)
+        // wheelSettings.mLongitudinalFriction = friction
 
         const vehicleSettings = new JOLT.VehicleConstraintSettings()
 

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -30,6 +30,11 @@ const COUNT_OBJECT_LAYERS = 10
 export const SIMULATION_PERIOD = 1.0 / 120.0
 const STANDARD_SUB_STEPS = 3
 
+// Friction constants
+const FLOOR_FRICTION = 0.7;
+const SUSPENSION_MIN_FACTOR = 0.1;
+const SUSPENSION_MAX_FACTOR = 0.3;
+
 /**
  * The PhysicsSystem handles all Jolt Phyiscs interactions within Synthesis.
  * This system can create physical representations of objects such as Robots,
@@ -68,7 +73,7 @@ class PhysicsSystem extends WorldSystem {
             new THREE.Vector3(0.0, -2.0, 0.0),
             undefined
         )
-        ground.SetFriction(0.7);
+        ground.SetFriction(FLOOR_FRICTION);
         this._joltBodyInterface.AddBody(ground.GetID(), JOLT.EActivation_Activate)
     }
     
@@ -451,15 +456,9 @@ class PhysicsSystem extends WorldSystem {
         wheelSettings.mMaxHandBrakeTorque = 0.0
         wheelSettings.mRadius = radius * 1.05
         wheelSettings.mWidth = 0.1
-        wheelSettings.mSuspensionMinLength = 0.0000003
-        wheelSettings.mSuspensionMaxLength = 0.0000006
+        wheelSettings.mSuspensionMinLength = radius * SUSPENSION_MIN_FACTOR
+        wheelSettings.mSuspensionMaxLength = radius * SUSPENSION_MAX_FACTOR
         wheelSettings.mInertia = 1
-
-        // const friction = new JOLT.LinearCurve()
-        // friction.Clear()
-        // friction.AddPoint(1, 1)
-        // friction.AddPoint(0, 1)
-        // wheelSettings.mLongitudinalFriction = friction
 
         const vehicleSettings = new JOLT.VehicleConstraintSettings()
 

--- a/fission/src/systems/simulation/driver/WheelDriver.ts
+++ b/fission/src/systems/simulation/driver/WheelDriver.ts
@@ -2,6 +2,9 @@ import Jolt from "@barclah/jolt-physics"
 import Driver from "./Driver"
 import JOLT from "@/util/loading/JoltSyncLoader"
 
+const LATERIAL_FRICTION = 0.6;
+const LONGITUDINAL_FRICTION = 0.8;
+
 class WheelDriver extends Driver {
     private _constraint: Jolt.VehicleConstraint
     private _wheel: Jolt.WheelWV
@@ -22,6 +25,8 @@ class WheelDriver extends Driver {
 
         this._constraint = constraint;
         this._wheel = JOLT.castObject(this._constraint.GetWheel(0), JOLT.WheelWV);
+        this._wheel.set_mCombinedLateralFriction(LATERIAL_FRICTION); 
+        this._wheel.set_mCombinedLongitudinalFriction(LONGITUDINAL_FRICTION);
     }
 
     public Update(_: number): void {        


### PR DESCRIPTION
### Description
Fixed frictional constants for the floor and wheels in addition to fixing suspension to prevent robot from rocking sideways while stationary. Changes to the WheelDriver.ts file include the constants used to determine the friction between the wheels and other surfaces and setting the friction. Changes to the PhysicsSystem.ts file includes the removal of the current friction implementation and adding friction to the floor. In addition, this file includes changes to the values of *mSuspensionMinLength* and *mSuspensionMaxLength* to make them a function of the wheel radius (which is not constant).

> [!WARNING]
> **Potential Issue:** change in suspension has increased the height of the robot from the floor.

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1720)
