### PR TITLE
Add `Barclay/JoltPhysics.js` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "mirabuf"]
 	path = mirabuf
 	url = https://github.com/HiceS/mirabuf.git
+[submodule "JoltPhysics.js"]
+	path = jolt-physics-barclay
+	url = https://github.com/HunterBarclay/JoltPhysics.js.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "mirabuf"]
 	path = mirabuf
 	url = https://github.com/HiceS/mirabuf.git
-[submodule "JoltPhysics.js"]
-	path = jolt-physics-barclay
+[submodule "jolt"]
+	path = jolt
 	url = https://github.com/HunterBarclay/JoltPhysics.js.git

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ All code is under a configured formatting utility. See each component for more d
 
 Mirabuf is a file format we use to store physical data from Fusion to load into the Synthesis simulator (Fission). This is a separate project that is a submodule of Synthesis. [See Mirabuf](https://github.com/HiceS/mirabuf/)
 
+### Jolt Physics
+
+Jolt is the core physics engine for our web biased simulator. [See JoltPhysics.js](https://github.com/HunterBarclay/JoltPhysics.js) for more information.
+
 ### Tutorials
 
 Our source code for the tutorials featured on our [Tutorials Page](https://synthesis.autodesk.com/tutorials.html).


### PR DESCRIPTION
We still have `mirabuf` as a submodule even though we don't really need it anymore. It does however make the repo look cooler and just that much more complex. So why not also add Hunter's fork of jolt that we use? We don't really need it here, but it looks cool.