### PR TITLE
Open correct tab in spawn panel from configuration panel

### DIFF
--- a/fission/src/ui/PanelContext.tsx
+++ b/fission/src/ui/PanelContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect, useCallback, useContext, ReactNode, ReactElement } from "react"
+import React, { createContext, ReactElement, ReactNode, useCallback, useContext, useEffect, useState } from "react"
 
 type PanelControlContextType = {
     openPanel: (panelId: string) => void

--- a/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
@@ -5,7 +5,7 @@ import Label from "@/ui/components/Label"
 import Panel, { PanelPropsImpl } from "@/ui/components/Panel"
 import SelectMenu, { SelectMenuOption } from "@/ui/components/SelectMenu"
 import { ToggleButton, ToggleButtonGroup } from "@/ui/components/ToggleButtonGroup"
-import { useEffect, useMemo, useReducer, useState, MouseEvent } from "react"
+import { MouseEvent, useEffect, useMemo, useReducer, useState } from "react"
 import ConfigureScoringZonesInterface from "./interfaces/scoring/ConfigureScoringZonesInterface"
 import ChangeInputsInterface from "./interfaces/inputs/ConfigureInputsInterface"
 import InputSystem from "@/systems/input/InputSystem"
@@ -24,6 +24,7 @@ import TransformGizmoControl from "@/ui/components/TransformGizmoControl"
 import { ConfigMode, popConfigurePanelSettings } from "./ConfigurePanelControls"
 import BrainSelectionInterface from "./interfaces/BrainSelectionInterface"
 import SimulationInterface from "./interfaces/SimulationInterface"
+import { mirabufPanelSettings } from "@/panels/mirabuf/MirabufState.tsx"
 
 /** Option for selecting a robot of field */
 class AssemblySelectionOption extends SelectMenuOption {
@@ -101,6 +102,8 @@ const AssemblySelection: React.FC<ConfigurationSelectionProps> = ({
                 update()
             }}
             onAddClicked={() => {
+                mirabufPanelSettings.current =
+                    configurationType == ConfigurationType.FIELD ? MiraType.FIELD : MiraType.ROBOT
                 openPanel("import-mirabuf")
             }}
             noOptionsText={`No ${configurationType == ConfigurationType.ROBOT ? "robots" : "fields"} spawned!`}

--- a/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
+++ b/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
@@ -25,11 +25,11 @@ import { usePanelControlContext } from "@/ui/PanelContext"
 import { useModalControlContext } from "@/ui/ModalContext"
 import TaskStatus from "@/util/TaskStatus"
 import {
+    DeleteButton,
     PositiveButton,
+    RefreshButton,
     SectionDivider,
     SectionLabel,
-    DeleteButton,
-    RefreshButton,
     SynthesisIcons,
 } from "@/ui/components/StyledComponents"
 import { ProgressHandle } from "@/ui/components/ProgressNotificationData"
@@ -37,6 +37,7 @@ import Panel, { PanelPropsImpl } from "@/ui/components/Panel"
 import Button from "@/ui/components/Button"
 import { Global_OpenPanel } from "@/ui/components/GlobalUIControls"
 import { PAUSE_REF_ASSEMBLY_SPAWNING } from "@/systems/physics/PhysicsSystem"
+import { mirabufPanelSettings } from "@/panels/mirabuf/MirabufState.tsx"
 
 interface ItemCardProps {
     id: string
@@ -361,7 +362,10 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
                 ),
         [files, selectAPS, viewType]
     )
-
+    useEffect(() => {
+        setViewType(mirabufPanelSettings.current)
+        mirabufPanelSettings.current = mirabufPanelSettings.default
+    }, [])
     return (
         <Panel
             name={"Spawn Asset"}

--- a/fission/src/ui/panels/mirabuf/MirabufState.tsx
+++ b/fission/src/ui/panels/mirabuf/MirabufState.tsx
@@ -1,0 +1,6 @@
+import { MiraType } from "@/mirabuf/MirabufLoader.ts"
+
+export const mirabufPanelSettings = {
+    current: MiraType.ROBOT,
+    default: MiraType.ROBOT,
+}


### PR DESCRIPTION
### Description
When opening the mirabuf import panel through the Configure Assets panel, it now opens to the import mode matching the configure mode. For example, when the Fields tab is selected in Configure Assets and the user clicks the plus button, the spawn panel opens to the fields tab instead of robots.


[JIRA Issue](https://jira.autodesk.com/browse/AARD-1891)
