### PR TITLE
Mitigate levitation issue

### DIFF
--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -72,8 +72,8 @@ export function GetLastDeltaT(): number {
 // Friction constants
 const FLOOR_FRICTION = 0.7
 const DEFAULT_FRICTION = 0.7
-const SUSPENSION_MIN_FACTOR = 0.1
-const SUSPENSION_MAX_FACTOR = 0.3
+const SUSPENSION_MIN_FACTOR = 0.0001
+const SUSPENSION_MAX_FACTOR = 0.0001
 
 const DEFAULT_PHYSICAL_MATERIAL_KEY = "default"
 

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -72,6 +72,11 @@ export function GetLastDeltaT(): number {
 // Friction constants
 const FLOOR_FRICTION = 0.7
 const DEFAULT_FRICTION = 0.7
+
+// Transition GH-1152, AARD-1885:
+// Temporary workaround to reduce visible levitation of robots by minimizing suspension.
+// Setting these values to 0 causes physics issues (e.g., ground collisionn problems).
+// Some robots still float slightly, assuming this is due to different export conditions.
 const SUSPENSION_MIN_FACTOR = 0.0001
 const SUSPENSION_MAX_FACTOR = 0.0001
 


### PR DESCRIPTION
### Description
Previously, all robots levitated a bunch and it looked really ugly, by lowering the suspension factor, some robots (like Dozer) will still levitate but not appear to do so. Other robots, however, will still have a minimum amount of levitation due to wheel suspension. I speculate that it has something to do with the physics of real vs toon robots, as that seemed to be the distinguishing factor, perhaps the dimensions or hit-boxes on the real robots are ill defined, or the wheel types work differently, I'm not really sure.  The only way to fix it for them is to set the suspension constants to `0`, which causes collision-like issues with the ground (for some reason). To fix the collision issue, I tried disabling friction and printing for collisions, however, no collisions were being triggered when the robots tried and failed to be moved forward while touching the ground. I left this mini-investigation very confused.

I'm going to come back to this ticket another time and take another crack at it, since I'm sure I could do better with a bit of inspiration and some more time to test

### Objectives
- [x] To reduce levitation
- [ ] To make all robots not need to levitate to move

### Testing Done
- Testing grounded movement with normal, increased, minimized, and no friction
- Testing collisions caused during grounded movement
- Testing how wheel suspension (and other jolt wheel settings) affect levitation and movement
  - https://jrouwe.github.io/JoltPhysicsDocs/5.1.0/class_wheel_settings.html#a29632dde4d9c95457019aa478e415345
- Testing to make sure the suspension changes don't have negative externalities

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1885)

> [!NOTE]
> This PR doesn't exactly _close_ this ticket, it's just a mitigation of the issue.
