### PR TITLE
Real Case Usage Exporter Fixes

### DIFF
--- a/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
+++ b/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
@@ -127,7 +127,6 @@ class ConfigureCommandCreatedHandler(adsk.core.CommandCreatedEventHandler):
 
     def __init__(self, configure):
         super().__init__()
-        self.designAttrs = adsk.core.Application.get().activeProduct.attributes
 
     @logFailure(messageBox=True)
     def notify(self, args):
@@ -282,8 +281,9 @@ class ConfigureCommandCreatedHandler(adsk.core.CommandCreatedEventHandler):
         # Should consider changing how the parser handles wheels and joints to avoid overlap
         if exporterOptions.wheels:
             for wheel in exporterOptions.wheels:
-                fusionJoint = gm.app.activeDocument.design.findEntityByToken(wheel.jointToken)[0]
-                jointConfigTab.addWheel(fusionJoint, wheel)
+                fusionJoints = gm.app.activeDocument.design.findEntityByToken(wheel.jointToken)
+                if len(fusionJoints):
+                    jointConfigTab.addWheel(fusionJoints[0], wheel)
 
         # ~~~~~~~~~~~~~~~~ GAMEPIECE CONFIGURATION ~~~~~~~~~~~~~~~~
         """

--- a/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
+++ b/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
@@ -263,8 +263,9 @@ class ConfigureCommandCreatedHandler(adsk.core.CommandCreatedEventHandler):
         # Should investigate changes to improve performance.
         if exporterOptions.joints:
             for synJoint in exporterOptions.joints:
-                fusionJoint = gm.app.activeDocument.design.findEntityByToken(synJoint.jointToken)[0]
-                jointConfigTab.addJoint(fusionJoint, synJoint)
+                fusionJoints = gm.app.activeDocument.design.findEntityByToken(synJoint.jointToken)
+                if len(fusionJoints):
+                    jointConfigTab.addJoint(fusionJoints[0], synJoint)
         else:
             for joint in [
                 *gm.app.activeDocument.design.rootComponent.allJoints,


### PR DESCRIPTION
- Fixed an issue where the Synthesis Addin would hang if `Run on Startup` was checked.
- Fixed an issue where the exporter assumed that all saved joint tokens would never be removed from the design, resulting in handlers not being added properly.