### PR TITLE
Operation Remove the Javascript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 * text=auto
+
+# Workaround for a bug it GitHub's language detection,
+# previously half of our code was being counted as JavaScript.. for some reason...
+# and we certainly can't have that. - Brandon
+*.js linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 * text=auto
 
-# Workaround for a bug it GitHub's language detection,
+# Workaround for a bug in GitHub's language detection,
 # previously half of our code was being counted as JavaScript.. for some reason...
 # and we certainly can't have that. - Brandon
 *.js linguist-detectable=false


### PR DESCRIPTION
Previously over half our code was being counted as javascript even though we only have like 50 lines total. We want this to be a typescript repository, not a javascript one. This is the current workaround found by @azaleacolburn.