### PR TITLE
Quick Fix

### DIFF
--- a/fission/src/Synthesis.tsx
+++ b/fission/src/Synthesis.tsx
@@ -207,7 +207,6 @@ const initialModals = [
     <RCConfigPwmGroupModal key="config-pwm" modalId="config-pwm" />,
     <RCConfigEncoderModal key="config-encoder" modalId="config-encoder" />,
     <MatchModeModal key="match-mode" modalId="match-mode" />,
-    <SpawningModal key="spawning-2" modalId="spawning" />,
     <ConfigMotorModal key="config-motor" modalId="config-motor" />,
     <ManageAssembliesModal key="manage-assemblies" modalId="manage-assemblies" />,
     <ImportMirabufModal key="import-mirabuf" modalId="import-mirabuf" />,

--- a/fission/src/ui/components/MainHUD.tsx
+++ b/fission/src/ui/components/MainHUD.tsx
@@ -101,7 +101,7 @@ const MainHUD: React.FC = () => {
                     <MainHUDButton
                         value={"Manage Assemblies"}
                         icon={<FaGear />}
-                        onClick={() => openModal("manage-assembles")}
+                        onClick={() => openModal("manage-assemblies")}
                     />
                     <MainHUDButton value={"Settings"} icon={<FaGear />} onClick={() => openModal("settings")} />
                     <MainHUDButton value={"View"} icon={<FaMagnifyingGlass />} onClick={() => openModal("view")} />


### PR DESCRIPTION
### Description
Fixed the Manage Assemblies modal not opening. Error coming from #1012 where the modalID was changed because it was originally misspelt. MainHUD was not updated to follow suit. 
Also removed duplicate SpawningModal from Synthesis.tsx