### PR TITLE
Fission Unit Tests Playwright Update

### DIFF
--- a/fission/package.json
+++ b/fission/package.json
@@ -32,7 +32,7 @@
     "colord": "^2.9.3",
     "framer-motion": "^10.13.1",
     "lygia": "^1.1.3",
-    "playwright": "^1.45.0",
+    "playwright": "^1.46.0",
     "postprocessing": "^6.35.6",
     "react": "^18.2.0",
     "react-colorful": "^5.6.1",


### PR DESCRIPTION
### Description
Fission unit tests currently failing for everyone due to Playwright update to 1.46.