### PR TITLE
APS Required Login Fix

### DIFF
--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Parser.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Parser.py
@@ -34,7 +34,7 @@ class Parser:
         app = adsk.core.Application.get()
         design: adsk.fusion.Design = app.activeDocument.design
 
-        if not getAuth():
+        if self.exporterOptions.exportLocation == ExportLocation.UPLOAD and not getAuth():
             app.userInterface.messageBox("APS Login Required for Uploading.", "APS Login")
             return
 


### PR DESCRIPTION
Fix an issue where APS login was always required, even if upload was not selected as the export location.