### PR TITLE
Fix overlapping spawn and configure panels

### DIFF
--- a/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
@@ -327,6 +327,7 @@ const ConfigurePanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
 
         closePanel("choose-scheme")
         closePanel("import-mirabuf")
+        closePanel("initial-config")
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 

--- a/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
@@ -326,6 +326,7 @@ const ConfigurePanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
         }
 
         closePanel("choose-scheme")
+        closePanel("import-mirabuf")
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 


### PR DESCRIPTION
### Description
Closes the mirabuf import panel when the configure panel is opened. Prevents this behavior
![image](https://github.com/user-attachments/assets/6dfd8ef9-8635-47d1-bcc8-938a68108be7)


AARD-1992
