### PR TITLE
Intake Zone Persistent Visibility

### DIFF
--- a/fission/src/mirabuf/IntakeSensorSceneObject.ts
+++ b/fission/src/mirabuf/IntakeSensorSceneObject.ts
@@ -85,15 +85,9 @@ class IntakeSensorSceneObject extends SceneObject {
         }
     }
 
-    public HideVisualIndicator(): void {
+    public SetVisualIndicatorVisible(visible: boolean): void {
         if (this._visualIndicator) {
-            this._visualIndicator.visible = false
-        }
-    }
-
-    public ShowVisualIndicator(): void {
-        if (this._visualIndicator && this._parentAssembly.intakePreferences?.showZoneAlways) {
-            this._visualIndicator.visible = true
+            this._visualIndicator.visible = visible && (this._parentAssembly.intakePreferences?.showZoneAlways ?? false)
         }
     }
 

--- a/fission/src/mirabuf/IntakeSensorSceneObject.ts
+++ b/fission/src/mirabuf/IntakeSensorSceneObject.ts
@@ -78,7 +78,7 @@ class IntakeSensorSceneObject extends SceneObject {
                 color: 0x00ff00, // Green color for intake zone
                 transparent: true,
                 opacity: 0.3,
-                wireframe: true
+                wireframe: true,
             })
             this._visualIndicator = new THREE.Mesh(geometry, material)
             World.SceneRenderer.scene.add(this._visualIndicator)

--- a/fission/src/mirabuf/IntakeSensorSceneObject.ts
+++ b/fission/src/mirabuf/IntakeSensorSceneObject.ts
@@ -19,6 +19,7 @@ class IntakeSensorSceneObject extends SceneObject {
 
     private _joltBodyId?: Jolt.BodyID
     private _collision?: (e: OnContactPersistedEvent) => void
+    private _visualIndicator?: THREE.Mesh
 
     public constructor(parentAssembly: MirabufSceneObject) {
         super()
@@ -58,6 +59,42 @@ class IntakeSensorSceneObject extends SceneObject {
 
             OnContactPersistedEvent.AddListener(this._collision)
         }
+
+        // Create visual indicator if showZoneAlways is enabled
+        this.UpdateVisualIndicator()
+    }
+
+    public UpdateVisualIndicator(): void {
+        // Remove existing visual indicator
+        if (this._visualIndicator) {
+            World.SceneRenderer.scene.remove(this._visualIndicator)
+            this._visualIndicator = undefined
+        }
+
+        // Create new visual indicator if showZoneAlways is enabled
+        if (this._parentAssembly.intakePreferences?.showZoneAlways) {
+            const geometry = new THREE.SphereGeometry(this._parentAssembly.intakePreferences.zoneDiameter / 2.0)
+            const material = new THREE.MeshBasicMaterial({
+                color: 0x00ff00, // Green color for intake zone
+                transparent: true,
+                opacity: 0.3,
+                wireframe: true
+            })
+            this._visualIndicator = new THREE.Mesh(geometry, material)
+            World.SceneRenderer.scene.add(this._visualIndicator)
+        }
+    }
+
+    public HideVisualIndicator(): void {
+        if (this._visualIndicator) {
+            this._visualIndicator.visible = false
+        }
+    }
+
+    public ShowVisualIndicator(): void {
+        if (this._visualIndicator && this._parentAssembly.intakePreferences?.showZoneAlways) {
+            this._visualIndicator.visible = true
+        }
     }
 
     public Update(): void {
@@ -72,6 +109,12 @@ class IntakeSensorSceneObject extends SceneObject {
 
             World.PhysicsSystem.SetBodyPosition(this._joltBodyId, ThreeVector3_JoltRVec3(position))
             World.PhysicsSystem.SetBodyRotation(this._joltBodyId, ThreeQuaternion_JoltQuat(rotation))
+
+            // Update visual indicator position if it exists
+            if (this._visualIndicator) {
+                this._visualIndicator.position.copy(position)
+                this._visualIndicator.quaternion.copy(rotation)
+            }
         }
     }
 
@@ -81,6 +124,12 @@ class IntakeSensorSceneObject extends SceneObject {
         }
 
         if (this._collision) OnContactPersistedEvent.RemoveListener(this._collision)
+
+        // Clean up visual indicator
+        if (this._visualIndicator) {
+            World.SceneRenderer.scene.remove(this._visualIndicator)
+            this._visualIndicator = undefined
+        }
     }
 
     private IntakeCollision(gpID: Jolt.BodyID) {

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -409,6 +409,24 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
         }
     }
 
+    public UpdateIntakeVisualIndicator() {
+        if (this._intakeSensor) {
+            this._intakeSensor.UpdateVisualIndicator()
+        }
+    }
+
+    public HideIntakeVisualIndicator() {
+        if (this._intakeSensor) {
+            this._intakeSensor.HideVisualIndicator()
+        }
+    }
+
+    public ShowIntakeVisualIndicator() {
+        if (this._intakeSensor) {
+            this._intakeSensor.ShowVisualIndicator()
+        }
+    }
+
     public SetEjectable(bodyId?: Jolt.BodyID, removeExisting: boolean = false): boolean {
         if (this._ejectable) {
             if (!removeExisting) return false
@@ -486,6 +504,10 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
         const robotPrefs = PreferencesSystem.getRobotPreferences(this.assemblyName)
         if (robotPrefs) {
             this._intakePreferences = robotPrefs.intake
+            // Ensure backwards compatibility for showZoneAlways field
+            if (this._intakePreferences && this._intakePreferences.showZoneAlways === undefined) {
+                this._intakePreferences.showZoneAlways = false
+            }
             this._ejectorPreferences = robotPrefs.ejector
             this._simConfigData = robotPrefs.simConfig
         }

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -415,15 +415,9 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
         }
     }
 
-    public HideIntakeVisualIndicator() {
+    public SetIntakeVisualIndicatorVisible(visible: boolean) {
         if (this._intakeSensor) {
-            this._intakeSensor.HideVisualIndicator()
-        }
-    }
-
-    public ShowIntakeVisualIndicator() {
-        if (this._intakeSensor) {
-            this._intakeSensor.ShowVisualIndicator()
+            this._intakeSensor.SetVisualIndicatorVisible(visible)
         }
     }
 

--- a/fission/src/systems/preferences/PreferenceTypes.ts
+++ b/fission/src/systems/preferences/PreferenceTypes.ts
@@ -45,6 +45,7 @@ export type IntakePreferences = {
     deltaTransformation: number[]
     zoneDiameter: number
     parentNode: string | undefined
+    showZoneAlways: boolean
 }
 
 export type EjectorPreferences = {
@@ -118,6 +119,7 @@ export function DefaultRobotPreferences(): RobotPreferences {
             deltaTransformation: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
             zoneDiameter: 0.5,
             parentNode: undefined,
+            showZoneAlways: false,
         },
         ejector: {
             deltaTransformation: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
@@ -130,10 +130,7 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
         const material = World.SceneRenderer.CreateToonMaterial(ReactRgbaColor_ThreeColor(theme.HighlightHover.color))
         material.transparent = true
         material.opacity = 0.6
-        return new THREE.Mesh(
-            new THREE.SphereGeometry(0.5),
-            material
-        )
+        return new THREE.Mesh(new THREE.SphereGeometry(0.5), material)
     }, [theme])
 
     const gizmoComponent = useMemo(() => {
@@ -193,7 +190,7 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
 
     useEffect(() => {
         World.PhysicsSystem.HoldPause(PAUSE_REF_ASSEMBLY_CONFIG)
-        
+
         // Hide the visual indicator when entering configuration mode
         if (selectedRobot) {
             selectedRobot.HideIntakeVisualIndicator()
@@ -201,7 +198,7 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
 
         return () => {
             World.PhysicsSystem.ReleasePause(PAUSE_REF_ASSEMBLY_CONFIG)
-            
+
             // Show the visual indicator when exiting configuration mode
             if (selectedRobot) {
                 selectedRobot.ShowIntakeVisualIndicator()
@@ -270,7 +267,7 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
                         input: {
                             className: `cursor-inherit absolute w-full h-full top-0 left-0 opacity-0 z-10 border-none`,
                         },
-                        track: (ownerState) => {
+                        track: ownerState => {
                             return {
                                 className: `absolute block w-full h-full transition rounded-full border border-solid outline-none border-interactive-element-right dark:border-interactive-element-right group-[.base--focusVisible]:shadow-outline-switch ${ownerState.checked ? "bg-gradient-to-br from-interactive-element-left to-interactive-element-right" : "bg-background-secondary"} transform transition-transform group-hover:scale-[1.03] group-active:scale-[1.06]`,
                             }

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
@@ -193,7 +193,7 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
 
         // Hide the visual indicator when entering configuration mode
         if (selectedRobot) {
-            selectedRobot.HideIntakeVisualIndicator()
+            selectedRobot.SetIntakeVisualIndicatorVisible(false)
         }
 
         return () => {
@@ -201,7 +201,7 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
 
             // Show the visual indicator when exiting configuration mode
             if (selectedRobot) {
-                selectedRobot.ShowIntakeVisualIndicator()
+                selectedRobot.SetIntakeVisualIndicatorVisible(true)
             }
         }
     }, [selectedRobot])

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
@@ -262,18 +262,41 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
                     }}
                     slotProps={{
                         root: {
-                            className: `group relative inline-block w-[24px] h-[24px] m-2.5 cursor-pointer transform transition-transform hover:scale-[1.03] active:scale-[1.06]`,
+                            className: `
+                                group relative inline-block 
+                                w-[24px] h-[24px] m-2.5 
+                                cursor-pointer transform transition-transform 
+                                hover:scale-[1.03] active:scale-[1.06]
+                            `,
                         },
                         input: {
-                            className: `cursor-inherit absolute w-full h-full top-0 left-0 opacity-0 z-10 border-none`,
+                            className: `
+                                cursor-inherit absolute 
+                                w-full h-full top-0 left-0 
+                                opacity-0 z-10 border-none
+                            `,
                         },
                         track: ownerState => {
+                            const baseClasses = `
+                                absolute block w-full h-full 
+                                transition rounded-full 
+                                border border-solid outline-none 
+                                border-interactive-element-right 
+                                dark:border-interactive-element-right 
+                                group-[.base--focusVisible]:shadow-outline-switch 
+                                transform transition-transform 
+                                group-hover:scale-[1.03] group-active:scale-[1.06]
+                            `
+                            const backgroundClasses = ownerState.checked
+                                ? "bg-gradient-to-br from-interactive-element-left to-interactive-element-right"
+                                : "bg-background-secondary"
+
                             return {
-                                className: `absolute block w-full h-full transition rounded-full border border-solid outline-none border-interactive-element-right dark:border-interactive-element-right group-[.base--focusVisible]:shadow-outline-switch ${ownerState.checked ? "bg-gradient-to-br from-interactive-element-left to-interactive-element-right" : "bg-background-secondary"} transform transition-transform group-hover:scale-[1.03] group-active:scale-[1.06]`,
+                                className: `${baseClasses} ${backgroundClasses}`,
                             }
                         },
                         thumb: {
-                            className: `display-none`,
+                            className: "display-none",
                         },
                     }}
                 />

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
@@ -20,7 +20,9 @@ import GizmoSceneObject from "@/systems/scene/GizmoSceneObject"
 import { ConfigurationSavedEvent } from "../ConfigurationSavedEvent"
 import TransformGizmoControl from "@/ui/components/TransformGizmoControl"
 import { PAUSE_REF_ASSEMBLY_CONFIG } from "@/systems/physics/PhysicsSystem"
-import Checkbox from "@/ui/components/Checkbox"
+import { Box } from "@mui/material"
+import { Switch } from "@mui/base/Switch"
+import Label, { LabelSize } from "@/ui/components/Label"
 
 // slider constants
 const MIN_ZONE_SIZE = 0.1
@@ -246,15 +248,39 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
                 step={0.01}
             />
             {/* Checkbox for showing intake zone indicator at all times */}
-            <Checkbox
-                key={selectedRobot?.assemblyName ?? "no-robot"}
-                label="Show intake zone indicator always"
-                defaultState={showZoneAlways}
-                onClick={(checked) => {
-                    setShowZoneAlways(checked)
-                }}
-                tooltipText="When enabled, the intake zone indicator will be visible during regular use, not just during configuration."
-            />
+            <Box
+                display="flex"
+                flexDirection={"row"}
+                justifyContent={"space-between"}
+                alignItems={"center"}
+                textAlign={"center"}
+            >
+                <Label size={LabelSize.Small} className="mr-12 whitespace-nowrap">
+                    Show intake zone indicator always
+                </Label>
+                <Switch
+                    checked={showZoneAlways}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        setShowZoneAlways(e.target.checked)
+                    }}
+                    slotProps={{
+                        root: {
+                            className: `group relative inline-block w-[24px] h-[24px] m-2.5 cursor-pointer transform transition-transform hover:scale-[1.03] active:scale-[1.06]`,
+                        },
+                        input: {
+                            className: `cursor-inherit absolute w-full h-full top-0 left-0 opacity-0 z-10 border-none`,
+                        },
+                        track: (ownerState) => {
+                            return {
+                                className: `absolute block w-full h-full transition rounded-full border border-solid outline-none border-interactive-element-right dark:border-interactive-element-right group-[.base--focusVisible]:shadow-outline-switch ${ownerState.checked ? "bg-gradient-to-br from-interactive-element-left to-interactive-element-right" : "bg-background-secondary"} transform transition-transform group-hover:scale-[1.03] group-active:scale-[1.06]`,
+                            }
+                        },
+                        thumb: {
+                            className: `display-none`,
+                        },
+                    }}
+                />
+            </Box>
             {gizmoComponent}
             {Spacer(10)}
             <Button

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
@@ -20,6 +20,7 @@ import GizmoSceneObject from "@/systems/scene/GizmoSceneObject"
 import { ConfigurationSavedEvent } from "../ConfigurationSavedEvent"
 import TransformGizmoControl from "@/ui/components/TransformGizmoControl"
 import { PAUSE_REF_ASSEMBLY_CONFIG } from "@/systems/physics/PhysicsSystem"
+import Checkbox from "@/ui/components/Checkbox"
 
 // slider constants
 const MIN_ZONE_SIZE = 0.1
@@ -52,7 +53,8 @@ function save(
     zoneSize: number,
     gizmo: GizmoSceneObject,
     selectedRobot: MirabufSceneObject,
-    selectedNode?: RigidNodeId
+    selectedNode?: RigidNodeId,
+    showZoneAlways?: boolean
 ) {
     if (!selectedRobot?.intakePreferences || !gizmo) {
         return
@@ -76,6 +78,9 @@ function save(
     selectedRobot.intakePreferences.deltaTransformation = ThreeMatrix4_Array(deltaTransformation)
     selectedRobot.intakePreferences.parentNode = selectedNode
     selectedRobot.intakePreferences.zoneDiameter = zoneSize
+    if (showZoneAlways !== undefined) {
+        selectedRobot.intakePreferences.showZoneAlways = showZoneAlways
+    }
 
     PreferencesSystem.savePreferences()
 }
@@ -92,15 +97,16 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
 
     const [selectedNode, setSelectedNode] = useState<RigidNodeId | undefined>(undefined)
     const [zoneSize, setZoneSize] = useState<number>((MIN_ZONE_SIZE + MAX_ZONE_SIZE) / 2.0)
+    const [showZoneAlways, setShowZoneAlways] = useState<boolean>(false)
 
     const gizmoRef = useRef<GizmoSceneObject | undefined>(undefined)
 
     const saveEvent = useCallback(() => {
         if (gizmoRef.current && selectedRobot) {
-            save(zoneSize, gizmoRef.current, selectedRobot, selectedNode)
+            save(zoneSize, gizmoRef.current, selectedRobot, selectedNode, showZoneAlways)
             selectedRobot.UpdateIntakeSensor()
         }
-    }, [selectedRobot, selectedNode, zoneSize])
+    }, [selectedRobot, selectedNode, zoneSize, showZoneAlways])
 
     useEffect(() => {
         ConfigurationSavedEvent.Listen(saveEvent)
@@ -119,9 +125,12 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
     }, [zoneSize])
 
     const placeholderMesh = useMemo(() => {
+        const material = World.SceneRenderer.CreateToonMaterial(ReactRgbaColor_ThreeColor(theme.HighlightHover.color))
+        material.transparent = true
+        material.opacity = 0.6
         return new THREE.Mesh(
             new THREE.SphereGeometry(0.5),
-            World.SceneRenderer.CreateToonMaterial(ReactRgbaColor_ThreeColor(theme.HighlightHover.color))
+            material
         )
     }, [theme])
 
@@ -173,18 +182,30 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
         if (selectedRobot?.intakePreferences) {
             setZoneSize(selectedRobot.intakePreferences.zoneDiameter)
             setSelectedNode(selectedRobot.intakePreferences.parentNode)
+            setShowZoneAlways(selectedRobot.intakePreferences.showZoneAlways ?? false)
         } else {
             setSelectedNode(undefined)
+            setShowZoneAlways(false)
         }
     }, [selectedRobot])
 
     useEffect(() => {
         World.PhysicsSystem.HoldPause(PAUSE_REF_ASSEMBLY_CONFIG)
+        
+        // Hide the visual indicator when entering configuration mode
+        if (selectedRobot) {
+            selectedRobot.HideIntakeVisualIndicator()
+        }
 
         return () => {
             World.PhysicsSystem.ReleasePause(PAUSE_REF_ASSEMBLY_CONFIG)
+            
+            // Show the visual indicator when exiting configuration mode
+            if (selectedRobot) {
+                selectedRobot.ShowIntakeVisualIndicator()
+            }
         }
-    }, [])
+    }, [selectedRobot])
 
     const trySetSelectedNode = useCallback(
         (body: Jolt.BodyID) => {
@@ -223,6 +244,16 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
                     setZoneSize(vel as number)
                 }}
                 step={0.01}
+            />
+            {/* Checkbox for showing intake zone indicator at all times */}
+            <Checkbox
+                key={selectedRobot?.assemblyName ?? "no-robot"}
+                label="Show intake zone indicator always"
+                defaultState={showZoneAlways}
+                onClick={(checked) => {
+                    setShowZoneAlways(checked)
+                }}
+                tooltipText="When enabled, the intake zone indicator will be visible during regular use, not just during configuration."
             />
             {gizmoComponent}
             {Spacer(10)}


### PR DESCRIPTION
The visibility zone that typically appears in the intake configuration menu now has an option that allows it to be seen when said config is not open (in gameplay). When enabled, the zone will appear as a wireframe to make it more subtle and visually appealing. Additionally, regardless of the state of the setting, the zone is now semitransparent when using the config menu to make it easier to align the zone.

Zone in config
<img width="704" alt="image" src="https://github.com/user-attachments/assets/9277dbfd-648b-4729-92cd-d4bdc0f5445e" />

Zone with "always show" enabled
<img width="769" alt="image" src="https://github.com/user-attachments/assets/c4f4be3a-4485-436d-b972-46efa990b20d" />

"Always show" option in intake config
<img width="427" alt="image" src="https://github.com/user-attachments/assets/7899790e-40ce-432c-accd-c8732bc4d852" />
