### PR TITLE
Analytics

### DIFF
--- a/fission/index.html
+++ b/fission/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6XNCRD7QNC"></script>
     <link rel="icon" type="image/svg+xml" href="/synthesis-logo.svg" />
     <link rel='stylesheet' href='https://static-dc.autodesk.net/etc/designs/v201808022224/templates-general/structure/fonts/artifakt/clientlibs/artifakt.css'/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" />

--- a/fission/package.json
+++ b/fission/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@barclah/jolt-physics": "^0.24.1",
+    "@haensl/google-analytics": "^1.2.0",
     "@mui/base": "^5.0.0-beta.40",
     "@mui/icons-material": "^5.15.20",
     "@mui/system": "^5.15.20",

--- a/fission/src/GA.d.ts
+++ b/fission/src/GA.d.ts
@@ -1,0 +1,10 @@
+declare module "@haensl/google-analytics" {
+
+    type GaEvent = { name: string, params: { [key: string]: (string | number) } }
+    type GaException = { description: string, fatal: boolean }
+
+    function init(params: { [key: string]: unknown }): void
+    function consent(granted: boolean): void
+    function event(e: GaEvent)
+    function exception(e: GaException)
+}

--- a/fission/src/GA.d.ts
+++ b/fission/src/GA.d.ts
@@ -6,4 +6,6 @@ declare module "@haensl/google-analytics" {
     function consent(granted: boolean): void
     function event(e: GaEvent)
     function exception(e: GaException)
+    function setUserId({ id: string })
+    function setUserProperty({ name: string, value: string })
 }

--- a/fission/src/GA.d.ts
+++ b/fission/src/GA.d.ts
@@ -1,7 +1,6 @@
 declare module "@haensl/google-analytics" {
-
-    type GaEvent = { name: string, params: { [key: string]: (string | number) } }
-    type GaException = { description: string, fatal: boolean }
+    type GaEvent = { name: string; params: { [key: string]: string | number } }
+    type GaException = { description: string; fatal: boolean }
 
     function init(params: { [key: string]: unknown }): void
     function consent(granted: boolean): void

--- a/fission/src/Synthesis.tsx
+++ b/fission/src/Synthesis.tsx
@@ -85,7 +85,7 @@ function Synthesis() {
     const { openPanel, closePanel, closeAllPanels, getActivePanelElements } = usePanelManager(initialPanels)
     const { showTooltip } = useTooltipManager()
 
-    const [ consentPopupDisable, setConsentPopupDisable ] = useState<boolean>(true)
+    const [consentPopupDisable, setConsentPopupDisable] = useState<boolean>(true)
 
     const { currentTheme, applyTheme, defaultTheme } = useTheme()
 
@@ -186,10 +186,11 @@ function Synthesis() {
                             <ProgressNotifications key={"progress-notifications"} />
                             <ToastContainer key={"toast-container"} />
 
-                            { !consentPopupDisable 
-                                ? <AnalyticsConsent onClose={onDisableConsent} onConsent={onConsent} /> 
-                                : <></>
-                            }
+                            {!consentPopupDisable ? (
+                                <AnalyticsConsent onClose={onDisableConsent} onConsent={onConsent} />
+                            ) : (
+                                <></>
+                            )}
                         </ToastProvider>
                     </PanelControlProvider>
                 </ModalControlProvider>

--- a/fission/src/Synthesis.tsx
+++ b/fission/src/Synthesis.tsx
@@ -1,6 +1,6 @@
 import Scene from "@/components/Scene.tsx"
 import { AnimatePresence } from "framer-motion"
-import { ReactElement, useEffect } from "react"
+import { ReactElement, useCallback, useEffect, useState } from "react"
 import { ModalControlProvider, useModalManager } from "@/ui/ModalContext"
 import { PanelControlProvider, usePanelManager } from "@/ui/PanelContext"
 import { useTheme } from "@/ui/ThemeContext"
@@ -65,6 +65,7 @@ import RCConfigCANGroupModal from "@/modals/configuring/rio-config/RCConfigCANGr
 import DebugPanel from "./ui/panels/DebugPanel.tsx"
 import NewInputSchemeModal from "./ui/modals/configuring/theme-editor/NewInputSchemeModal.tsx"
 import AssignNewSchemeModal from "./ui/modals/configuring/theme-editor/AssignNewSchemeModal.tsx"
+import AnalyticsConsent from "./ui/components/AnalyticsConsent.tsx"
 import PreferencesSystem from "./systems/preferences/PreferencesSystem.ts"
 
 const worker = new Lazy<Worker>(() => new WPILibWSWorker())
@@ -84,6 +85,8 @@ function Synthesis() {
     const { openPanel, closePanel, closeAllPanels, getActivePanelElements } = usePanelManager(initialPanels)
     const { showTooltip } = useTooltipManager()
 
+    const [ consentPopupDisable, setConsentPopupDisable ] = useState<boolean>(true)
+
     const { currentTheme, applyTheme, defaultTheme } = useTheme()
 
     useEffect(() => {
@@ -97,6 +100,10 @@ function Synthesis() {
         if (has_code) return
 
         World.InitWorld()
+
+        if (!PreferencesSystem.getGlobalPreference<boolean>("ReportAnalytics")) {
+            setConsentPopupDisable(false)
+        }
 
         worker.getValue()
 
@@ -130,6 +137,16 @@ function Synthesis() {
             openPanel("scoreboard")
         }
     })
+    
+    const onConsent = useCallback(() => {
+        setConsentPopupDisable(true)
+        PreferencesSystem.setGlobalPreference<boolean>("ReportAnalytics", true)
+        PreferencesSystem.savePreferences()
+    }, [])
+
+    const onDisableConsent = useCallback(() => {
+        setConsentPopupDisable(true)
+    }, [])
 
     return (
         <AnimatePresence key={"animate-presence"}>
@@ -168,6 +185,11 @@ function Synthesis() {
                             )}
                             <ProgressNotifications key={"progress-notifications"} />
                             <ToastContainer key={"toast-container"} />
+
+                            { !consentPopupDisable 
+                                ? <AnalyticsConsent onClose={onDisableConsent} onConsent={onConsent} /> 
+                                : <></>
+                            }
                         </ToastProvider>
                     </PanelControlProvider>
                 </ModalControlProvider>

--- a/fission/src/Synthesis.tsx
+++ b/fission/src/Synthesis.tsx
@@ -137,7 +137,7 @@ function Synthesis() {
             openPanel("scoreboard")
         }
     })
-    
+
     const onConsent = useCallback(() => {
         setConsentPopupDisable(true)
         PreferencesSystem.setGlobalPreference<boolean>("ReportAnalytics", true)

--- a/fission/src/aps/APS.ts
+++ b/fission/src/aps/APS.ts
@@ -263,7 +263,9 @@ class APS {
             : `https://synthesis.autodesk.com${import.meta.env.BASE_URL}`
 
         try {
-            const res = await fetch(`${ENDPOINT_SYNTHESIS_CODE}?code=${code}&redirect_uri=${encodeURIComponent(callbackUrl)}`)
+            const res = await fetch(
+                `${ENDPOINT_SYNTHESIS_CODE}?code=${code}&redirect_uri=${encodeURIComponent(callbackUrl)}`
+            )
             const json = await res.json()
             if (!res.ok) {
                 World.AnalyticsSystem?.Exception("APS Login Failure")

--- a/fission/src/aps/APS.ts
+++ b/fission/src/aps/APS.ts
@@ -37,9 +37,15 @@ class APS {
     static requestMutex: Mutex = new Mutex()
 
     private static _numApsCalls = new Map<string, number>()
-    public static get numApsCalls() { return this._numApsCalls }
-    public static incApsCalls(endpoint: string) { this._numApsCalls.set(endpoint, (this._numApsCalls.get(endpoint) ?? 0) + 1) }
-    public static resetNumApsCalls() { this._numApsCalls.clear() }
+    public static get numApsCalls() {
+        return this._numApsCalls
+    }
+    public static incApsCalls(endpoint: string) {
+        this._numApsCalls.set(endpoint, (this._numApsCalls.get(endpoint) ?? 0) + 1)
+    }
+    public static resetNumApsCalls() {
+        this._numApsCalls.clear()
+    }
 
     private static get auth(): APSAuth | undefined {
         const res = window.localStorage.getItem(APS_AUTH_KEY)
@@ -331,6 +337,10 @@ class APS {
                 givenName: json.given_name,
                 picture: json.picture,
                 email: json.email,
+            }
+
+            if (json.sub) {
+                World.AnalyticsSystem?.SetUserId(json.sub as string)
             }
 
             this.userInfo = info

--- a/fission/src/aps/APS.ts
+++ b/fission/src/aps/APS.ts
@@ -50,7 +50,7 @@ class APS {
         window.localStorage.removeItem(APS_AUTH_KEY)
         if (a) {
             window.localStorage.setItem(APS_AUTH_KEY, JSON.stringify(a))
-            World.AnalyticsSystem.Event('APS Login')
+            World.AnalyticsSystem?.Event("APS Login")
         }
         this.userInfo = undefined
     }
@@ -193,7 +193,7 @@ class APS {
                 window.open(url, "_self")
             } catch (e) {
                 console.error(e)
-                World.AnalyticsSystem.Exception("APS Login Failure")
+                World.AnalyticsSystem?.Exception("APS Login Failure")
                 MainHUD_AddToast("error", "Error signing in.", "Please try again.")
             }
         })
@@ -242,7 +242,7 @@ class APS {
                 }
                 return true
             } catch (e) {
-                World.AnalyticsSystem.Exception("APS Login Failure")
+                World.AnalyticsSystem?.Exception("APS Login Failure")
                 MainHUD_AddToast("error", "Error signing in.", "Please try again.")
                 this.auth = undefined
                 await this.requestAuthCode()
@@ -261,7 +261,7 @@ class APS {
             const res = await fetch(`${ENDPOINT_SYNTHESIS_CODE}?code=${code}`)
             const json = await res.json()
             if (!res.ok) {
-                World.AnalyticsSystem.Exception("APS Login Failure")
+                World.AnalyticsSystem?.Exception("APS Login Failure")
                 MainHUD_AddToast("error", "Error signing in.", json.userMessage)
                 this.auth = undefined
                 return
@@ -286,7 +286,7 @@ class APS {
         }
         if (retry_login) {
             this.auth = undefined
-            World.AnalyticsSystem.Exception("APS Login Failure")
+            World.AnalyticsSystem?.Exception("APS Login Failure")
             MainHUD_AddToast("error", "Error signing in.", "Please try again.")
         }
     }
@@ -306,7 +306,7 @@ class APS {
             })
             const json = await res.json()
             if (!res.ok) {
-                World.AnalyticsSystem.Exception("APS Failure: User Info")
+                World.AnalyticsSystem?.Exception("APS Failure: User Info")
                 MainHUD_AddToast("error", "Error fetching user data.", json.userMessage)
                 this.auth = undefined
                 await this.requestAuthCode()
@@ -322,7 +322,7 @@ class APS {
             this.userInfo = info
         } catch (e) {
             console.error(e)
-            World.AnalyticsSystem.Exception("APS Login Failure: User Info")
+            World.AnalyticsSystem?.Exception("APS Login Failure: User Info")
             MainHUD_AddToast("error", "Error signing in.", "Please try again.")
             this.auth = undefined
         }
@@ -338,7 +338,7 @@ class APS {
             return json["challenge"]
         } catch (e) {
             console.error(e)
-            World.AnalyticsSystem.Exception("APS Login Failure: Code Challenge")
+            World.AnalyticsSystem?.Exception("APS Login Failure: Code Challenge")
             MainHUD_AddToast("error", "Error signing in.", "Please try again.")
         }
     }

--- a/fission/src/aps/APS.ts
+++ b/fission/src/aps/APS.ts
@@ -257,8 +257,13 @@ class APS {
      */
     static async convertAuthToken(code: string) {
         let retry_login = false
+
+        const callbackUrl = import.meta.env.DEV
+            ? `http://localhost:3000${import.meta.env.BASE_URL}`
+            : `https://synthesis.autodesk.com${import.meta.env.BASE_URL}`
+
         try {
-            const res = await fetch(`${ENDPOINT_SYNTHESIS_CODE}?code=${code}`)
+            const res = await fetch(`${ENDPOINT_SYNTHESIS_CODE}?code=${code}&redirect_uri=${encodeURIComponent(callbackUrl)}`)
             const json = await res.json()
             if (!res.ok) {
                 World.AnalyticsSystem?.Exception("APS Login Failure")

--- a/fission/src/aps/APS.ts
+++ b/fission/src/aps/APS.ts
@@ -36,6 +36,11 @@ class APS {
     static authCode: string | undefined = undefined
     static requestMutex: Mutex = new Mutex()
 
+    private static _numApsCalls = new Map<string, number>()
+    public static get numApsCalls() { return this._numApsCalls }
+    public static incApsCalls(endpoint: string) { this._numApsCalls.set(endpoint, (this._numApsCalls.get(endpoint) ?? 0) + 1) }
+    public static resetNumApsCalls() { this._numApsCalls.clear() }
+
     private static get auth(): APSAuth | undefined {
         const res = window.localStorage.getItem(APS_AUTH_KEY)
         try {
@@ -209,6 +214,7 @@ class APS {
     static async refreshAuthToken(refresh_token: string, shouldRelog: boolean): Promise<boolean> {
         return this.requestMutex.runExclusive(async () => {
             try {
+                APS.incApsCalls("authentication-v2-token")
                 const res = await fetch(ENDPOINT_AUTODESK_AUTHENTICATION_TOKEN, {
                     method: "POST",
                     headers: {
@@ -305,6 +311,7 @@ class APS {
     static async loadUserInfo(auth: APSAuth) {
         console.log("Loading user information")
         try {
+            APS.incApsCalls("userinfo")
             const res = await fetch(ENDPOINT_AUTODESK_USERINFO, {
                 method: "GET",
                 headers: {

--- a/fission/src/aps/APS.ts
+++ b/fission/src/aps/APS.ts
@@ -1,3 +1,4 @@
+import World from "@/systems/World"
 import { MainHUD_AddToast } from "@/ui/components/MainHUD"
 import { Mutex } from "async-mutex"
 
@@ -49,6 +50,7 @@ class APS {
         window.localStorage.removeItem(APS_AUTH_KEY)
         if (a) {
             window.localStorage.setItem(APS_AUTH_KEY, JSON.stringify(a))
+            World.AnalyticsSystem.Event('APS Login')
         }
         this.userInfo = undefined
     }
@@ -191,6 +193,7 @@ class APS {
                 window.open(url, "_self")
             } catch (e) {
                 console.error(e)
+                World.AnalyticsSystem.Exception("APS Login Failure")
                 MainHUD_AddToast("error", "Error signing in.", "Please try again.")
             }
         })
@@ -239,6 +242,7 @@ class APS {
                 }
                 return true
             } catch (e) {
+                World.AnalyticsSystem.Exception("APS Login Failure")
                 MainHUD_AddToast("error", "Error signing in.", "Please try again.")
                 this.auth = undefined
                 await this.requestAuthCode()
@@ -257,6 +261,7 @@ class APS {
             const res = await fetch(`${ENDPOINT_SYNTHESIS_CODE}?code=${code}`)
             const json = await res.json()
             if (!res.ok) {
+                World.AnalyticsSystem.Exception("APS Login Failure")
                 MainHUD_AddToast("error", "Error signing in.", json.userMessage)
                 this.auth = undefined
                 return
@@ -281,6 +286,7 @@ class APS {
         }
         if (retry_login) {
             this.auth = undefined
+            World.AnalyticsSystem.Exception("APS Login Failure")
             MainHUD_AddToast("error", "Error signing in.", "Please try again.")
         }
     }
@@ -300,6 +306,7 @@ class APS {
             })
             const json = await res.json()
             if (!res.ok) {
+                World.AnalyticsSystem.Exception("APS Failure: User Info")
                 MainHUD_AddToast("error", "Error fetching user data.", json.userMessage)
                 this.auth = undefined
                 await this.requestAuthCode()
@@ -315,6 +322,7 @@ class APS {
             this.userInfo = info
         } catch (e) {
             console.error(e)
+            World.AnalyticsSystem.Exception("APS Login Failure: User Info")
             MainHUD_AddToast("error", "Error signing in.", "Please try again.")
             this.auth = undefined
         }
@@ -330,6 +338,7 @@ class APS {
             return json["challenge"]
         } catch (e) {
             console.error(e)
+            World.AnalyticsSystem.Exception("APS Login Failure: Code Challenge")
             MainHUD_AddToast("error", "Error signing in.", "Please try again.")
         }
     }

--- a/fission/src/aps/APSDataManagement.ts
+++ b/fission/src/aps/APSDataManagement.ts
@@ -117,6 +117,7 @@ export async function getHubs(): Promise<Hub[] | undefined> {
     }
 
     try {
+        APS.incApsCalls("project-v1-hubs")
         return await fetch("https://developer.api.autodesk.com/project/v1/hubs", {
             method: "GET",
             headers: {
@@ -154,6 +155,7 @@ export async function getProjects(hub: Hub): Promise<Project[] | undefined> {
     }
 
     try {
+        APS.incApsCalls("project-v1-hubs-x-projects")
         return await fetch(`https://developer.api.autodesk.com/project/v1/hubs/${hub.id}/projects/`, {
             method: "GET",
             headers: {
@@ -190,6 +192,7 @@ export async function getFolderData(project: Project, folder: Folder): Promise<D
     }
 
     try {
+        APS.incApsCalls("data-v1-projects-x-folders-x-contents")
         return await fetch(
             `https://developer.api.autodesk.com/data/v1/projects/${project.id}/folders/${folder.id}/contents`,
             {
@@ -239,6 +242,7 @@ export async function searchFolder(project: Project, folder: Folder, filters?: F
         endpoint += `?${filterToQuery(filters)}`
     }
 
+    APS.incApsCalls("data-v1-projects-x-folders-x-search")
     const res = await fetch(endpoint, {
         method: "GET",
         headers: {
@@ -267,6 +271,7 @@ export async function downloadData(data: Data): Promise<ArrayBuffer | undefined>
         return undefined
     }
 
+    APS.incApsCalls("object_bucket")
     return await fetch(data.href, {
         method: "GET",
         headers: {

--- a/fission/src/index.css
+++ b/fission/src/index.css
@@ -20,11 +20,11 @@
 
 a {
     font-weight: 500;
-    color: #646cff;
-    text-decoration: inherit;
+    color: #eb8042;
+    text-decoration: underline;
 }
 a:hover {
-    color: #535bf2;
+    color: #c26c37;
 }
 
 body {

--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -91,7 +91,7 @@ class MirabufCachingService {
             .then(x => x.arrayBuffer())
         World.AnalyticsSystem?.Event("Remote Download", {
             type: miraType == MiraType.ROBOT ? "robot" : "field",
-            fileSize: miraBuff.byteLength
+            fileSize: miraBuff.byteLength,
         })
         return await MirabufCachingService.StoreInCache(fetchLocation, miraBuff, miraType)
     }
@@ -117,7 +117,7 @@ class MirabufCachingService {
 
         World.AnalyticsSystem?.Event("APS Download", {
             type: miraType == MiraType.ROBOT ? "robot" : "field",
-            fileSize: miraBuff.byteLength
+            fileSize: miraBuff.byteLength,
         })
 
         return await MirabufCachingService.StoreInCache(data.id, miraBuff, miraType)
@@ -228,7 +228,7 @@ class MirabufCachingService {
                     key: id,
                     type: miraType == MiraType.ROBOT ? "robot" : "field",
                     assemblyName: assembly.info!.name!,
-                    fileSize: buff.byteLength
+                    fileSize: buff.byteLength,
                 })
                 return assembly
             } else {

--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -93,7 +93,6 @@ class MirabufCachingService {
             type: miraType == MiraType.ROBOT ? "robot" : "field",
             fileSize: miraBuff.byteLength,
         })
-        console.debug("wut")
         return await MirabufCachingService.StoreInCache(fetchLocation, miraBuff, miraType)
     }
 

--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -249,11 +249,14 @@ class MirabufCachingService {
             const dir = miraType == MiraType.ROBOT ? robotFolderHandle : fieldFolderHandle
             await dir.removeEntry(id)
 
-            World.AnalyticsSystem.Event("Removed mirabuf from cache", { key: key, type: miraType == MiraType.ROBOT ? "robot" : "field" })
+            World.AnalyticsSystem?.Event("Removed mirabuf from cache", {
+                key: key,
+                type: miraType == MiraType.ROBOT ? "robot" : "field",
+            })
             return true
         } catch (e) {
             console.error(`Failed to remove\n${e}`)
-            World.AnalyticsSystem.Exception("Failed to remove mirabuf from cache")
+            World.AnalyticsSystem?.Exception("Failed to remove mirabuf from cache")
             return false
         }
     }
@@ -307,11 +310,15 @@ class MirabufCachingService {
             map[key] = info
             window.localStorage.setItem(miraType == MiraType.ROBOT ? robotsDirName : fieldsDirName, JSON.stringify(map))
 
-            World.AnalyticsSystem.Event("Cache Load", { name: name ?? '-', key: key, type: miraType == MiraType.ROBOT ? "robot" : "field" })
+            World.AnalyticsSystem?.Event("Cache Load", {
+                name: name ?? "-",
+                key: key,
+                type: miraType == MiraType.ROBOT ? "robot" : "field",
+            })
             return info
         } catch (e) {
             console.error("Failed to cache mira " + e)
-            World.AnalyticsSystem.Exception("Failed to store in cache")
+            World.AnalyticsSystem?.Exception("Failed to store in cache")
             return undefined
         }
     }

--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -93,6 +93,7 @@ class MirabufCachingService {
             type: miraType == MiraType.ROBOT ? "robot" : "field",
             fileSize: miraBuff.byteLength,
         })
+        console.debug("wut")
         return await MirabufCachingService.StoreInCache(fetchLocation, miraBuff, miraType)
     }
 
@@ -329,6 +330,7 @@ class MirabufCachingService {
                 name: name ?? "-",
                 key: key,
                 type: miraType == MiraType.ROBOT ? "robot" : "field",
+                fileSize: miraBuff.byteLength,
             })
             return info
         } catch (e) {

--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -89,6 +89,10 @@ class MirabufCachingService {
         const miraBuff = await fetch(encodeURI(fetchLocation), import.meta.env.DEV ? { cache: "no-store" } : undefined)
             .then(x => x.blob())
             .then(x => x.arrayBuffer())
+        World.AnalyticsSystem?.Event("Remote Download", {
+            type: miraType == MiraType.ROBOT ? "robot" : "field",
+            fileSize: miraBuff.byteLength
+        })
         return await MirabufCachingService.StoreInCache(fetchLocation, miraBuff, miraType)
     }
 
@@ -110,6 +114,11 @@ class MirabufCachingService {
             console.error("Failed to download file")
             return undefined
         }
+
+        World.AnalyticsSystem?.Event("APS Download", {
+            type: miraType == MiraType.ROBOT ? "robot" : "field",
+            fileSize: miraBuff.byteLength
+        })
 
         return await MirabufCachingService.StoreInCache(data.id, miraBuff, miraType)
     }
@@ -215,6 +224,12 @@ class MirabufCachingService {
             if (fileHandle) {
                 const buff = await fileHandle.getFile().then(x => x.arrayBuffer())
                 const assembly = this.AssemblyFromBuffer(buff)
+                World.AnalyticsSystem?.Event("Cache Get", {
+                    key: id,
+                    type: miraType == MiraType.ROBOT ? "robot" : "field",
+                    assemblyName: assembly.info!.name!,
+                    fileSize: buff.byteLength
+                })
                 return assembly
             } else {
                 console.error(`Failed to get file handle for ID: ${id}`)
@@ -249,7 +264,7 @@ class MirabufCachingService {
             const dir = miraType == MiraType.ROBOT ? robotFolderHandle : fieldFolderHandle
             await dir.removeEntry(id)
 
-            World.AnalyticsSystem?.Event("Removed mirabuf from cache", {
+            World.AnalyticsSystem?.Event("Cache Remove", {
                 key: key,
                 type: miraType == MiraType.ROBOT ? "robot" : "field",
             })
@@ -310,7 +325,7 @@ class MirabufCachingService {
             map[key] = info
             window.localStorage.setItem(miraType == MiraType.ROBOT ? robotsDirName : fieldsDirName, JSON.stringify(map))
 
-            World.AnalyticsSystem?.Event("Cache Load", {
+            World.AnalyticsSystem?.Event("Cache Store", {
                 name: name ?? "-",
                 key: key,
                 type: miraType == MiraType.ROBOT ? "robot" : "field",

--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -1,5 +1,6 @@
 import { Data, downloadData } from "@/aps/APSDataManagement"
 import { mirabuf } from "@/proto/mirabuf"
+import World from "@/systems/World"
 import Pako from "pako"
 
 const MIRABUF_LOCALSTORAGE_GENERATION_KEY = "Synthesis Nonce Key"
@@ -248,9 +249,11 @@ class MirabufCachingService {
             const dir = miraType == MiraType.ROBOT ? robotFolderHandle : fieldFolderHandle
             await dir.removeEntry(id)
 
+            World.AnalyticsSystem.Event("Removed mirabuf from cache", { key: key, type: miraType == MiraType.ROBOT ? "robot" : "field" })
             return true
         } catch (e) {
             console.error(`Failed to remove\n${e}`)
+            World.AnalyticsSystem.Exception("Failed to remove mirabuf from cache")
             return false
         }
     }
@@ -304,9 +307,11 @@ class MirabufCachingService {
             map[key] = info
             window.localStorage.setItem(miraType == MiraType.ROBOT ? robotsDirName : fieldsDirName, JSON.stringify(map))
 
+            World.AnalyticsSystem.Event("Cache Load", { name: name ?? '-', key: key, type: miraType == MiraType.ROBOT ? "robot" : "field" })
             return info
         } catch (e) {
             console.error("Failed to cache mira " + e)
+            World.AnalyticsSystem.Exception("Failed to store in cache")
             return undefined
         }
     }

--- a/fission/src/systems/World.ts
+++ b/fission/src/systems/World.ts
@@ -22,7 +22,7 @@ class World {
         physicsTime: 0,
         simulationTime: 0,
         inputTime: 0,
-        totalTime: 0
+        totalTime: 0,
     }
 
     public static get accumTimes() {
@@ -56,7 +56,7 @@ class World {
             physicsTime: 0,
             simulationTime: 0,
             inputTime: 0,
-            totalTime: 0
+            totalTime: 0,
         }
     }
 
@@ -86,7 +86,7 @@ class World {
         World._sceneRenderer.Destroy()
         World._simulationSystem.Destroy()
         World._inputSystem.Destroy()
-        
+
         World._analyticsSystem?.Destroy()
     }
 

--- a/fission/src/systems/World.ts
+++ b/fission/src/systems/World.ts
@@ -14,7 +14,7 @@ class World {
     private static _physicsSystem: PhysicsSystem
     private static _simulationSystem: SimulationSystem
     private static _inputSystem: InputSystem
-    private static _analyticsSystem: AnalyticsSystem
+    private static _analyticsSystem: AnalyticsSystem | undefined
 
     public static get isAlive() {
         return World._isAlive
@@ -46,7 +46,11 @@ class World {
         World._physicsSystem = new PhysicsSystem()
         World._simulationSystem = new SimulationSystem()
         World._inputSystem = new InputSystem()
-        World._analyticsSystem = new AnalyticsSystem()
+        try {
+            World._analyticsSystem = new AnalyticsSystem()
+        } catch (_) {
+            World._analyticsSystem = undefined
+        }
     }
 
     public static DestroyWorld() {
@@ -58,7 +62,7 @@ class World {
         World._sceneRenderer.Destroy()
         World._simulationSystem.Destroy()
         World._inputSystem.Destroy()
-        World._analyticsSystem.Destroy()
+        World._analyticsSystem?.Destroy()
     }
 
     public static UpdateWorld() {
@@ -67,7 +71,7 @@ class World {
         World._physicsSystem.Update(deltaT)
         World._inputSystem.Update(deltaT)
         World._sceneRenderer.Update(deltaT)
-        World._analyticsSystem.Update(deltaT)
+        World._analyticsSystem?.Update(deltaT)
     }
 }
 

--- a/fission/src/systems/World.ts
+++ b/fission/src/systems/World.ts
@@ -4,6 +4,7 @@ import PhysicsSystem from "./physics/PhysicsSystem"
 import SceneRenderer from "./scene/SceneRenderer"
 import SimulationSystem from "./simulation/SimulationSystem"
 import InputSystem from "./input/InputSystem"
+import AnalyticsSystem from "./analytics/AnalyticsSystem"
 
 class World {
     private static _isAlive: boolean = false
@@ -13,6 +14,7 @@ class World {
     private static _physicsSystem: PhysicsSystem
     private static _simulationSystem: SimulationSystem
     private static _inputSystem: InputSystem
+    private static _analyticsSystem: AnalyticsSystem
 
     public static get isAlive() {
         return World._isAlive
@@ -30,6 +32,9 @@ class World {
     public static get InputSystem() {
         return World._inputSystem
     }
+    public static get AnalyticsSystem() {
+        return World._analyticsSystem
+    }
 
     public static InitWorld() {
         if (World._isAlive) return
@@ -41,6 +46,7 @@ class World {
         World._physicsSystem = new PhysicsSystem()
         World._simulationSystem = new SimulationSystem()
         World._inputSystem = new InputSystem()
+        World._analyticsSystem = new AnalyticsSystem()
     }
 
     public static DestroyWorld() {
@@ -52,6 +58,7 @@ class World {
         World._sceneRenderer.Destroy()
         World._simulationSystem.Destroy()
         World._inputSystem.Destroy()
+        World._analyticsSystem.Destroy()
     }
 
     public static UpdateWorld() {
@@ -60,6 +67,7 @@ class World {
         World._physicsSystem.Update(deltaT)
         World._inputSystem.Update(deltaT)
         World._sceneRenderer.Update(deltaT)
+        World._analyticsSystem.Update(deltaT)
     }
 }
 

--- a/fission/src/systems/World.ts
+++ b/fission/src/systems/World.ts
@@ -4,7 +4,7 @@ import PhysicsSystem from "./physics/PhysicsSystem"
 import SceneRenderer from "./scene/SceneRenderer"
 import SimulationSystem from "./simulation/SimulationSystem"
 import InputSystem from "./input/InputSystem"
-import AnalyticsSystem from "./analytics/AnalyticsSystem"
+import AnalyticsSystem, { AccumTimes } from "./analytics/AnalyticsSystem"
 
 class World {
     private static _isAlive: boolean = false
@@ -15,6 +15,19 @@ class World {
     private static _simulationSystem: SimulationSystem
     private static _inputSystem: InputSystem
     private static _analyticsSystem: AnalyticsSystem | undefined
+
+    private static _accumTimes: AccumTimes = {
+        frames: 0,
+        sceneTime: 0,
+        physicsTime: 0,
+        simulationTime: 0,
+        inputTime: 0,
+        totalTime: 0
+    }
+
+    public static get accumTimes() {
+        return World._accumTimes
+    }
 
     public static get isAlive() {
         return World._isAlive
@@ -34,6 +47,17 @@ class World {
     }
     public static get AnalyticsSystem() {
         return World._analyticsSystem
+    }
+
+    public static resetAccumTimes() {
+        this._accumTimes = {
+            frames: 0,
+            sceneTime: 0,
+            physicsTime: 0,
+            simulationTime: 0,
+            inputTime: 0,
+            totalTime: 0
+        }
     }
 
     public static InitWorld() {
@@ -62,16 +86,29 @@ class World {
         World._sceneRenderer.Destroy()
         World._simulationSystem.Destroy()
         World._inputSystem.Destroy()
+        
         World._analyticsSystem?.Destroy()
     }
 
     public static UpdateWorld() {
         const deltaT = World._clock.getDelta()
-        World._simulationSystem.Update(deltaT)
-        World._physicsSystem.Update(deltaT)
-        World._inputSystem.Update(deltaT)
-        World._sceneRenderer.Update(deltaT)
+
+        this._accumTimes.frames++
+
+        this._accumTimes.totalTime += this.time(() => {
+            this._accumTimes.simulationTime += this.time(() => World._simulationSystem.Update(deltaT))
+            this._accumTimes.physicsTime += this.time(() => World._physicsSystem.Update(deltaT))
+            this._accumTimes.inputTime += this.time(() => World._inputSystem.Update(deltaT))
+            this._accumTimes.sceneTime += this.time(() => World._sceneRenderer.Update(deltaT))
+        })
+
         World._analyticsSystem?.Update(deltaT)
+    }
+
+    private static time(func: () => void): number {
+        const start = Date.now()
+        func()
+        return Date.now() - start
     }
 }
 

--- a/fission/src/systems/analytics/AnalyticsSystem.ts
+++ b/fission/src/systems/analytics/AnalyticsSystem.ts
@@ -1,10 +1,9 @@
-import { consent, event, exception, init } from '@haensl/google-analytics'
+import { consent, event, exception, init } from "@haensl/google-analytics"
 
-import WorldSystem from "../WorldSystem";
-import PreferencesSystem from '../preferences/PreferencesSystem';
+import WorldSystem from "../WorldSystem"
+import PreferencesSystem from "../preferences/PreferencesSystem"
 
 class AnalyticsSystem extends WorldSystem {
-
     public constructor() {
         super()
 
@@ -12,13 +11,15 @@ class AnalyticsSystem extends WorldSystem {
             measurementId: "G-6XNCRD7QNC",
             debug: import.meta.env.DEV,
             sendPageViews: true,
-            trackingConsent: PreferencesSystem.getGlobalPreference<boolean>("ReportAnalytics")
+            trackingConsent: PreferencesSystem.getGlobalPreference<boolean>("ReportAnalytics"),
         })
 
-        PreferencesSystem.addEventListener(e => (e.prefName == "ReportAnalytics") && this.ConsentUpdate(e.prefValue as boolean))
+        PreferencesSystem.addEventListener(
+            e => e.prefName == "ReportAnalytics" && this.ConsentUpdate(e.prefValue as boolean)
+        )
     }
 
-    public Event(name: string, params?: { [key: string]: (string | number) }) {
+    public Event(name: string, params?: { [key: string]: string | number }) {
         event({ name: name, params: params ?? {} })
     }
 
@@ -30,9 +31,8 @@ class AnalyticsSystem extends WorldSystem {
         consent(granted)
     }
 
-    public Update(_: number): void { }
-    public Destroy(): void { }
-
+    public Update(_: number): void {}
+    public Destroy(): void {}
 }
 
 export default AnalyticsSystem

--- a/fission/src/systems/analytics/AnalyticsSystem.ts
+++ b/fission/src/systems/analytics/AnalyticsSystem.ts
@@ -7,6 +7,7 @@ import APS from "@/aps/APS"
 
 const SAMPLE_INTERVAL = 60000 // 1 minute
 const BETA_CODE_COOKIE_REGEX = /access_code=.*(;|$)/
+const MOBILE_USER_AGENT_REGEX = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i
 
 export interface AccumTimes {
     frames: number
@@ -43,7 +44,7 @@ class AnalyticsSystem extends WorldSystem {
             console.debug("No code match")
         }
 
-        if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+        if (MOBILE_USER_AGENT_REGEX.test(navigator.userAgent)) {
             this.SetUserProperty("Is Mobile", "true")
         } else {
             this.SetUserProperty("Is Mobile", "false")

--- a/fission/src/systems/analytics/AnalyticsSystem.ts
+++ b/fission/src/systems/analytics/AnalyticsSystem.ts
@@ -2,8 +2,24 @@ import { consent, event, exception, init } from "@haensl/google-analytics"
 
 import WorldSystem from "../WorldSystem"
 import PreferencesSystem from "../preferences/PreferencesSystem"
+import World from "../World"
+import APS from "@/aps/APS"
+
+const SAMPLE_INTERVAL = 60000 // 1 minute
+
+export interface AccumTimes {
+    frames: number,
+    physicsTime: number,
+    sceneTime: number,
+    inputTime: number,
+    simulationTime: number,
+    totalTime: number
+}
 
 class AnalyticsSystem extends WorldSystem {
+    
+    private _lastSampleTime = Date.now()
+    
     public constructor() {
         super()
 
@@ -31,8 +47,47 @@ class AnalyticsSystem extends WorldSystem {
         consent(granted)
     }
 
-    public Update(_: number): void {}
-    public Destroy(): void {}
+    public Update(_: number): void {
+        if (Date.now() - this._lastSampleTime > SAMPLE_INTERVAL) {
+            const times = World.accumTimes
+            this.PushPerformanceSample(times)
+            World.resetAccumTimes()
+
+            const apsCalls = APS.numApsCalls
+            this.PushApsCounts(0.001 * (Date.now() - this._lastSampleTime), apsCalls)
+            APS.resetNumApsCalls()
+
+            this._lastSampleTime = Date.now()
+        }
+    }
+
+    public Destroy(): void {
+        const times = World.accumTimes
+        this.PushPerformanceSample(times)
+        const apsCalls = APS.numApsCalls
+        this.PushApsCounts(0.001 * (Date.now() - this._lastSampleTime), apsCalls)
+    }
+
+    private PushPerformanceSample(times: AccumTimes) {
+        if (times.frames > 0) {
+            this.Event("Performance Sample", {
+                frames: times.frames,
+                avgTotal: times.totalTime / times.frames,
+                avgPhysics: times.physicsTime / times.frames,
+                avgScene: times.sceneTime / times.frames,
+                avgInput: times.inputTime / times.frames,
+                avgSimulation: times.simulationTime / times.frames,
+            })
+        }
+    }
+
+    private PushApsCounts(interval: number, calls: Map<string, number>) {
+        if (interval > 0) {
+            const entries = Object.fromEntries([...calls.entries()].map(v => [v[0], v[1] / interval]))
+            entries.total = [...calls.values()].reduce((a, b) => a + b)
+            this.Event("APS Calls per Minute", entries)
+        }
+    }
 }
 
 export default AnalyticsSystem

--- a/fission/src/systems/analytics/AnalyticsSystem.ts
+++ b/fission/src/systems/analytics/AnalyticsSystem.ts
@@ -1,0 +1,38 @@
+import { consent, event, exception, init } from '@haensl/google-analytics'
+
+import WorldSystem from "../WorldSystem";
+import PreferencesSystem from '../preferences/PreferencesSystem';
+
+class AnalyticsSystem extends WorldSystem {
+
+    public constructor() {
+        super()
+
+        init({
+            measurementId: "G-6XNCRD7QNC",
+            debug: import.meta.env.DEV,
+            sendPageViews: true,
+            trackingConsent: PreferencesSystem.getGlobalPreference<boolean>("ReportAnalytics")
+        })
+
+        PreferencesSystem.addEventListener(e => (e.prefName == "ReportAnalytics") && this.ConsentUpdate(e.prefValue as boolean))
+    }
+
+    public Event(name: string, params?: { [key: string]: (string | number) }) {
+        event({ name: name, params: params ?? {} })
+    }
+
+    public Exception(description: string, fatal?: boolean) {
+        exception({ description: description, fatal: fatal ?? false })
+    }
+
+    private ConsentUpdate(granted: boolean) {
+        consent(granted)
+    }
+
+    public Update(_: number): void { }
+    public Destroy(): void { }
+
+}
+
+export default AnalyticsSystem

--- a/fission/src/ui/components/AnalyticsConsent.tsx
+++ b/fission/src/ui/components/AnalyticsConsent.tsx
@@ -1,0 +1,47 @@
+import { Box } from "@mui/material"
+import Label, { LabelSize } from "./Label"
+import Button from "./Button"
+import { colorNameToVar } from "../ThemeContext"
+import { AiOutlineClose } from "react-icons/ai"
+
+interface AnalyticsConsentProps {
+    onClose: () => void
+    onConsent: () => void
+}
+
+function AnalyticsConsent({ onConsent, onClose }: AnalyticsConsentProps) {
+    return (
+        <Box
+            component="div"
+            display="flex"
+            sx={{
+                flexDirection: "column",
+                maxWidth: "300pt",
+                position: "fixed",
+                right: "0.5rem",
+                bottom: "0.5rem",
+                backgroundColor: colorNameToVar("Background"),
+                padding: "1rem",
+                borderRadius: "0.5rem",
+                gap: "0.5rem"
+            }}
+        >
+            <Label size={LabelSize.Small}>Synthesis uses cookies to improve the performance and quality of our app. Do you consent to the usage of cookies for tracking analytics data?</Label>
+            <a target="_blank" rel="noopener noreferrer" href="https://synthesis.autodesk.com/data-collection/" className={`text-sm font-artifakt-normal`}>See here for more information</a>
+            <Box
+                component="div"
+                display="flex"
+                sx={{
+                    flexDirection: "row-reverse",
+                    gap: "0.5rem",
+                    justifyContent: "space-between"
+                }}
+            >
+                <Button value="I consent" onClick={() => onConsent()} />
+                <Button value={<AiOutlineClose />} onClick={() => onClose()} sizeOverrideClass="h-full" colorOverrideClass="bg-background-secondary" />
+            </Box>
+        </Box>
+    )
+}
+
+export default AnalyticsConsent

--- a/fission/src/ui/components/AnalyticsConsent.tsx
+++ b/fission/src/ui/components/AnalyticsConsent.tsx
@@ -23,22 +23,37 @@ function AnalyticsConsent({ onConsent, onClose }: AnalyticsConsentProps) {
                 backgroundColor: colorNameToVar("Background"),
                 padding: "1rem",
                 borderRadius: "0.5rem",
-                gap: "0.5rem"
+                gap: "0.5rem",
             }}
         >
-            <Label size={LabelSize.Small}>Synthesis uses cookies to improve the performance and quality of our app. Do you consent to the usage of cookies for tracking analytics data?</Label>
-            <a target="_blank" rel="noopener noreferrer" href="https://synthesis.autodesk.com/data-collection/" className={`text-sm font-artifakt-normal`}>See here for more information</a>
+            <Label size={LabelSize.Small}>
+                Synthesis uses cookies to improve the performance and quality of our app. Do you consent to the usage of
+                cookies for tracking analytics data?
+            </Label>
+            <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://synthesis.autodesk.com/data-collection/"
+                className={`text-sm font-artifakt-normal`}
+            >
+                See here for more information
+            </a>
             <Box
                 component="div"
                 display="flex"
                 sx={{
                     flexDirection: "row-reverse",
                     gap: "0.5rem",
-                    justifyContent: "space-between"
+                    justifyContent: "space-between",
                 }}
             >
                 <Button value="I consent" onClick={() => onConsent()} />
-                <Button value={<AiOutlineClose />} onClick={() => onClose()} sizeOverrideClass="h-full" colorOverrideClass="bg-background-secondary" />
+                <Button
+                    value={<AiOutlineClose />}
+                    onClick={() => onClose()}
+                    sizeOverrideClass="h-full"
+                    colorOverrideClass="bg-background-secondary"
+                />
             </Box>
         </Box>
     )


### PR DESCRIPTION
### Description
Created a system to interact with Google Analytics, and provide avenues for tracking custom events and exceptions. A pop up will display in the bottom-right corner asking for consent to use cookies. This will show every time the application loads if the user hasn't consented. I would say this is a tactic to encourage the user consenting to allowing the use of cookies, but I just don't want to track if they say no or not.

The google analytics NPM package I am using has built-in support for ensuring consent compliance within the EU.

### Testing
You can view analytic data using the Synthesis google account on the Google Analytics site (I will actually refuse to give you creds until you setup Keeper). Debug view is enabled only on development servers.

![image](https://github.com/user-attachments/assets/94be8853-5754-4c30-acaf-c5dd8d5d7eeb)

![image](https://github.com/user-attachments/assets/cbdedb72-030f-4d1e-ab93-613b3dd668c3)

### Current Analytic Data Points
Caching Data Points (file size information and Mirabuf assembly type):
- Remote Download
- APS Download
- Cache Store
- Cache Get

APS Data Points:
- Successful Login
- Successful Challenge Code
- Failed Login
- Failed Refresh
- \# of APS calls per minute (by endpoint)
- Associated User ID

Performance:
- Average Frame time (both total and broken up by System)

Beta:
- Associated Beta code with user

User:
- Associated user property for if they are on a mobile device or not

### Data Collection Information
I've added an information page about our data collection methods and reasonings to the website. This is like compliance x1000 so we should be in the clear to collect anything we need.
