### PR TITLE
APS Upload Pipeline Polish

### DIFF
--- a/exporter/SynthesisFusionAddin/src/APS/APS.py
+++ b/exporter/SynthesisFusionAddin/src/APS/APS.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import pathlib
 import pickle
@@ -12,6 +11,9 @@ from typing import Any
 import requests
 
 from ..general_imports import INTERNAL_ID, gm, my_addin_path
+from ..Logging import getLogger
+
+logger = getLogger()
 
 CLIENT_ID = "GCxaewcLjsYlK8ud7Ka9AKf9dPwMR3e4GlybyfhAK2zvl3tU"
 auth_path = os.path.abspath(os.path.join(my_addin_path, "..", ".aps_auth"))
@@ -70,7 +72,6 @@ def getAuth() -> APSAuth | None:
     if os.path.exists(auth_path):
         with open(auth_path, "rb") as f:
             p: APSAuth = pickle.load(f)
-            logging.getLogger(f"{INTERNAL_ID}").info(msg=f"{json.dumps(p.__dict__)}")
             APS_AUTH = p
     else:
         return None
@@ -143,7 +144,7 @@ def refreshAuthToken():
             f.close()
     except urllib.request.HTTPError as e:
         removeAuth()
-        logging.getLogger(f"{INTERNAL_ID}").error(f"Refresh Error:\n{e.code} - {e.reason}")
+        logger.error(f"Refresh Error:\n{e.code} - {e.reason}")
         gm.ui.messageBox("Please sign in again.")
 
 
@@ -175,7 +176,7 @@ def loadUserInfo() -> APSUserInfo | None:
         return APS_USER_INFO
     except urllib.request.HTTPError as e:
         removeAuth()
-        logging.getLogger(f"{INTERNAL_ID}").error(f"User Info Error:\n{e.code} - {e.reason}")
+        logger.error(f"User Info Error:\n{e.code} - {e.reason}")
         gm.ui.messageBox("Please sign in again.")
 
 

--- a/exporter/SynthesisFusionAddin/src/APS/APS.py
+++ b/exporter/SynthesisFusionAddin/src/APS/APS.py
@@ -65,20 +65,23 @@ def getAuth() -> APSAuth | None:
     global APS_AUTH
     if APS_AUTH is not None:
         return APS_AUTH
-    try:
-        curr_time = time.time()
+
+    currTime = time.time()
+    if os.path.exists(auth_path):
         with open(auth_path, "rb") as f:
             p: APSAuth = pickle.load(f)
             logging.getLogger(f"{INTERNAL_ID}").info(msg=f"{json.dumps(p.__dict__)}")
             APS_AUTH = p
-    except Exception as arg:
-        gm.ui.messageBox(f"ERROR:\n{arg}", "Please Sign In")
+    else:
         return None
-    curr_time = int(time.time() * 1000)
-    if curr_time >= APS_AUTH.expires_at:
+
+    currTime = int(time.time() * 1000)
+    if currTime >= APS_AUTH.expires_at:
         refreshAuthToken()
+
     if APS_USER_INFO is None:
         _ = loadUserInfo()
+
     return APS_AUTH
 
 

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Parser.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Parser.py
@@ -7,7 +7,7 @@ from google.protobuf.json_format import MessageToJson
 
 from proto.proto_out import assembly_pb2, types_pb2
 
-from ...APS.APS import upload_mirabuf  # This line causes everything to break
+from ...APS.APS import getAuth, upload_mirabuf
 from ...general_imports import *
 from ...Logging import getLogger, logFailure, timed
 from ...Types import ExportLocation, ExportMode
@@ -33,6 +33,10 @@ class Parser:
     def export(self) -> None:
         app = adsk.core.Application.get()
         design: adsk.fusion.Design = app.activeDocument.design
+
+        if not getAuth():
+            app.userInterface.messageBox("APS Login Required for Uploading.", "APS Login")
+            return
 
         assembly_out = assembly_pb2.Assembly()
         fill_info(
@@ -178,9 +182,9 @@ class Parser:
             folder_id = project.rootFolder.id
             file_name = f"{self.exporterOptions.fileLocation}.mira"
             if upload_mirabuf(project_id, folder_id, file_name, assembly_out.SerializeToString()) is None:
-                gm.ui.messageBox("FAILED TO UPLOAD FILE TO APS", "ERROR")  # add throw later
-        # Download Mirabuf File
+                raise RuntimeError("Could not upload to APS")
         else:
+            assert self.exporterOptions.exportLocation == ExportLocation.DOWNLOAD
             # check if entire path exists and create if not since gzip doesn't do that.
             path = pathlib.Path(self.exporterOptions.fileLocation).parent
             path.mkdir(parents=True, exist_ok=True)

--- a/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
+++ b/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
@@ -556,7 +556,6 @@ class ConfigureCommandCreatedHandler(adsk.core.CommandCreatedEventHandler):
             "aps_settings", f"APS Settings ({user_info.given_name if user_info else 'Not Signed In'})"
         )
         apsSettings.tooltip = "Configuration settings for Autodesk Platform Services."
-        aps_input = apsSettings.children
 
         # clear all selections before instantiating handlers.
         gm.ui.activeSelections.clear()


### PR DESCRIPTION
- Now no longer throws a message box error if the user is not signed in.
  - This would previously prevent the event handlers from being added properly and would cause some undefined behaviour.
- Will now prompt for login on export with upload and missing APS login data instead of throwing an error message.
  - Previously would parse the whole robot before telling you that your destination was invalid.
- Removed the log that was logging the user auth token.
- Now calling the logging module from #1010.

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1774)
