### PR TITLE
Add tooltip text for Configure Assets panel

### DIFF
--- a/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
@@ -139,7 +139,7 @@ function getRobotModes(assembly: MirabufSceneObject): Map<ConfigMode, ConfigMode
             new ConfigModeSelectionOption(
                 "Intake",
                 ConfigMode.INTAKE,
-                "Configure intake mechanism position, parent node, and zone size for accurate simulation and behavior."
+                "Configure the robot’s intake position and parent node for picking up game pieces."
             ),
         ],
         [

--- a/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
@@ -131,28 +131,24 @@ function getRobotModes(assembly: MirabufSceneObject): Map<ConfigMode, ConfigMode
             ),
         ],
         [
-            ConfigMode.MOVE, 
-            new ConfigModeSelectionOption(
-                "Move", 
-                ConfigMode.MOVE,
-                "Adjust position of robot relative to field."
-            )
+            ConfigMode.MOVE,
+            new ConfigModeSelectionOption("Move", ConfigMode.MOVE, "Adjust position of robot relative to field."),
         ],
         [
-            ConfigMode.INTAKE, 
+            ConfigMode.INTAKE,
             new ConfigModeSelectionOption(
-                "Intake", 
+                "Intake",
                 ConfigMode.INTAKE,
                 "Configure intake mechanism position, parent node, and zone size for accurate simulation and behavior."
-            )
+            ),
         ],
         [
-            ConfigMode.EJECTOR, 
+            ConfigMode.EJECTOR,
             new ConfigModeSelectionOption(
-                "Ejector", 
+                "Ejector",
                 ConfigMode.EJECTOR,
                 "Configure the robot’s ejector mechanism, which controls the release or expulsion of game pieces."
-            )
+            ),
         ],
         [
             ConfigMode.SUBSYSTEMS,
@@ -184,12 +180,9 @@ function getRobotModes(assembly: MirabufSceneObject): Map<ConfigMode, ConfigMode
             )
             break
         case "synthesis":
-            modes.set(ConfigMode.CONTROLS, 
-                new ConfigModeSelectionOption(
-                    "Controls", 
-                    ConfigMode.CONTROLS,
-                    "Set your controller scheme."
-                )
+            modes.set(
+                ConfigMode.CONTROLS,
+                new ConfigModeSelectionOption("Controls", ConfigMode.CONTROLS, "Set your controller scheme.")
             )
             break
         default:
@@ -200,16 +193,18 @@ function getRobotModes(assembly: MirabufSceneObject): Map<ConfigMode, ConfigMode
 }
 
 const fieldModes: Map<ConfigMode, ConfigModeSelectionOption> = new Map<ConfigMode, ConfigModeSelectionOption>([
-    [ConfigMode.MOVE, new ConfigModeSelectionOption(
-        "Move", 
+    [
         ConfigMode.MOVE,
-        "Adjust position of field relative to robot."
-    )],
-    [ConfigMode.SCORING_ZONES, new ConfigModeSelectionOption(
-        "Scoring Zones", 
+        new ConfigModeSelectionOption("Move", ConfigMode.MOVE, "Adjust position of field relative to robot."),
+    ],
+    [
         ConfigMode.SCORING_ZONES,
-        "Define and manage zones on the field where robots can earn points during simulation."
-    )],
+        new ConfigModeSelectionOption(
+            "Scoring Zones",
+            ConfigMode.SCORING_ZONES,
+            "Define and manage zones on the field where robots can earn points during simulation."
+        ),
+    ],
 ])
 
 interface ConfigModeSelectionProps {

--- a/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
@@ -130,9 +130,30 @@ function getRobotModes(assembly: MirabufSceneObject): Map<ConfigMode, ConfigMode
                 "Select and modify what is controlling of the robot."
             ),
         ],
-        [ConfigMode.MOVE, new ConfigModeSelectionOption("Move", ConfigMode.MOVE)],
-        [ConfigMode.INTAKE, new ConfigModeSelectionOption("Intake", ConfigMode.INTAKE)],
-        [ConfigMode.EJECTOR, new ConfigModeSelectionOption("Ejector", ConfigMode.EJECTOR)],
+        [
+            ConfigMode.MOVE, 
+            new ConfigModeSelectionOption(
+                "Move", 
+                ConfigMode.MOVE,
+                "Adjust position of robot relative to field."
+            )
+        ],
+        [
+            ConfigMode.INTAKE, 
+            new ConfigModeSelectionOption(
+                "Intake", 
+                ConfigMode.INTAKE,
+                "Configure intake mechanism position, parent node, and zone size for accurate simulation and behavior."
+            )
+        ],
+        [
+            ConfigMode.EJECTOR, 
+            new ConfigModeSelectionOption(
+                "Ejector", 
+                ConfigMode.EJECTOR,
+                "Configure the robot’s ejector mechanism, which controls the release or expulsion of game pieces."
+            )
+        ],
         [
             ConfigMode.SUBSYSTEMS,
             new ConfigModeSelectionOption(
@@ -163,7 +184,13 @@ function getRobotModes(assembly: MirabufSceneObject): Map<ConfigMode, ConfigMode
             )
             break
         case "synthesis":
-            modes.set(ConfigMode.CONTROLS, new ConfigModeSelectionOption("Controls", ConfigMode.CONTROLS))
+            modes.set(ConfigMode.CONTROLS, 
+                new ConfigModeSelectionOption(
+                    "Controls", 
+                    ConfigMode.CONTROLS,
+                    "Set your controller scheme."
+                )
+            )
             break
         default:
             break
@@ -173,8 +200,16 @@ function getRobotModes(assembly: MirabufSceneObject): Map<ConfigMode, ConfigMode
 }
 
 const fieldModes: Map<ConfigMode, ConfigModeSelectionOption> = new Map<ConfigMode, ConfigModeSelectionOption>([
-    [ConfigMode.MOVE, new ConfigModeSelectionOption("Move", ConfigMode.MOVE)],
-    [ConfigMode.SCORING_ZONES, new ConfigModeSelectionOption("Scoring Zones", ConfigMode.SCORING_ZONES)],
+    [ConfigMode.MOVE, new ConfigModeSelectionOption(
+        "Move", 
+        ConfigMode.MOVE,
+        "Adjust position of field relative to robot."
+    )],
+    [ConfigMode.SCORING_ZONES, new ConfigModeSelectionOption(
+        "Scoring Zones", 
+        ConfigMode.SCORING_ZONES,
+        "Define and manage zones on the field where robots can earn points during simulation."
+    )],
 ])
 
 interface ConfigModeSelectionProps {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "synthesis",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "synthesis",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Description

Adds helpful tooltips to the Robots and Fields sections of Configure Assets panel for a more intuitive UI.

<img width="365" alt="Screenshot 2025-06-17 at 11 21 00 AM" src="https://github.com/user-attachments/assets/99729fda-1fad-45f5-9ef6-638cbc590ab7" />

<img width="369" alt="Screenshot 2025-06-17 at 11 21 23 AM" src="https://github.com/user-attachments/assets/4f88aac4-d94f-4e97-a629-a8f8e4cc92c1" />





