### PR TITLE
HALSim websocket server only listens on localhost

### DIFF
--- a/simulation/samples/JavaAutoSample/build.gradle
+++ b/simulation/samples/JavaAutoSample/build.gradle
@@ -91,7 +91,6 @@ test {
 wpi.sim.addGui().defaultEnabled = true
 wpi.sim.addDriverstation()
 
-wpi.sim.envVar("HALSIMWS_HOST", "127.0.0.1")
 wpi.sim.addWebsocketsServer().defaultEnabled = true
 
 // Setting up my Jar File. In this case, adding all libraries into the main jar ('fat jar')

--- a/simulation/samples/JavaSample/build.gradle
+++ b/simulation/samples/JavaSample/build.gradle
@@ -91,7 +91,6 @@ test {
 wpi.sim.addGui().defaultEnabled = true
 wpi.sim.addDriverstation()
 
-wpi.sim.envVar("HALSIMWS_HOST", "127.0.0.1")
 wpi.sim.addWebsocketsServer().defaultEnabled = true
 
 // Setting up my Jar File. In this case, adding all libraries into the main jar ('fat jar')

--- a/tutorials/CodeSimulation.md
+++ b/tutorials/CodeSimulation.md
@@ -27,7 +27,6 @@ def includeDesktopSupport = true
 In order to communicate with your browser, you'll need to enable the websocket server extension with the following:
 
 ```java
-wpi.sim.envVar("HALSIMWS_HOST", "127.0.0.1")
 wpi.sim.addWebsocketsServer().defaultEnabled = true
 ```
 


### PR DESCRIPTION
I personally haven't tried this (so you should verify before merging!) but the websocket server only listens on localhost, so that environment variable specified in build.gradle serves no purpose (it's a client setting, not a server setting).

Reference: https://github.com/wpilibsuite/allwpilib/blob/b65f159c3fdfdfce9ec126cf79dfd9a16d1e66e9/simulation/halsim_ws_server/src/main/native/cpp/HALSimWeb.cpp#L120