### PR TITLE
Fix Scoring Zone Scaling `[AARD-1913]`

### DIFF
--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -466,14 +466,13 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
 
     public RemoveScoringZoneObject(zone: ScoringZonePreferences) {
         const index = this._fieldPreferences?.scoringZones?.indexOf(zone) ?? -1
-        if (index != -1) {
-            const zoneObject = this._scoringZones[index]
+        if (index == -1) return
 
-            if (zoneObject != null) {
-                World.SceneRenderer.RemoveSceneObject(zoneObject.id)
-                zoneObject.id = -1
-            }
-        }
+        const zoneObject = this._scoringZones[index]
+        if (zoneObject == null) return
+
+        World.SceneRenderer.RemoveSceneObject(zoneObject.id)
+        zoneObject.id = -1
     }
 
     /**

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -465,12 +465,13 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
     }
 
     public RemoveScoringZoneObject(zone: ScoringZonePreferences) {
-        const index = this._fieldPreferences?.scoringZones?.indexOf(zone)
-        if (index != null) {
-            const zone = this._scoringZones[index]
-            if (zone != null) {
-                World.SceneRenderer.RemoveSceneObject(zone.id)
-                zone.id = -1
+        const index = this._fieldPreferences?.scoringZones?.indexOf(zone) ?? -1
+        if (index != -1) {
+            const zoneObject = this._scoringZones[index]
+
+            if (zoneObject != null) {
+                World.SceneRenderer.RemoveSceneObject(zoneObject.id)
+                zoneObject.id = -1
             }
         }
     }

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -9,7 +9,12 @@ import * as THREE from "three"
 import JOLT from "@/util/loading/JoltSyncLoader"
 import { BodyAssociate, LayerReserve } from "@/systems/physics/PhysicsSystem"
 import Mechanism from "@/systems/physics/Mechanism"
-import { EjectorPreferences, FieldPreferences, IntakePreferences } from "@/systems/preferences/PreferenceTypes"
+import {
+    EjectorPreferences,
+    FieldPreferences,
+    IntakePreferences,
+    ScoringZonePreferences,
+} from "@/systems/preferences/PreferenceTypes"
 import PreferencesSystem from "@/systems/preferences/PreferencesSystem"
 import { MiraType } from "./MirabufLoader"
 import IntakeSensorSceneObject from "./IntakeSensorSceneObject"
@@ -443,7 +448,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
     }
 
     public UpdateScoringZones(render?: boolean) {
-        this._scoringZones.forEach(zone => World.SceneRenderer.RemoveSceneObject(zone.id))
+        this._scoringZones.filter(zone => zone.id != -1).forEach(zone => World.SceneRenderer.RemoveSceneObject(zone.id))
         this._scoringZones = []
 
         if (this._fieldPreferences && this._fieldPreferences.scoringZones) {
@@ -455,6 +460,17 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
                 )
                 this._scoringZones.push(newZone)
                 World.SceneRenderer.RegisterSceneObject(newZone)
+            }
+        }
+    }
+
+    public RemoveScoringZoneObject(zone: ScoringZonePreferences) {
+        const index = this._fieldPreferences?.scoringZones?.indexOf(zone)
+        if (index != null) {
+            const zone = this._scoringZones[index]
+            if (zone != null) {
+                World.SceneRenderer.RemoveSceneObject(zone.id)
+                zone.id = -1
             }
         }
     }

--- a/fission/src/systems/scene/GizmoSceneObject.ts
+++ b/fission/src/systems/scene/GizmoSceneObject.ts
@@ -1,11 +1,11 @@
 import * as THREE from "three"
+import { Object3D, PerspectiveCamera } from "three"
 import SceneObject from "./SceneObject"
 import { TransformControls } from "three/examples/jsm/controls/TransformControls.js"
 import InputSystem from "../input/InputSystem"
 import World from "../World"
 import MirabufSceneObject from "@/mirabuf/MirabufSceneObject"
-import { Object3D, PerspectiveCamera } from "three"
-import { ThreeQuaternion_JoltQuat, JoltMat44_ThreeMatrix4, ThreeVector3_JoltRVec3 } from "@/util/TypeConversions"
+import { JoltMat44_ThreeMatrix4, ThreeQuaternion_JoltQuat, ThreeVector3_JoltRVec3 } from "@/util/TypeConversions"
 import { RigidNodeId } from "@/mirabuf/MirabufParser"
 
 export type GizmoMode = "translate" | "rotate" | "scale"
@@ -137,7 +137,10 @@ class GizmoSceneObject extends SceneObject {
                     event.target.setScaleSnap(isAlt ? 0.1 : null)
 
                     // scale uniformly if shift is pressed
-                    event.target.axis = isShift ? "XYZE" : null
+                    if (isShift) {
+                        event.target.axis = "XYZE"
+                    }
+
                     break
                 }
                 default: {

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/scoring/ZoneConfigInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/scoring/ZoneConfigInterface.tsx
@@ -71,6 +71,9 @@ function save(
     const rotation = new THREE.Quaternion(0, 0, 0, 1)
     const scale = new THREE.Vector3(1, 1, 1)
     gizmo.obj.matrixWorld.decompose(translation, rotation, scale)
+    scale.x = Math.abs(scale.x)
+    scale.y = Math.abs(scale.y)
+    scale.z = Math.abs(scale.z)
 
     const gizmoTransformation = new THREE.Matrix4().compose(translation, rotation, scale)
     const fieldTransformation = JoltMat44_ThreeMatrix4(World.PhysicsSystem.GetBody(nodeBodyId).GetWorldTransform())
@@ -201,6 +204,7 @@ const ZoneConfigInterface: React.FC<ZoneConfigProps> = ({ selectedField, selecte
                 gizmo.obj.position.set(props.translation.x, props.translation.y, props.translation.z)
                 gizmo.obj.rotation.setFromQuaternion(props.rotation)
                 gizmo.obj.scale.set(props.scale.x, props.scale.y, props.scale.z)
+                selectedField.RemoveScoringZoneObject(selectedZone) // avoid rendering twice
             }
 
             return (


### PR DESCRIPTION
### Description
Scoring zones previously could not be scaled non-uniformly (without holding shift), the page would crash if the scalars were negative, and would leave ghosts behind while moving an existing scoring zone. They now no longer suffer from those problems

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1913)
