### PR TITLE
Fix toast crashes

### DIFF
--- a/fission/src/ui/ToastContext.tsx
+++ b/fission/src/ui/ToastContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, useCallback, ReactNode } from "react"
+import React, { createContext, ReactNode, useCallback, useContext, useState } from "react"
 import Toast from "@/components/Toast"
 import { AnimatePresence, motion } from "framer-motion"
 
@@ -6,7 +6,7 @@ export type ToastType = "info" | "warning" | "error"
 
 export type ToastData = {
     id: string
-    type: ToastType
+    toastType: ToastType
     title: string
     description: string
 }
@@ -28,12 +28,12 @@ export const useToastContext = () => {
 export const ToastProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
     const [toasts, setToasts] = useState<ToastData[]>([])
 
-    const addToast = useCallback((type: ToastType, title: string, description: string) => {
+    const addToast = useCallback((toastType: ToastType, title: string, description: string) => {
         // divide by 10 so that it's harder to have duplicates? could make smaller or remove
         const id = "toast-" + Math.floor(Date.now() / 10).toString()
         const newToast: ToastData = {
             id,
-            type,
+            toastType,
             title,
             description,
         }
@@ -80,7 +80,13 @@ export const ToastContainer: React.FC = () => {
                             key={t.id}
                             className="w-fit"
                         >
-                            <Toast key={t.id} id={t.id} type={t.type} title={t.title} description={t.description} />
+                            <Toast
+                                key={t.id}
+                                id={t.id}
+                                toastType={t.toastType}
+                                title={t.title}
+                                description={t.description}
+                            />
                         </motion.div>
                     ))}
             </AnimatePresence>

--- a/fission/src/ui/components/Toast.tsx
+++ b/fission/src/ui/components/Toast.tsx
@@ -6,7 +6,7 @@ import { BiSolidErrorCircle } from "react-icons/bi"
 
 const TOAST_TIMEOUT: number = 5_000
 
-const Toast: React.FC<ToastData> = ({ id, type, title, description }) => {
+const Toast: React.FC<ToastData> = ({ id, toastType, title, description }) => {
     const { removeToast } = useToastContext()
 
     useEffect(() => {
@@ -22,7 +22,7 @@ const Toast: React.FC<ToastData> = ({ id, type, title, description }) => {
     let icon: ReactElement
     let className: string
 
-    switch (type) {
+    switch (toastType) {
         case "info":
             icon = <AiOutlineInfoCircle size={48} className="h-full w-full text-main-text" />
             className = "bg-toast-info"
@@ -39,7 +39,7 @@ const Toast: React.FC<ToastData> = ({ id, type, title, description }) => {
 
     return (
         <div
-            className={`toast toast-${type.toLowerCase()} aspect-toast relative flex flex-row ${className} px-4 py-2 content-center justify-between items-center rounded-lg shadow-md shadow-[rgba(0,0,0,0.5)]`}
+            className={`toast toast-${toastType.toLowerCase()} aspect-toast relative flex flex-row ${className} px-4 py-2 content-center justify-between items-center rounded-lg shadow-md shadow-[rgba(0,0,0,0.5)]`}
         >
             <div className="w-10 h-10 mr-1">{icon}</div>
             <div className="toast-content w-auto ml-2 text-main-text">


### PR DESCRIPTION
### Description
Dev branch was previously exhibiting intermittent page crashing with toasts (`type` was undefined). I don't see a definitive cause but I imagine it's related to the use of `type` as the parameter name. Renaming seems to have resolved the issue.

