### PR TITLE
Delete Assembly Hot Fix

### DIFF
--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -30,7 +30,6 @@ class MirabufSceneObject extends SceneObject {
     private _physicsLayerReserve: LayerReserve | undefined = undefined
 
     private _transformGizmos: TransformGizmos | undefined = undefined
-    private _deleteGizmoOnEscape: boolean = true
 
     get mirabufInstance() {
         return this._mirabufInstance
@@ -109,16 +108,12 @@ class MirabufSceneObject extends SceneObject {
             if (this._transformGizmos) {
                 if (InputSystem.isKeyPressed("Enter")) {
                     // confirming placement of the mirabuf object
-                    this._transformGizmos.RemoveGizmos()
-                    this.EnablePhysics()
-                    this._transformGizmos = undefined
+                    this.DisableTransformControls()
                     return
-                } else if (InputSystem.isKeyPressed("Escape") && this._deleteGizmoOnEscape) {
+                } else if (InputSystem.isKeyPressed("Escape")) {
                     // cancelling the creation of the mirabuf scene object
-                    this._transformGizmos.RemoveGizmos()
+                    this.DisableTransformControls()
                     World.SceneRenderer.RemoveSceneObject(this.id)
-                    this._transformGizmos = undefined
-                    this._deleteGizmoOnEscape = false
                     return
                 }
 
@@ -168,10 +163,6 @@ class MirabufSceneObject extends SceneObject {
         this._brain?.clearControls()
     }
 
-    public GetRootNodeId(): Jolt.BodyID | undefined {
-        return this._mechanism.nodeToBody.get(this._mechanism.rootBody)
-    }
-
     private CreateMeshForShape(shape: Jolt.Shape): THREE.Mesh {
         const scale = new JOLT.Vec3(1, 1, 1)
         const triangleContext = new JOLT.ShapeGetTriangles(
@@ -205,6 +196,9 @@ class MirabufSceneObject extends SceneObject {
         return mesh
     }
 
+    /**
+     * Changes the mode of the mirabuf object from being interacted with to being placed.
+     */
     public EnableTransformControls(): void {
         this._transformGizmos = new TransformGizmos(
             new THREE.Mesh(
@@ -216,6 +210,15 @@ class MirabufSceneObject extends SceneObject {
         this._transformGizmos.CreateGizmo("translate")
 
         this.DisablePhysics()
+    }
+
+    /**
+     * Changes the mode of the mirabuf object from being placed to being interacted with.
+     */
+    public DisableTransformControls(): void {
+        this._transformGizmos?.RemoveGizmos()
+        this._transformGizmos = undefined
+        this.EnablePhysics()
     }
 
     private EnablePhysics() {

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -200,6 +200,8 @@ class MirabufSceneObject extends SceneObject {
      * Changes the mode of the mirabuf object from being interacted with to being placed.
      */
     public EnableTransformControls(): void {
+        if (this._transformGizmos) return
+
         this._transformGizmos = new TransformGizmos(
             new THREE.Mesh(
                 new THREE.SphereGeometry(3.0),

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -112,7 +112,6 @@ class MirabufSceneObject extends SceneObject {
                     return
                 } else if (InputSystem.isKeyPressed("Escape")) {
                     // cancelling the creation of the mirabuf scene object
-                    this.DisableTransformControls()
                     World.SceneRenderer.RemoveSceneObject(this.id)
                     return
                 }
@@ -147,6 +146,7 @@ class MirabufSceneObject extends SceneObject {
     }
 
     public Dispose(): void {
+        this.DisableTransformControls()
         World.SimulationSystem.UnregisterMechanism(this._mechanism)
         World.PhysicsSystem.DestroyMechanism(this._mechanism)
         this._mirabufInstance.Dispose(World.SceneRenderer.scene)
@@ -216,6 +216,7 @@ class MirabufSceneObject extends SceneObject {
      * Changes the mode of the mirabuf object from being placed to being interacted with.
      */
     public DisableTransformControls(): void {
+        if (!this._transformGizmos) return
         this._transformGizmos?.RemoveGizmos()
         this._transformGizmos = undefined
         this.EnablePhysics()

--- a/fission/src/ui/modals/spawning/ManageAssembliesModal.tsx
+++ b/fission/src/ui/modals/spawning/ManageAssembliesModal.tsx
@@ -20,11 +20,9 @@ const AssemblyCard: React.FC<AssemblyCardProps> = ({ id, update }) => {
             <Label className="text-wrap break-all">{id}</Label>
             <Button
                 value="Delete"
+                // prettier-ignore
                 onClick={() => {
-                    if (World.SceneRenderer.sceneObjects.get(id) && World.SceneRenderer.sceneObjects.get(id) instanceof MirabufSceneObject) {
-                        const mirabuf = World.SceneRenderer.sceneObjects.get(id) as MirabufSceneObject
-                        mirabuf.DisableTransformControls()
-                    }
+                    (World.SceneRenderer.sceneObjects.get(id) as MirabufSceneObject).DisableTransformControls()
                     World.SceneRenderer.RemoveSceneObject(id)
                     update()
                 }}

--- a/fission/src/ui/modals/spawning/ManageAssembliesModal.tsx
+++ b/fission/src/ui/modals/spawning/ManageAssembliesModal.tsx
@@ -21,6 +21,10 @@ const AssemblyCard: React.FC<AssemblyCardProps> = ({ id, update }) => {
             <Button
                 value="Delete"
                 onClick={() => {
+                    if (World.SceneRenderer.sceneObjects.get(id) && World.SceneRenderer.sceneObjects.get(id) instanceof MirabufSceneObject) {
+                        const mirabuf = World.SceneRenderer.sceneObjects.get(id) as MirabufSceneObject
+                        mirabuf.DisableTransformControls()
+                    }
                     World.SceneRenderer.RemoveSceneObject(id)
                     update()
                 }}

--- a/fission/src/ui/modals/spawning/ManageAssembliesModal.tsx
+++ b/fission/src/ui/modals/spawning/ManageAssembliesModal.tsx
@@ -20,9 +20,7 @@ const AssemblyCard: React.FC<AssemblyCardProps> = ({ id, update }) => {
             <Label className="text-wrap break-all">{id}</Label>
             <Button
                 value="Delete"
-                // prettier-ignore
                 onClick={() => {
-                    (World.SceneRenderer.sceneObjects.get(id) as MirabufSceneObject).DisableTransformControls()
                     World.SceneRenderer.RemoveSceneObject(id)
                     update()
                 }}


### PR DESCRIPTION
### Description
- [x] Fixed Bug: deleting assemblies from ManageAssembliesModal does not delete the transform gizmo attached
- [x] Removed duplicate GetRootNodeId() implementation in MirabufSceneObject.ts
- [x] Removed inaccessible variable _deleteGizmoOnEscape