### PR TITLE
Exporter Formatting Fix

### DIFF
--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Components.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Components.py
@@ -6,7 +6,6 @@ from typing import *
 
 import adsk.core
 import adsk.fusion
-
 from proto.proto_out import assembly_pb2, joint_pb2, material_pb2, types_pb2
 
 from ...Logging import logFailure, timed

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/JointHierarchy.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/JointHierarchy.py
@@ -5,7 +5,6 @@ from typing import *
 
 import adsk.core
 import adsk.fusion
-
 from proto.proto_out import joint_pb2, types_pb2
 
 from ...general_imports import *

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Joints.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Joints.py
@@ -28,7 +28,6 @@ from typing import Union
 
 import adsk.core
 import adsk.fusion
-
 from proto.proto_out import assembly_pb2, joint_pb2, motor_pb2, signal_pb2, types_pb2
 
 from ...general_imports import *

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Materials.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Materials.py
@@ -5,7 +5,6 @@ import math
 import traceback
 
 import adsk
-
 from proto.proto_out import material_pb2
 
 from ...general_imports import *

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Parser.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Parser.py
@@ -4,7 +4,6 @@ import pathlib
 import adsk.core
 import adsk.fusion
 from google.protobuf.json_format import MessageToJson
-
 from proto.proto_out import assembly_pb2, types_pb2
 
 from ...APS.APS import getAuth, upload_mirabuf

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/PhysicalProperties.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/PhysicalProperties.py
@@ -21,7 +21,6 @@ import traceback
 from typing import Union
 
 import adsk
-
 from proto.proto_out import types_pb2
 
 from ...general_imports import INTERNAL_ID

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/RigidGroup.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/RigidGroup.py
@@ -16,7 +16,6 @@ from typing import *
 
 import adsk.core
 import adsk.fusion
-
 from proto.proto_out import assembly_pb2
 
 from ...Logging import logFailure

--- a/exporter/SynthesisFusionAddin/tools/verifyIsortFormatting.py
+++ b/exporter/SynthesisFusionAddin/tools/verifyIsortFormatting.py
@@ -18,9 +18,20 @@ def main() -> None:
     exitCode = 0
     for i, (oldFileState, newFileState) in enumerate(zip(oldFileStates, newFileStates)):
         for j, (previousLine, newLine) in enumerate(zip(oldFileState, newFileState)):
-            if previousLine != newLine:
-                print(f"File {files[i]} is not formatted correctly!\nLine: {j + 1}")
-                exitCode = 1
+            if previousLine == newLine:
+                continue
+
+            print(f"File {files[i]} is not formatted correctly!\nLine: {j + 1}")
+            print(
+                "\nOld file state:\n"
+                + "\n".join(oldFileState[k].strip() for k in range(max(0, j - 10), min(len(oldFileState), j + 11)))
+            )
+            print(
+                "\nNew file state:\n"
+                + "\n".join(newFileState[k].strip() for k in range(max(0, j - 10), min(len(newFileState), j + 11)))
+            )
+            exitCode = 1
+            break
 
     if not exitCode:
         print("All files are formatted correctly with isort!")

--- a/exporter/SynthesisFusionAddin/tools/verifyIsortFormatting.py
+++ b/exporter/SynthesisFusionAddin/tools/verifyIsortFormatting.py
@@ -22,14 +22,10 @@ def main() -> None:
                 continue
 
             print(f"File {files[i]} is not formatted correctly!\nLine: {j + 1}")
-            print(
-                "\nOld file state:\n"
-                + "\n".join(oldFileState[k].strip() for k in range(max(0, j - 10), min(len(oldFileState), j + 11)))
-            )
-            print(
-                "\nNew file state:\n"
-                + "\n".join(newFileState[k].strip() for k in range(max(0, j - 10), min(len(newFileState), j + 11)))
-            )
+            oldFileStateRange = range(max(0, j - 10), min(len(oldFileState), j + 11))
+            print("\nOld file state:\n" + "\n".join(oldFileState[k].strip() for k in oldFileStateRange))
+            newFileStateRange = range(max(0, j - 10), min(len(newFileState), j + 11))
+            print("\nNew file state:\n" + "\n".join(newFileState[k].strip() for k in newFileStateRange))
             exitCode = 1
             break
 


### PR DESCRIPTION
For some reason the isort formatter on mac wants to add a line between these imports:

```python
import adsk.core
import adsk.fusion
from google.protobuf.json_format import MessageToJson

from proto.proto_out import assembly_pb2, types_pb2
```

And on linux it wants to remove this line:

```python
import adsk.core
import adsk.fusion
from google.protobuf.json_format import MessageToJson
from proto.proto_out import assembly_pb2, types_pb2
```

¯\\_(ツ)_/¯

Edit:

This is actually because our local machines know that `proto.proto_out` is a local path but because we don't track that with git the server can't find it as a local path so it thinks that it's a package import.
