### PR TITLE
Additional `CODEOWNERS` subteams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,16 @@
 # This file is used to auto request reviews for a pull request
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @autodesk/synthesis-devs
+/exporter/ @autodesk/fusion hunter.barclay@autodesk.com
+
+/fission/src/aps/ @autodesk/fusion hunter.barclay@autodesk.com
+/fission/src/mirabuf/ @autodesk/fusion hunter.barclay@autodesk.com
+/fission/src/proto/ @autodesk/fusion hunter.barclay@autodesk.com
+
+/fission/src/ui/components/ julian.wright@autodesk.com luca.haverty@autodesk.com hunter.barclay@autodesk.com
+/fission/**/*.css julian.wright@autodesk.com luca.haverty@autodesk.com hunter.barclay@autodesk.com
+
+/fission/ @autodesk/fission hunter.barclay@autodesk.com
+/installer/ @autodesk/fusion hunter.barclay@autodesk.com
+
+* @autodesk/synthesis-devs hunter.barclay@autodesk.com


### PR DESCRIPTION
Current behaviour for new codeowner file:

- @HunterBarclay Now auto requested for review on every change.
- Changes in `/exporter/`, `/fission/src/aps/`, `/fission/src/mirabuf/`, `/fission/src/proto/`, and `/installer/` auto request to @Autodesk/fusion.
- Changes in `fission/src/ui/components/` and `fission/**/*.css` (all `.css` files in `/fission/` auto request to @PepperLola @LucaHaverty (current "ui" framework people).
- All other changes that are not for files specified above will reach the fallback pattern of @autodesk/synthesis-devs (@HunterBarclay will still be requested).

This is not final and I would appreciate any and all name suggestions for the teams.

Currently they are:
- `fission` currently corresponds to general feature development.
- `fusion` currently corresponds to the exporter and other cross platform "integration" things.
- Currently no UI team, currently specifying @PepperLola and @LucaHaverty as the reviewers on just the reusable UI components.
