### PR TITLE
No scheme with APS bots bug

### DIFF
--- a/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
+++ b/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
@@ -282,8 +282,10 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
                 .catch(() => status.Fail())
 
             closePanel(panelId)
+
+            if (type == MiraType.ROBOT) openPanel("choose-scheme")
         },
-        [closePanel, panelId]
+        [closePanel, panelId, openPanel]
     )
 
     // Generate Item cards for cached robots.


### PR DESCRIPTION
### Description
Fixed the bug where you would not be prompted to choose an input scheme when spawning a robot from APS.

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1778)
