### PR TITLE
Mirabuf Caching OPFS Back Up

### DIFF
--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -32,17 +32,14 @@ const fieldFolderHandle = await root.getDirectoryHandle(fieldsDirName, { create:
 export const backUpRobots: Map<MirabufCacheID, ArrayBuffer> = new Map<MirabufCacheID, ArrayBuffer>()
 export const backUpFields: Map<MirabufCacheID, ArrayBuffer> = new Map<MirabufCacheID, ArrayBuffer>()
 
-const canOPFS = await (async() => {
+const canOPFS = await (async () => {
     try {
         if (robotFolderHandle.name == robotsDirName) {
             robotFolderHandle.entries
             robotFolderHandle.keys
 
-            const fileHandle = await robotFolderHandle.getFileHandle(
-                "0",
-                { create: true }
-            )
-            const writable = await fileHandle.createWritable() 
+            const fileHandle = await robotFolderHandle.getFileHandle("0", { create: true })
+            const writable = await fileHandle.createWritable()
             await writable.close()
             await fileHandle.getFile()
 
@@ -96,7 +93,6 @@ class MirabufCachingService {
             return {}
         }
     }
-
 
     /**
      * Cache remote Mirabuf file
@@ -246,17 +242,18 @@ class MirabufCachingService {
         try {
             // Get buffer from hashMap. If not in hashMap, check OPFS. Otherwise, buff is undefined
             const cache = miraType == MiraType.ROBOT ? backUpRobots : backUpFields
-            const buff = cache.get(id) ?? await (async() => {
-                const fileHandle = canOPFS ? await (miraType == MiraType.ROBOT ? robotFolderHandle : fieldFolderHandle).getFileHandle(
-                    id,
-                    {
-                        create: false,
-                    }
-                ) : undefined
-                return fileHandle ? await fileHandle.getFile().then(x => x.arrayBuffer()) : undefined
-            })()
+            const buff =
+                cache.get(id) ??
+                (await (async () => {
+                    const fileHandle = canOPFS
+                        ? await (miraType == MiraType.ROBOT ? robotFolderHandle : fieldFolderHandle).getFileHandle(id, {
+                              create: false,
+                          })
+                        : undefined
+                    return fileHandle ? await fileHandle.getFile().then(x => x.arrayBuffer()) : undefined
+                })())
 
-            // If we have buffer, get assembly 
+            // If we have buffer, get assembly
             if (buff) {
                 const assembly = this.AssemblyFromBuffer(buff)
                 World.AnalyticsSystem?.Event("Cache Get", {
@@ -370,10 +367,9 @@ class MirabufCachingService {
             // Store buffer
             if (canOPFS) {
                 // Store in OPFS
-                const fileHandle = await (miraType == MiraType.ROBOT ? robotFolderHandle : fieldFolderHandle).getFileHandle(
-                    backupID,
-                    { create: true }
-                )
+                const fileHandle = await (
+                    miraType == MiraType.ROBOT ? robotFolderHandle : fieldFolderHandle
+                ).getFileHandle(backupID, { create: true })
                 const writable = await fileHandle.createWritable()
                 await writable.write(miraBuff)
                 await writable.close()

--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -40,14 +40,27 @@ const fieldFolderHandle = await root.getDirectoryHandle(fieldsDirName, { create:
 const canOPFS = await (async() => {
     try {
         console.log(`trying OPFS`)
-        const fileHandle = await robotFolderHandle.getFileHandle(
-            "0",
-            { create: true }
-        )
-        const writable = await fileHandle.createWritable()
-        await writable.close()
-        console.log(`yes OPFS`)
-        return true
+
+        if (robotFolderHandle.name == robotsDirName) {
+            robotFolderHandle.entries
+            robotFolderHandle.keys
+
+            const fileHandle = await robotFolderHandle.getFileHandle(
+                "0",
+                { create: true }
+            )
+            const writable = await fileHandle.createWritable() 
+            await writable.close()
+            await fileHandle.getFile()
+
+            robotFolderHandle.removeEntry(fileHandle.name)
+
+            console.log(`yes OPFS`)
+            return true
+        } else {
+            console.log(`no OPFS`)
+            return false
+        }
     } catch (e) {
         console.log(`no OPFS`)
         return false

--- a/fission/src/mirabuf/MirabufParser.ts
+++ b/fission/src/mirabuf/MirabufParser.ts
@@ -240,7 +240,6 @@ class MirabufParser {
             console.log("Failed to get part definitions")
             return
         }
-        console.log(partDefinitions)
     }
 
     private NewRigidNode(suffix?: string): RigidNode {

--- a/fission/src/ui/panels/DebugPanel.tsx
+++ b/fission/src/ui/panels/DebugPanel.tsx
@@ -6,7 +6,11 @@ import WPILibBrain from "@/systems/simulation/wpilib_brain/WPILibBrain"
 import { MainHUD_AddToast } from "../components/MainHUD"
 import { ToastType } from "../ToastContext"
 import { Random } from "@/util/Random"
-import MirabufCachingService, { backUpFields as hashedMiraFields, backUpRobots as hashedMiraRobots, MiraType } from "@/mirabuf/MirabufLoader"
+import MirabufCachingService, {
+    backUpFields as hashedMiraFields,
+    backUpRobots as hashedMiraRobots,
+    MiraType,
+} from "@/mirabuf/MirabufLoader"
 import { Box, styled } from "@mui/material"
 import { usePanelControlContext } from "../PanelContext"
 import APS from "@/aps/APS"

--- a/fission/src/ui/panels/DebugPanel.tsx
+++ b/fission/src/ui/panels/DebugPanel.tsx
@@ -6,7 +6,7 @@ import WPILibBrain from "@/systems/simulation/wpilib_brain/WPILibBrain"
 import { MainHUD_AddToast } from "../components/MainHUD"
 import { ToastType } from "../ToastContext"
 import { Random } from "@/util/Random"
-import MirabufCachingService, { MiraType } from "@/mirabuf/MirabufLoader"
+import MirabufCachingService, { backUpFields as hashedMiraFields, backUpRobots as hashedMiraRobots, MiraType } from "@/mirabuf/MirabufLoader"
 import { Box, styled } from "@mui/material"
 import { usePanelControlContext } from "../PanelContext"
 import APS from "@/aps/APS"
@@ -113,6 +113,8 @@ const DebugPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
                     onClick={() => {
                         console.log(MirabufCachingService.GetCacheMap(MiraType.ROBOT))
                         console.log(MirabufCachingService.GetCacheMap(MiraType.FIELD))
+                        console.log(hashedMiraRobots)
+                        console.log(hashedMiraFields)
                     }}
                 />
                 <Button value={"Clear Mira Cache"} onClick={() => MirabufCachingService.RemoveAll()} />


### PR DESCRIPTION
### Description
We cannot create writables in OPFS on Safari/iOS, so this PR puts the ArrayBuffers in a hashMap so there is at least temporary storage.

### Testing Done
- [X] Chrome/Firefox on Windows (with canOPFS directly set true/false)
- [X] Safari (thanks @Dhruv-0-Arora)

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1797)