### PR TITLE
Light Reposition to fix Low Graphics Shader bug

### DIFF
--- a/fission/src/systems/scene/SceneRenderer.ts
+++ b/fission/src/systems/scene/SceneRenderer.ts
@@ -250,7 +250,8 @@ class SceneRenderer extends WorldSystem {
             const shadowCamSize = 15
 
             this._light = new THREE.DirectionalLight(0xffffff, 5.0)
-            this._light.position.set(-1.0, 3.0, 2.0)
+            const lightDirection = new THREE.Vector3(1.0, -3.0, -2.0).normalize()
+            this._light.position.copy(lightDirection.clone().multiplyScalar(-20))
             this._light.castShadow = true
             this._light.shadow.camera.top = shadowCamSize
             this._light.shadow.camera.bottom = -shadowCamSize


### PR DESCRIPTION
The directional light by ThreeJS is now positioned by taking the normalized light direction and multiplying by -20 (placing it 20 units away in the opposite direction from the origin), and now both lighting modes use the same direction vector (1.0, -3.0, -2.0) normalized. The light target remains at (0, 0, 0) to center the shadow camera on the ground plane.

<img width="682" alt="image" src="https://github.com/user-attachments/assets/c9b8b705-5a04-4aae-866b-b8f8e784045a" />
