### PR TITLE
Bug: Friction Override Slider Shown on Startup

### DIFF
--- a/exporter/SynthesisFusionAddin/src/Parser/ExporterOptions.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/ExporterOptions.py
@@ -51,7 +51,7 @@ class ExporterOptions:
     autoCalcGamepieceWeight: bool = field(default=False)
 
     frictionOverride: bool = field(default=False)
-    frictionOverrideCoeff: float | None = field(default=None)
+    frictionOverrideCoeff: float = field(default=0.5)
 
     compressOutput: bool = field(default=True)
     exportAsPart: bool = field(default=False)


### PR DESCRIPTION
Fixed a bug that would cause the friction override slider to show on startup even if the friction override checkbox was set to false.