### PR TITLE
Camera Customization

### DIFF
--- a/fission/package.json
+++ b/fission/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
+    "host": "vite --open --host",
     "dev": "vite --open",
     "build": "tsc && vite build",
     "build:prod": "tsc && vite build --base=/fission/ --outDir dist/prod",
@@ -51,6 +52,7 @@
     "@types/three": "^0.160.0",
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
+    "@vitejs/plugin-basic-ssl": "^1.1.0",
     "@vitejs/plugin-react": "^4.0.3",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.14",

--- a/fission/src/Synthesis.tsx
+++ b/fission/src/Synthesis.tsx
@@ -66,6 +66,7 @@ import SceneOverlay from "./ui/components/SceneOverlay.tsx"
 import WPILibWSWorker from "@/systems/simulation/wpilib_brain/WPILibWSWorker.ts?worker"
 import WSViewPanel from "./ui/panels/WSViewPanel.tsx"
 import Lazy from "./util/Lazy.ts"
+import CameraSelectionPanel from "./ui/panels/configuring/CameraSelectionPanel.tsx"
 
 const DEFAULT_MIRA_PATH = "/api/mira/Robots/Team 2471 (2018)_v7.mira"
 
@@ -267,6 +268,7 @@ const initialPanels: ReactElement[] = [
     <ImportMirabufPanel key="import-mirabuf" panelId="import-mirabuf" />,
     <PokerPanel key="poker" panelId="poker" />,
     <WSViewPanel key="ws-view" panelId="ws-view" />,
+    <CameraSelectionPanel key="camera-select" panelId="camera-select" />,
 ]
 
 export default Synthesis

--- a/fission/src/main.tsx
+++ b/fission/src/main.tsx
@@ -64,9 +64,9 @@ const defaultColors: Theme = {
     FloorGrid: { color: { r: 93, g: 93, b: 93, a: 1 }, above: [] },
     MatchRedAlliance: { color: { r: 255, g: 0, b: 0, a: 1 }, above: [] },
     MatchBlueAlliance: { color: { r: 0, g: 0, b: 255, a: 1 }, above: [] },
-    ToastInfo: { color: { r: 126, g: 34, b: 206, a: 1 }, above: [] },
-    ToastWarning: { color: { r: 234, g: 179, b: 8, a: 1 }, above: [] },
-    ToastError: { color: { r: 239, g: 68, b: 68, a: 1 }, above: [] },
+    ToastInfo: { color: { r: 95, g: 96, b: 255, a: 1 }, above: [] },
+    ToastWarning: { color: { r: 255, g: 194, b: 26, a: 1 }, above: [] },
+    ToastError: { color: { r: 214, g: 78, b: 38, a: 1 }, above: [] },
 }
 const themes = {
     Default: defaultColors,

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -4,7 +4,7 @@ import MirabufInstance from "./MirabufInstance"
 import MirabufParser, { ParseErrorSeverity, RigidNodeId, RigidNodeReadOnly } from "./MirabufParser"
 import World from "@/systems/World"
 import Jolt from "@barclah/jolt-physics"
-import { JoltMat44_ThreeMatrix4 } from "@/util/TypeConversions"
+import { JoltMat44_ThreeMatrix4, JoltVec3_ThreeVector3 } from "@/util/TypeConversions"
 import * as THREE from "three"
 import JOLT from "@/util/loading/JoltSyncLoader"
 import { BodyAssociate, LayerReserve } from "@/systems/physics/PhysicsSystem"
@@ -228,6 +228,9 @@ class MirabufSceneObject extends SceneObject {
                 )
             )
         }
+        
+        const com = World.PhysicsSystem.GetBody(this._mechanism.nodeToBody.get(this.rootNodeId)!).GetCenterOfMassPosition()
+        World.SceneRenderer.currentCameraControls.setFocus(JoltVec3_ThreeVector3(com))
     }
 
     public Dispose(): void {

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -216,7 +216,7 @@ class MirabufSceneObject extends SceneObject {
             x.computeBoundingBox()
             x.computeBoundingSphere()
         })
-
+        
         /* Updating the position of the name tag according to the robots position on screen */
         if (this._nameTag && PreferencesSystem.getGlobalPreference<boolean>("RenderSceneTags")) {
             const boundingBox = this.ComputeBoundingBox()
@@ -228,9 +228,6 @@ class MirabufSceneObject extends SceneObject {
                 )
             )
         }
-
-        const com = World.PhysicsSystem.GetBody(this._mechanism.nodeToBody.get(this.rootNodeId)!).GetCenterOfMassTransform()
-        World.SceneRenderer.currentCameraControls.setFocusTransform(JoltMat44_ThreeMatrix4(com))
     }
 
     public Dispose(): void {
@@ -403,6 +400,11 @@ class MirabufSceneObject extends SceneObject {
 
     public GetRootNodeId(): Jolt.BodyID | undefined {
         return this._mechanism.GetBodyByNodeId(this._mechanism.rootBody)
+    }
+
+    public LoadFocusTransform(mat: THREE.Matrix4) {
+        const com = World.PhysicsSystem.GetBody(this._mechanism.nodeToBody.get(this.rootNodeId)!).GetCenterOfMassTransform()
+        mat.copy(JoltMat44_ThreeMatrix4(com))
     }
 }
 

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -4,7 +4,7 @@ import MirabufInstance from "./MirabufInstance"
 import MirabufParser, { ParseErrorSeverity, RigidNodeId, RigidNodeReadOnly } from "./MirabufParser"
 import World from "@/systems/World"
 import Jolt from "@barclah/jolt-physics"
-import { JoltMat44_ThreeMatrix4, JoltVec3_ThreeVector3 } from "@/util/TypeConversions"
+import { JoltMat44_ThreeMatrix4 } from "@/util/TypeConversions"
 import * as THREE from "three"
 import JOLT from "@/util/loading/JoltSyncLoader"
 import { BodyAssociate, LayerReserve } from "@/systems/physics/PhysicsSystem"
@@ -228,9 +228,9 @@ class MirabufSceneObject extends SceneObject {
                 )
             )
         }
-        
-        const com = World.PhysicsSystem.GetBody(this._mechanism.nodeToBody.get(this.rootNodeId)!).GetCenterOfMassPosition()
-        World.SceneRenderer.currentCameraControls.setFocus(JoltVec3_ThreeVector3(com))
+
+        const com = World.PhysicsSystem.GetBody(this._mechanism.nodeToBody.get(this.rootNodeId)!).GetCenterOfMassTransform()
+        World.SceneRenderer.currentCameraControls.setFocusTransform(JoltMat44_ThreeMatrix4(com))
     }
 
     public Dispose(): void {

--- a/fission/src/systems/scene/CameraControls.ts
+++ b/fission/src/systems/scene/CameraControls.ts
@@ -1,0 +1,70 @@
+import * as THREE from 'three'
+import { OrbitControls as ThreeOrbitControls } from "three/examples/jsm/controls/OrbitControls.js"
+import { FlyControls as ThreeFlyControls } from "three/examples/jsm/controls/FlyControls.js"
+
+export enum CameraControlsType {
+    Orbit = 1, Fly = 2
+}
+
+export abstract class CameraControls {
+    private _controlsType;
+
+    public abstract set enabled(val: boolean)
+    public abstract get enabled(): boolean
+
+    public get controlsType() { return this._controlsType }
+
+    public constructor(controlsType: CameraControlsType) {
+        this._controlsType = controlsType
+    }
+
+    public abstract update(deltaT: number): void
+
+    public abstract dispose(): void
+}
+
+export class OrbitControls extends CameraControls {
+    private _orbit: ThreeOrbitControls
+
+    public get settings() { return this._orbit }
+    
+    public set enabled(val: boolean) { this._orbit.enabled = val }
+    public get enabled(): boolean { return this._orbit.enabled }
+    
+    public constructor(mainCamera: THREE.Camera, domElement: HTMLElement) {
+        super(CameraControlsType.Orbit)
+
+        this._orbit = new ThreeOrbitControls(mainCamera, domElement)
+    }
+
+    public update(_: number): void {
+        this._orbit.update()
+    }
+
+    public dispose(): void {
+        this._orbit.dispose()
+    }
+}
+
+export class FlyControls extends CameraControls {
+    private _fly: ThreeFlyControls
+
+    public get settings() { return this._fly }
+    
+    public set enabled(val: boolean) { this._fly.enabled = val }
+    public get enabled(): boolean { return this._fly.enabled }
+    
+    public constructor(mainCamera: THREE.Camera, domElement: HTMLElement) {
+        super(CameraControlsType.Orbit)
+
+        this._fly = new ThreeFlyControls(mainCamera, domElement)
+    }
+
+    public update(deltaT: number): void {
+        this._fly.update(deltaT)
+    }
+
+    public dispose(): void {
+        this._fly.dispose()
+    }
+}

--- a/fission/src/systems/scene/CameraControls.ts
+++ b/fission/src/systems/scene/CameraControls.ts
@@ -67,22 +67,32 @@ class PointerHandler {
     private _wheelMove: (ev: WheelEvent) => void
     private _pointerDown: (ev: PointerEvent) => void
     private _pointerUp: (ev: PointerEvent) => void
+    private _contextMenu: (ev: MouseEvent) => unknown
 
     private _domElement: HTMLElement
 
-    private _isPointerDown: boolean = false
-    public get isPointerDown() { return this._isPointerDown }
-
-    public constructor(domElement: HTMLElement, pointerMove: (ev: PointerEvent) => void, wheelMove: (ev: WheelEvent) => void) {
+    public constructor(
+        domElement: HTMLElement,
+        pointerDown: (ev: PointerEvent) => void,
+        pointerUp: (ev: PointerEvent) => void,
+        pointerMove: (ev: PointerEvent) => void,
+        wheelMove: (ev: WheelEvent) => void,
+        onContextMenu?: (ev: MouseEvent) => unknown
+    ) {
         this._pointerMove = pointerMove
         this._wheelMove = wheelMove
         this._domElement = domElement
 
-        this._pointerDown = (ev) => { this._isPointerDown = true }
-        this._pointerUp = (ev) => { this._isPointerDown = false }
+        this._pointerDown = pointerDown
+        this._pointerUp = pointerUp
+
+        this._contextMenu = onContextMenu ?? ((ev: MouseEvent) => {
+            ev.preventDefault()
+        }) 
         
         this._domElement.addEventListener("pointermove", this._pointerMove)
-        this._domElement.addEventListener("wheel", this._wheelMove)
+        this._domElement.addEventListener("wheel", this._wheelMove, { passive: false })
+        this._domElement.addEventListener("contextmenu", this._contextMenu)
         
         this._domElement.addEventListener("pointerdown", this._pointerDown)
         this._domElement.addEventListener("pointerup", this._pointerUp)
@@ -93,6 +103,7 @@ class PointerHandler {
     public dispose() {
         this._domElement.removeEventListener("pointermove", this._pointerMove)
         this._domElement.removeEventListener("wheel", this._wheelMove)
+        this._domElement.removeEventListener("contextmenu", this._contextMenu)
 
         this._domElement.removeEventListener("pointerdown", this._pointerDown)
         this._domElement.removeEventListener("pointerup", this._pointerUp)
@@ -100,6 +111,25 @@ class PointerHandler {
         this._domElement.removeEventListener("pointerleave", this._pointerUp)
     }
 }
+
+interface SphericalCoords {
+    theta: number
+    phi: number
+    r: number
+}
+
+const CO_MAX_ZOOM = 40.0
+const CO_MIN_ZOOM = 0.1
+const CO_MAX_PHI = Math.PI / 2.1
+const CO_MIN_PHI = -Math.PI / 2.1
+
+const CO_SENSITIVITY_ZOOM = 3.0
+const CO_SENSITIVITY_PHI = 1.0
+const CO_SENSITIVITY_THETA = 1.0
+
+const CO_DEFAULT_ZOOM = 3.5
+const CO_DEFAULT_PHI = -Math.PI / 6.0
+const CO_DEFAULT_THETA = -Math.PI / 4.0
 
 export class CustomOrbitControls extends CameraControls {
     private _enabled = true
@@ -109,7 +139,11 @@ export class CustomOrbitControls extends CameraControls {
 
     private _pointerHandler: PointerHandler
 
-    private _omega: THREE.Vec2
+    private _isPointerDown: boolean
+    private _currentPos: SphericalCoords
+    private _lastPos: SphericalCoords
+    private _coords: SphericalCoords
+    private _focus: THREE.Vector3
 
     public set enabled(val: boolean) {
         this._enabled = val
@@ -124,29 +158,77 @@ export class CustomOrbitControls extends CameraControls {
         this._mainCamera = mainCamera
         this._domElement = domElement
 
-        this._omega = { x: 0, y: 0 }
+        this._currentPos = { theta: CO_DEFAULT_THETA, phi: CO_DEFAULT_PHI, r: CO_DEFAULT_ZOOM }
+        this._lastPos = this._currentPos
+        this._coords = { theta: CO_DEFAULT_THETA, phi: CO_DEFAULT_PHI, r: CO_DEFAULT_ZOOM }
+        this._isPointerDown = false
+
+        this._focus = new THREE.Vector3(0,0,0)
 
         this._pointerHandler = new PointerHandler(domElement,
-            (ev) => {
-                this._omega = { x: ev.movementX, y: ev.movementY }
-            },
-            (ev) => {
-
-            }
+            (ev) => this.pointerDown(ev),
+            (ev) => this.pointerUp(ev),
+            (ev) => this.pointerMove(ev),
+            (ev) => this.wheelMove(ev)
         )
     }
 
+    public wheelMove(ev: WheelEvent) {
+        this._currentPos.r += ev.deltaY * 0.01
+    }
+
+    public pointerUp(ev: PointerEvent) {
+        this._isPointerDown = false
+    }
+
+    public pointerDown(ev: PointerEvent) {
+        this._isPointerDown = ev.button == 0
+    }
+
+    public pointerMove(ev: PointerEvent) {
+        if (!this._isPointerDown) {
+            return
+        }
+
+        this._currentPos.theta -= ev.movementX
+        this._currentPos.phi -= ev.movementY
+
+        console.debug(this._currentPos)
+    }
+
     public update(deltaT: number): void {
-        if (this._pointerHandler.isPointerDown)
-        console.debug(this._omega)
+        const omega: SphericalCoords = this.enabled ? {
+            theta: this._currentPos.theta - this._lastPos.theta,
+            phi: this._currentPos.phi - this._lastPos.phi,
+            r: this._currentPos.r - this._lastPos.r
+        } : { theta: 0, phi: 0, r: 0 }
+
+        this._lastPos = { theta: this._currentPos.theta, phi: this._currentPos.phi, r: this._currentPos.r }
+
+        this._coords.theta += omega.theta * deltaT * CO_SENSITIVITY_THETA
+        this._coords.phi += omega.phi * deltaT * CO_SENSITIVITY_PHI
+        this._coords.r += omega.r * deltaT * CO_SENSITIVITY_ZOOM * Math.pow(this._coords.r, 1.6)
+
+        this._coords.phi = Math.min(CO_MAX_PHI, Math.max(CO_MIN_PHI, this._coords.phi))
+        this._coords.r = Math.min(CO_MAX_ZOOM, Math.max(CO_MIN_ZOOM, this._coords.r))
+
+        const deltaTransform = (new THREE.Matrix4()).makeTranslation(0, 0, this._coords.r)
+            .premultiply((new THREE.Matrix4()).makeRotationFromEuler(new THREE.Euler(this._coords.phi, this._coords.theta, 0, "YXZ")))
+
+        deltaTransform.premultiply((new THREE.Matrix4()).makeTranslation(this._focus))
+
+        this._mainCamera.position.setFromMatrixPosition(deltaTransform)
+        this._mainCamera.rotation.setFromRotationMatrix(deltaTransform)
     }
 
     public setFocus(vec: THREE.Vector3): void {
-    
+        if (this.enabled) {
+            this._focus.copy(vec)
+        }
     }
 
     public dispose(): void {
-        
+        this._pointerHandler.dispose()
     }
 
 }

--- a/fission/src/systems/scene/CameraControls.ts
+++ b/fission/src/systems/scene/CameraControls.ts
@@ -3,7 +3,7 @@ import { OrbitControls as ThreeOrbitControls } from "three/examples/jsm/controls
 import { FlyControls as ThreeFlyControls } from "three/examples/jsm/controls/FlyControls.js"
 
 export enum CameraControlsType {
-    Orbit = 1, Fly = 2
+    OrbitFocus = 1, OrbitFree = 2
 }
 
 export abstract class CameraControls {
@@ -20,6 +20,8 @@ export abstract class CameraControls {
 
     public abstract update(deltaT: number): void
 
+    public abstract setFocus(vec: THREE.Vector3): void;
+
     public abstract dispose(): void
 }
 
@@ -30,15 +32,28 @@ export class OrbitControls extends CameraControls {
     
     public set enabled(val: boolean) { this._orbit.enabled = val }
     public get enabled(): boolean { return this._orbit.enabled }
+
+    private _allowFocus: boolean
     
-    public constructor(mainCamera: THREE.Camera, domElement: HTMLElement) {
-        super(CameraControlsType.Orbit)
+    public constructor(mainCamera: THREE.Camera, domElement: HTMLElement, allowFocus: boolean) {
+        super(allowFocus ? CameraControlsType.OrbitFocus : CameraControlsType.OrbitFree)
+
+        this._allowFocus = allowFocus
 
         this._orbit = new ThreeOrbitControls(mainCamera, domElement)
+        this._orbit.enablePan = !allowFocus
     }
 
-    public update(_: number): void {
-        this._orbit.update()
+    public update(deltaT: number): void {
+        this._orbit.update(deltaT)
+    }
+
+    public setFocus(vec: THREE.Vector3): void {
+        if (!this._allowFocus) {
+            return
+        }
+
+        this._orbit.target = vec
     }
 
     public dispose(): void {
@@ -46,25 +61,92 @@ export class OrbitControls extends CameraControls {
     }
 }
 
-export class FlyControls extends CameraControls {
-    private _fly: ThreeFlyControls
+class PointerHandler {
 
-    public get settings() { return this._fly }
+    private _pointerMove: (ev: PointerEvent) => void
+    private _wheelMove: (ev: WheelEvent) => void
+    private _pointerDown: (ev: PointerEvent) => void
+    private _pointerUp: (ev: PointerEvent) => void
+
+    private _domElement: HTMLElement
+
+    private _isPointerDown: boolean = false
+    public get isPointerDown() { return this._isPointerDown }
+
+    public constructor(domElement: HTMLElement, pointerMove: (ev: PointerEvent) => void, wheelMove: (ev: WheelEvent) => void) {
+        this._pointerMove = pointerMove
+        this._wheelMove = wheelMove
+        this._domElement = domElement
+
+        this._pointerDown = (ev) => { this._isPointerDown = true }
+        this._pointerUp = (ev) => { this._isPointerDown = false }
+        
+        this._domElement.addEventListener("pointermove", this._pointerMove)
+        this._domElement.addEventListener("wheel", this._wheelMove)
+        
+        this._domElement.addEventListener("pointerdown", this._pointerDown)
+        this._domElement.addEventListener("pointerup", this._pointerUp)
+        this._domElement.addEventListener("pointercancel", this._pointerUp)
+        this._domElement.addEventListener("pointerleave", this._pointerUp)
+    }
+
+    public dispose() {
+        this._domElement.removeEventListener("pointermove", this._pointerMove)
+        this._domElement.removeEventListener("wheel", this._wheelMove)
+
+        this._domElement.removeEventListener("pointerdown", this._pointerDown)
+        this._domElement.removeEventListener("pointerup", this._pointerUp)
+        this._domElement.removeEventListener("pointercancel", this._pointerUp)
+        this._domElement.removeEventListener("pointerleave", this._pointerUp)
+    }
+}
+
+export class CustomOrbitControls extends CameraControls {
+    private _enabled = true
     
-    public set enabled(val: boolean) { this._fly.enabled = val }
-    public get enabled(): boolean { return this._fly.enabled }
-    
+    private _mainCamera: THREE.Camera
+    private _domElement: HTMLElement
+
+    private _pointerHandler: PointerHandler
+
+    private _omega: THREE.Vec2
+
+    public set enabled(val: boolean) {
+        this._enabled = val
+    }
+    public get enabled(): boolean {
+        return this._enabled
+    }
+
     public constructor(mainCamera: THREE.Camera, domElement: HTMLElement) {
-        super(CameraControlsType.Orbit)
+        super(CameraControlsType.OrbitFocus)
 
-        this._fly = new ThreeFlyControls(mainCamera, domElement)
+        this._mainCamera = mainCamera
+        this._domElement = domElement
+
+        this._omega = { x: 0, y: 0 }
+
+        this._pointerHandler = new PointerHandler(domElement,
+            (ev) => {
+                this._omega = { x: ev.movementX, y: ev.movementY }
+            },
+            (ev) => {
+
+            }
+        )
     }
 
     public update(deltaT: number): void {
-        this._fly.update(deltaT)
+        if (this._pointerHandler.isPointerDown)
+        console.debug(this._omega)
+    }
+
+    public setFocus(vec: THREE.Vector3): void {
+    
     }
 
     public dispose(): void {
-        this._fly.dispose()
+        
     }
+
 }

--- a/fission/src/systems/scene/SceneRenderer.ts
+++ b/fission/src/systems/scene/SceneRenderer.ts
@@ -9,7 +9,7 @@ import vertexShader from "@/shaders/vertex.glsl"
 import fragmentShader from "@/shaders/fragment.glsl"
 import { Theme } from "@/ui/ThemeContext"
 import InputSystem from "@/systems/input/InputSystem"
-import { CameraControls, CameraControlsType, CustomOrbitControls, OrbitControls } from "@/systems/scene/CameraControls"
+import { CameraControls, CameraControlsType, CustomOrbitControls } from "@/systems/scene/CameraControls"
 
 import { PixelSpaceCoord, SceneOverlayEvent, SceneOverlayEventKey } from "@/ui/components/SceneOverlayEvents"
 import {} from "@/ui/components/SceneOverlayEvents"
@@ -132,17 +132,20 @@ class SceneRenderer extends WorldSystem {
         this._composer.addPass(this._antiAliasPass)
 
         // Orbit controls
-        this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement);
+        this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement, true, false);
     }
 
     public SetCameraControls(controlsType: CameraControlsType) {
         this._cameraControls.dispose()
         switch (controlsType) {
             case CameraControlsType.OrbitFocus:
-                this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement)
+                this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement, true, false)
+                break
+            case CameraControlsType.OrbitLocked:
+                this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement, true, true)
                 break
             case CameraControlsType.OrbitFree:
-                this._cameraControls = new OrbitControls(this._mainCamera, this._renderer.domElement, false)
+                this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement, false, false)
                 break
         }
     }

--- a/fission/src/systems/scene/SceneRenderer.ts
+++ b/fission/src/systems/scene/SceneRenderer.ts
@@ -11,6 +11,7 @@ import { Theme } from "@/ui/ThemeContext"
 import InputSystem from "@/systems/input/InputSystem"
 import { CameraControls, CameraControlsType, CustomOrbitControls } from "@/systems/scene/CameraControls"
 import ScreenInteractionHandler from "./ScreenInteractionHandler"
+import { MainHUD_AddToast } from "@/ui/components/MainHUD"
 
 import { PixelSpaceCoord, SceneOverlayEvent, SceneOverlayEventKey } from "@/ui/components/SceneOverlayEvents"
 import {} from "@/ui/components/SceneOverlayEvents"
@@ -136,6 +137,7 @@ class SceneRenderer extends WorldSystem {
 
         // Orbit controls
         this._screenInteractionHandler = new ScreenInteractionHandler(this._renderer.domElement)
+        this._screenInteractionHandler.contextMenu = _ => MainHUD_AddToast("info", "Context Menu", "tmp tmp tmp tmptmptm ptm ")
 
         this._cameraControls = new CustomOrbitControls(this._mainCamera, this._screenInteractionHandler);
     }

--- a/fission/src/systems/scene/SceneRenderer.ts
+++ b/fission/src/systems/scene/SceneRenderer.ts
@@ -20,6 +20,10 @@ import PreferencesSystem from "../preferences/PreferencesSystem"
 const CLEAR_COLOR = 0x121212
 const GROUND_COLOR = 0x4066c7
 
+const STANDARD_ASPECT = 16.0 / 9.0
+const STANDARD_CAMERA_FOV_X = 110.0
+const STANDARD_CAMERA_FOV_Y = STANDARD_CAMERA_FOV_X / STANDARD_ASPECT
+
 let nextSceneObjectId = 1
 
 class SceneRenderer extends WorldSystem {
@@ -64,7 +68,8 @@ class SceneRenderer extends WorldSystem {
         this._sceneObjects = new Map()
         this._transformControls = new Map()
 
-        this._mainCamera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000)
+        const aspect = window.innerWidth / window.innerHeight
+        this._mainCamera = new THREE.PerspectiveCamera(STANDARD_CAMERA_FOV_Y, aspect, 0.1, 1000)
         this._mainCamera.position.set(-2.5, 2, 2.5)
 
         this._scene = new THREE.Scene()
@@ -152,11 +157,21 @@ class SceneRenderer extends WorldSystem {
     }
 
     public UpdateCanvasSize() {
-        this._renderer.setSize(window.innerWidth, window.innerHeight)
+        this._renderer.setSize(window.innerWidth, window.innerHeight, true)
+
+        const vec = new THREE.Vector2(0,0)
+        this._renderer.getSize(vec)
+        console.debug(`${vec.x.toFixed(2)}, ${vec.y.toFixed(2)}`)
         // No idea why height would be zero, but just incase.
         this._mainCamera.aspect = window.innerWidth / window.innerHeight
+
+        if (this._mainCamera.aspect < STANDARD_ASPECT) {
+            this._mainCamera.fov = STANDARD_CAMERA_FOV_Y
+        } else {
+            this._mainCamera.fov = STANDARD_CAMERA_FOV_X / this._mainCamera.aspect
+        }
+
         this._mainCamera.updateProjectionMatrix()
-        console.debug("Update")
     }
 
     public Update(deltaT: number): void {
@@ -182,6 +197,7 @@ class SceneRenderer extends WorldSystem {
         this._cameraControls.update(deltaT)
 
         this._composer.render(deltaT)
+        // this._renderer.render(this._scene, this._mainCamera)
     }
 
     public Destroy(): void {

--- a/fission/src/systems/scene/SceneRenderer.ts
+++ b/fission/src/systems/scene/SceneRenderer.ts
@@ -10,6 +10,7 @@ import fragmentShader from "@/shaders/fragment.glsl"
 import { Theme } from "@/ui/ThemeContext"
 import InputSystem from "@/systems/input/InputSystem"
 import { CameraControls, CameraControlsType, CustomOrbitControls } from "@/systems/scene/CameraControls"
+import ScreenInteractionHandler from "./ScreenInteractionHandler"
 
 import { PixelSpaceCoord, SceneOverlayEvent, SceneOverlayEventKey } from "@/ui/components/SceneOverlayEvents"
 import {} from "@/ui/components/SceneOverlayEvents"
@@ -33,6 +34,8 @@ class SceneRenderer extends WorldSystem {
 
     private _cameraControls: CameraControls
     private _transformControls: Map<TransformControls, number> // maps all rendered transform controls to their size
+
+    private _screenInteractionHandler: ScreenInteractionHandler
 
     public get sceneObjects() {
         return this._sceneObjects
@@ -132,14 +135,16 @@ class SceneRenderer extends WorldSystem {
         this._composer.addPass(this._antiAliasPass)
 
         // Orbit controls
-        this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement);
+        this._screenInteractionHandler = new ScreenInteractionHandler(this._renderer.domElement)
+
+        this._cameraControls = new CustomOrbitControls(this._mainCamera, this._screenInteractionHandler);
     }
 
     public SetCameraControls(controlsType: CameraControlsType) {
         this._cameraControls.dispose()
         switch (controlsType) {
             case "Orbit":
-                this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement)
+                this._cameraControls = new CustomOrbitControls(this._mainCamera, this._screenInteractionHandler)
                 break
         }
     }
@@ -149,6 +154,7 @@ class SceneRenderer extends WorldSystem {
         // No idea why height would be zero, but just incase.
         this._mainCamera.aspect = window.innerWidth / window.innerHeight
         this._mainCamera.updateProjectionMatrix()
+        console.debug("Update")
     }
 
     public Update(deltaT: number): void {
@@ -178,6 +184,7 @@ class SceneRenderer extends WorldSystem {
 
     public Destroy(): void {
         this.RemoveAllSceneObjects()
+        this._screenInteractionHandler.dispose()
     }
 
     public RegisterSceneObject<T extends SceneObject>(obj: T): number {

--- a/fission/src/systems/scene/SceneRenderer.ts
+++ b/fission/src/systems/scene/SceneRenderer.ts
@@ -9,7 +9,7 @@ import vertexShader from "@/shaders/vertex.glsl"
 import fragmentShader from "@/shaders/fragment.glsl"
 import { Theme } from "@/ui/ThemeContext"
 import InputSystem from "@/systems/input/InputSystem"
-import { CameraControls, CameraControlsType, OrbitControls } from "@/systems/scene/CameraControls"
+import { CameraControls, CameraControlsType, CustomOrbitControls, OrbitControls } from "@/systems/scene/CameraControls"
 
 import { PixelSpaceCoord, SceneOverlayEvent, SceneOverlayEventKey } from "@/ui/components/SceneOverlayEvents"
 import {} from "@/ui/components/SceneOverlayEvents"
@@ -48,6 +48,10 @@ class SceneRenderer extends WorldSystem {
 
     public get renderer(): THREE.WebGLRenderer {
         return this._renderer
+    }
+
+    public get currentCameraControls(): CameraControls {
+        return this._cameraControls
     }
 
     public constructor() {
@@ -128,17 +132,17 @@ class SceneRenderer extends WorldSystem {
         this._composer.addPass(this._antiAliasPass)
 
         // Orbit controls
-        this._cameraControls = new OrbitControls(this._mainCamera, this._renderer.domElement)
+        this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement);
     }
 
     public SetCameraControls(controlsType: CameraControlsType) {
         this._cameraControls.dispose()
         switch (controlsType) {
-            case CameraControlsType.Orbit:
-                this._cameraControls = new OrbitControls(this._mainCamera, this._renderer.domElement)
+            case CameraControlsType.OrbitFocus:
+                this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement)
                 break
-            case CameraControlsType.Fly:
-                // this._cameraControls = new 
+            case CameraControlsType.OrbitFree:
+                this._cameraControls = new OrbitControls(this._mainCamera, this._renderer.domElement, false)
                 break
         }
     }

--- a/fission/src/systems/scene/SceneRenderer.ts
+++ b/fission/src/systems/scene/SceneRenderer.ts
@@ -1,15 +1,15 @@
 import * as THREE from "three"
-import SceneObject from "./SceneObject"
-import WorldSystem from "../WorldSystem"
+import SceneObject from "@/systems/scene/SceneObject"
+import WorldSystem from "@/systems/WorldSystem"
 
 import { TransformControls } from "three/examples/jsm/controls/TransformControls.js"
-import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js"
 import { EdgeDetectionMode, EffectComposer, EffectPass, RenderPass, SMAAEffect } from "postprocessing"
 
 import vertexShader from "@/shaders/vertex.glsl"
 import fragmentShader from "@/shaders/fragment.glsl"
 import { Theme } from "@/ui/ThemeContext"
-import InputSystem from "../input/InputSystem"
+import InputSystem from "@/systems/input/InputSystem"
+import { CameraControls, CameraControlsType, OrbitControls } from "@/systems/scene/CameraControls"
 
 import { PixelSpaceCoord, SceneOverlayEvent, SceneOverlayEventKey } from "@/ui/components/SceneOverlayEvents"
 import {} from "@/ui/components/SceneOverlayEvents"
@@ -31,7 +31,7 @@ class SceneRenderer extends WorldSystem {
 
     private _sceneObjects: Map<number, SceneObject>
 
-    private _orbitControls: OrbitControls
+    private _cameraControls: CameraControls
     private _transformControls: Map<TransformControls, number> // maps all rendered transform controls to their size
 
     public get sceneObjects() {
@@ -128,8 +128,19 @@ class SceneRenderer extends WorldSystem {
         this._composer.addPass(this._antiAliasPass)
 
         // Orbit controls
-        this._orbitControls = new OrbitControls(this._mainCamera, this._renderer.domElement)
-        this._orbitControls.update()
+        this._cameraControls = new OrbitControls(this._mainCamera, this._renderer.domElement)
+    }
+
+    public SetCameraControls(controlsType: CameraControlsType) {
+        this._cameraControls.dispose()
+        switch (controlsType) {
+            case CameraControlsType.Orbit:
+                this._cameraControls = new OrbitControls(this._mainCamera, this._renderer.domElement)
+                break
+            case CameraControlsType.Fly:
+                // this._cameraControls = new 
+                break
+        }
     }
 
     public UpdateCanvasSize() {
@@ -158,6 +169,8 @@ class SceneRenderer extends WorldSystem {
         // Update the tags each frame if they are enabled in preferences
         if (PreferencesSystem.getGlobalPreference<boolean>("RenderSceneTags"))
             new SceneOverlayEvent(SceneOverlayEventKey.UPDATE)
+        
+        this._cameraControls.update(deltaT)
 
         this._composer.render(deltaT)
     }
@@ -274,11 +287,11 @@ class SceneRenderer extends WorldSystem {
             (event: { target: TransformControls; value: unknown }) => {
                 const isAnyGizmoDragging = Array.from(this._transformControls.keys()).some(gizmo => gizmo.dragging)
                 if (!event.value && !isAnyGizmoDragging) {
-                    this._orbitControls.enabled = true // enable orbit controls when not dragging another transform gizmo
+                    this._cameraControls.enabled = true // enable orbit controls when not dragging another transform gizmo
                 } else if (!event.value && isAnyGizmoDragging) {
-                    this._orbitControls.enabled = false // disable orbit controls when dragging another transform gizmo
+                    this._cameraControls.enabled = false // disable orbit controls when dragging another transform gizmo
                 } else {
-                    this._orbitControls.enabled = !event.value // disable orbit controls when dragging transform gizmo
+                    this._cameraControls.enabled = !event.value // disable orbit controls when dragging transform gizmo
                 }
 
                 if (event.target.mode === "translate") {

--- a/fission/src/systems/scene/SceneRenderer.ts
+++ b/fission/src/systems/scene/SceneRenderer.ts
@@ -132,20 +132,14 @@ class SceneRenderer extends WorldSystem {
         this._composer.addPass(this._antiAliasPass)
 
         // Orbit controls
-        this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement, true, false);
+        this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement);
     }
 
     public SetCameraControls(controlsType: CameraControlsType) {
         this._cameraControls.dispose()
         switch (controlsType) {
-            case CameraControlsType.OrbitFocus:
-                this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement, true, false)
-                break
-            case CameraControlsType.OrbitLocked:
-                this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement, true, true)
-                break
-            case CameraControlsType.OrbitFree:
-                this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement, false, false)
+            case "Orbit":
+                this._cameraControls = new CustomOrbitControls(this._mainCamera, this._renderer.domElement)
                 break
         }
     }

--- a/fission/src/systems/scene/ScreenInteractionHandler.ts
+++ b/fission/src/systems/scene/ScreenInteractionHandler.ts
@@ -154,6 +154,7 @@ class ScreenInteractionHandler {
             if (!this._primaryTouch) {
                 this._primaryTouch = e.pointerId
                 this._primaryTouchPosition = [e.clientX, e.clientY]
+                this._movementThresholdMet = false
                 this.interactionStart({ interactionType: PRIMARY_MOUSE_INTERACTION, position: this._primaryTouchPosition })
             } else if (!this._secondaryTouch) {
                 this._secondaryTouch = e.pointerId
@@ -162,6 +163,7 @@ class ScreenInteractionHandler {
             }
         } else {
             if (e.button >= 0 && e.button <= 2) {
+                this._movementThresholdMet = false
                 this.interactionStart({ interactionType: e.button as InteractionType, position: [e.clientX, e.clientY] })
             }
         }
@@ -179,9 +181,10 @@ class ScreenInteractionHandler {
                 if (!this._primaryTouch) {
                     const end: InteractionEnd = { interactionType: PRIMARY_MOUSE_INTERACTION, position: [e.clientX, e.clientY] }
                     this.interactionEnd(end)
-                    if (this._doubleTapInteraction && this.contextMenu) {
+                    if (this._doubleTapInteraction && !this._movementThresholdMet && this.contextMenu) {
                         this.contextMenu(end)
                     }
+                    this._doubleTapInteraction = false
                 }
                 // Reset continuous tracking
             } else if (e.pointerId == this._secondaryTouch) {
@@ -190,7 +193,11 @@ class ScreenInteractionHandler {
             }
         } else {
             if (e.button >= 0 && e.button <= 2) {
-                this.interactionEnd({ interactionType: e.button as InteractionType, position: [e.clientX, e.clientY] })
+                const end: InteractionEnd = { interactionType: e.button as InteractionType, position: [e.clientX, e.clientY] }
+                this.interactionEnd(end)
+                if (e.button == SECONDARY_MOUSE_INTERACTION && this.contextMenu) {
+                    this.contextMenu(end)
+                }
             }
         }
     }

--- a/fission/src/systems/scene/ScreenInteractionHandler.ts
+++ b/fission/src/systems/scene/ScreenInteractionHandler.ts
@@ -1,0 +1,171 @@
+import * as THREE from "three"
+
+export const PRIMARY_MOUSE_INTERACTION = 0
+export const MIDDLE_MOUSE_INTERACTION = 1
+export const SECONDARY_MOUSE_INTERACTION = 2
+export const TOUCH_INTERACTION = 3
+export const TOUCH_DOUBLE_INTERACTION = 4
+
+export type InteractionType = -1 | 0 | 1 | 2 | 3 | 4
+
+export interface InteractionStart {
+    interactionType: InteractionType
+    position: [number, number]
+}
+
+export interface InteractionMove {
+    interactionType: InteractionType
+    scale?: number,
+    movement?: [number, number]
+}
+
+export interface InteractionEnd {
+    interactionType: InteractionType
+    position: [number, number]
+}
+
+/**
+ * Handler for all screen interactions with Mouse, Pen, and Touch controls.
+ * 
+ * Mouse and Pen controls are stateless, whereas Touch controls are stateful
+ */
+class ScreenInteractionHandler {
+
+    private _primaryTouch: number | undefined
+    private _secondaryTouch: number | undefined
+    private _primaryTouchPosition: [number, number] | undefined
+    private _secondaryTouchPosition: [number, number] | undefined
+
+    private _pointerMove: (ev: PointerEvent) => void
+    private _wheelMove: (ev: WheelEvent) => void
+    private _pointerDown: (ev: PointerEvent) => void
+    private _pointerUp: (ev: PointerEvent) => void
+    private _contextMenu: (ev: MouseEvent) => unknown
+    private _touchMove: (ev: TouchEvent) => void
+
+    private _domElement: HTMLElement
+
+    public interactionStart: ((i: InteractionStart) => void) | undefined
+    public interactionEnd: ((i: InteractionEnd) => void) | undefined
+    public interactionMove: ((i: InteractionMove) => void) | undefined
+
+    public constructor(domElement: HTMLElement) {
+        this._domElement = domElement
+
+        this._pointerMove = e => this.pointerMove(e) 
+        this._wheelMove = e => this.wheelMove(e)
+        this._pointerDown = e => this.pointerDown(e)
+        this._pointerUp = e => this.pointerUp(e)
+        this._contextMenu = e => e.preventDefault()
+        this._touchMove = e => e.preventDefault()
+        
+        this._domElement.addEventListener("pointermove", this._pointerMove)
+        this._domElement.addEventListener("wheel", this._wheelMove, { passive: false })
+        this._domElement.addEventListener("contextmenu", this._contextMenu)
+        this._domElement.addEventListener("pointerdown", this._pointerDown)
+        this._domElement.addEventListener("pointerup", this._pointerUp)
+        this._domElement.addEventListener("pointercancel", this._pointerUp)
+        this._domElement.addEventListener("pointerleave", this._pointerUp)
+
+        this._domElement.addEventListener("touchmove", this._touchMove)
+    }
+
+    public dispose() {
+        this._domElement.removeEventListener("pointermove", this._pointerMove)
+        this._domElement.removeEventListener("wheel", this._wheelMove)
+        this._domElement.removeEventListener("contextmenu", this._contextMenu)
+        this._domElement.removeEventListener("pointerdown", this._pointerDown)
+        this._domElement.removeEventListener("pointerup", this._pointerUp)
+        this._domElement.removeEventListener("pointercancel", this._pointerUp)
+        this._domElement.removeEventListener("pointerleave", this._pointerUp)
+
+        this._domElement.removeEventListener("touchmove", this._touchMove)
+    }
+
+    private pointerMove(e: PointerEvent) {
+        if (!this.interactionMove) {
+            return
+        }
+        
+        if (e.pointerType == "mouse" || e.pointerType == "pen") {
+            this.interactionMove({ interactionType: e.button as InteractionType, movement: [e.movementX, e.movementY] })
+        } else {
+            if (e.pointerId == this._primaryTouch) {
+                this._primaryTouchPosition = [e.clientX, e.clientY]
+                this.interactionMove({
+                    interactionType: PRIMARY_MOUSE_INTERACTION,
+                    movement: [e.movementX, e.movementY]
+                })
+            } else if (e.pointerId == this._secondaryTouch) {
+                this._secondaryTouchPosition = [e.clientX, e.clientY]
+                if (this._primaryTouchPosition) { // This shouldn't happen, but you never know
+                    const scalingDir = (new THREE.Vector2(this._secondaryTouchPosition[0], this._secondaryTouchPosition[1])).sub(
+                        new THREE.Vector2(this._primaryTouchPosition[0], this._primaryTouchPosition[1])
+                    )
+
+                    const scale = scalingDir.normalize().dot(new THREE.Vector2(e.movementX, e.movementY))
+
+                    this.interactionMove({
+                        interactionType: PRIMARY_MOUSE_INTERACTION,
+                        scale: scale * -0.06
+                    })
+                }
+            }
+        }
+    }
+
+    private wheelMove(e: WheelEvent) {
+        if (!this.interactionMove) {
+            return
+        }
+
+        this.interactionMove({ interactionType: -1, scale: e.deltaY * 0.01 })
+    }
+
+    private pointerDown(e: PointerEvent) {
+        if (!this.interactionStart) {
+            return
+        }
+
+        if (e.pointerType == "touch") {
+            if (!this._primaryTouch) {
+                this._primaryTouch = e.pointerId
+                this._primaryTouchPosition = [e.clientX, e.clientY]
+                this.interactionStart({ interactionType: PRIMARY_MOUSE_INTERACTION, position: this._primaryTouchPosition })
+            } else if (!this._secondaryTouch) {
+                this._secondaryTouch = e.pointerId
+                this._secondaryTouchPosition = [e.clientX, e.clientY]
+            }
+        } else {
+            if (e.button >= 0 && e.button <= 2) {
+                this.interactionStart({ interactionType: e.button as InteractionType, position: [e.clientX, e.clientY] })
+            }
+        }
+    }
+
+    private pointerUp(e: PointerEvent) {
+        if (!this.interactionEnd) {
+            return
+        }
+
+        if (e.pointerType == "touch") {
+            if (e.pointerId == this._primaryTouch) {
+                this._primaryTouch = this._secondaryTouch
+                this._secondaryTouch = undefined
+                if (!this._primaryTouch) {
+                    this.interactionEnd({ interactionType: PRIMARY_MOUSE_INTERACTION, position: [e.clientX, e.clientY] })
+                }
+                // Reset continuous tracking
+            } else if (e.pointerId == this._secondaryTouch) {
+                this._secondaryTouch = undefined
+                // Reset continuous tracking
+            }
+        } else {
+            if (e.button >= 0 && e.button <= 2) {
+                this.interactionEnd({ interactionType: e.button as InteractionType, position: [e.clientX, e.clientY] })
+            }
+        }
+    }
+}
+
+export default ScreenInteractionHandler

--- a/fission/src/ui/components/MainHUD.tsx
+++ b/fission/src/ui/components/MainHUD.tsx
@@ -106,7 +106,11 @@ const MainHUD: React.FC = () => {
                         onClick={() => openModal("manage-assemblies")}
                     />
                     <MainHUDButton value={"Settings"} icon={<FaGear />} onClick={() => openModal("settings")} />
-                    <MainHUDButton value={"View"} icon={<FaMagnifyingGlass />} onClick={() => openModal("view")} />
+                    <MainHUDButton
+                        value={"View"}
+                        icon={<FaMagnifyingGlass />}
+                        onClick={() => openPanel("camera-select")}
+                    />
                     <MainHUDButton
                         value={"Controls"}
                         icon={<IoGameControllerOutline />}

--- a/fission/src/ui/components/Toast.tsx
+++ b/fission/src/ui/components/Toast.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useEffect } from "react"
 import { ToastData, useToastContext } from "@/ui/ToastContext"
 import { GrFormClose } from "react-icons/gr"
 import { BsFillWrenchAdjustableCircleFill } from "react-icons/bs"
-import { AiFillWarning } from "react-icons/ai"
+import { AiFillWarning, AiOutlineInfoCircle } from "react-icons/ai"
 import { BiSolidErrorCircle } from "react-icons/bi"
 
 const TOAST_TIMEOUT: number = 5_000
@@ -25,7 +25,7 @@ const Toast: React.FC<ToastData> = ({ id, type, title, description }) => {
 
     switch (type) {
         case "info":
-            icon = <BsFillWrenchAdjustableCircleFill size={48} className="h-full w-full text-main-text" />
+            icon = <AiOutlineInfoCircle size={48} className="h-full w-full text-main-text" />
             className = "bg-toast-info"
             break
         case "warning":

--- a/fission/src/ui/panels/configuring/CameraSelectionPanel.tsx
+++ b/fission/src/ui/panels/configuring/CameraSelectionPanel.tsx
@@ -1,0 +1,39 @@
+import { CameraControlsType } from "@/systems/scene/CameraControls"
+import World from "@/systems/World"
+import Panel, { PanelPropsImpl } from "@/ui/components/Panel"
+import { ToggleButton, ToggleButtonGroup } from "@/ui/components/ToggleButtonGroup"
+import { useEffect, useState } from "react"
+import { AiOutlineCamera } from "react-icons/ai"
+
+const CameraSelectionPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
+    const [cameraControlType, setCameraControlType] = useState<CameraControlsType>(World.SceneRenderer.currentCameraControls.controlsType)
+
+    useEffect(() => {
+        if (World.SceneRenderer.currentCameraControls.controlsType != cameraControlType) {
+            World.SceneRenderer.SetCameraControls(cameraControlType)
+        }
+    }, [cameraControlType])
+
+    return (
+        <Panel
+            openLocation="bottom-right"
+            name={"Choose a Camera"}
+            icon={<AiOutlineCamera />}
+            panelId={panelId}
+            acceptEnabled={false}
+            cancelName="Close"
+        >
+            <ToggleButtonGroup
+                orientation="vertical"
+                value={cameraControlType}
+                exclusive
+                onChange={(_, v) => v != null && setCameraControlType(v as CameraControlsType)}
+            >
+                <ToggleButton value={CameraControlsType.OrbitFocus}>Orbit Focus</ToggleButton>
+                <ToggleButton value={CameraControlsType.OrbitFree}>Orbit Free</ToggleButton>
+            </ToggleButtonGroup>
+        </Panel>
+    )
+}
+
+export default CameraSelectionPanel

--- a/fission/src/ui/panels/configuring/CameraSelectionPanel.tsx
+++ b/fission/src/ui/panels/configuring/CameraSelectionPanel.tsx
@@ -30,6 +30,7 @@ const CameraSelectionPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
                 onChange={(_, v) => v != null && setCameraControlType(v as CameraControlsType)}
             >
                 <ToggleButton value={CameraControlsType.OrbitFocus}>Orbit Focus</ToggleButton>
+                <ToggleButton value={CameraControlsType.OrbitLocked}>Orbit Locked</ToggleButton>
                 <ToggleButton value={CameraControlsType.OrbitFree}>Orbit Free</ToggleButton>
             </ToggleButtonGroup>
         </Panel>

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -9,7 +9,7 @@ const serverPort = 3000
 const dockerServerPort = 80
 
 const useLocal = false
-const useSsl = false
+const useSsl = true
 
 const plugins = [
     react(), glsl({

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -27,9 +27,9 @@ const plugins = [
     })
 ]
 
-if (useSsl) [
+if (useSsl) {
     plugins.push(basicSsl())
-]
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config'
 import * as path from 'path'
 import react from '@vitejs/plugin-react-swc'
+import basicSsl from '@vitejs/plugin-basic-ssl'
 import glsl from 'vite-plugin-glsl';
 
 const basePath = '/fission/'
@@ -8,22 +9,31 @@ const serverPort = 3000
 const dockerServerPort = 80
 
 const useLocal = false
+const useSsl = false
+
+const plugins = [
+    react(), glsl({
+        include: [                   // Glob pattern, or array of glob patterns to import
+          '**/*.glsl', '**/*.wgsl',
+          '**/*.vert', '**/*.frag',
+          '**/*.vs', '**/*.fs'
+        ],
+        exclude: undefined,          // Glob pattern, or array of glob patterns to ignore
+        warnDuplicatedImports: true, // Warn if the same chunk was imported multiple times
+        defaultExtension: 'glsl',    // Shader suffix when no extension is specified
+        compress: false,             // Compress output shader code
+        watch: true,                 // Recompile shader on change
+        root: '/'                    // Directory for root imports
+    })
+]
+
+if (useSsl) [
+    plugins.push(basicSsl())
+]
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [react(), /* viteSingleFile() */ glsl({
-    include: [                   // Glob pattern, or array of glob patterns to import
-      '**/*.glsl', '**/*.wgsl',
-      '**/*.vert', '**/*.frag',
-      '**/*.vs', '**/*.fs'
-    ],
-    exclude: undefined,          // Glob pattern, or array of glob patterns to ignore
-    warnDuplicatedImports: true, // Warn if the same chunk was imported multiple times
-    defaultExtension: 'glsl',    // Shader suffix when no extension is specified
-    compress: false,             // Compress output shader code
-    watch: true,                 // Recompile shader on change
-    root: '/'                    // Directory for root imports
-  }) ],
+    plugins: plugins,
     resolve: {
         alias: [
             { find: '@/components', replacement: path.resolve(__dirname, 'src', 'ui', 'components') },


### PR DESCRIPTION
### Description
The goal was to add a couple camera customization features. Unfortunately, it has turned into a complete recreation of the orbit camera. Currently there are 3 cameras to choose from:

- Orbit Focus: Follows the position of the robot around (v6 orbit camera)
- Orbit Locked: Follows the position of the robot around and matches it orientation as it moves (v4 orbit camera)
- Orbit Free: Original orbit camera with panning abilities

### Tasks
- [x] Create Focus Camera
- [x] Create Locked Camera
- [x] Add focus selection
- [x] Create these to be settings under the blanket of orbit camera, instead of separate camera modes
- [ ] Added camera settings to preferences
- [ ] Add usage notes under camera settings

### Questions
- What other types of camera controls should we add initially?
- Does the zooming scale feel alright?

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1760)
