### PR TITLE
Intake Multiple Gamepieces

### DIFF
--- a/fission/src/systems/preferences/PreferenceTypes.ts
+++ b/fission/src/systems/preferences/PreferenceTypes.ts
@@ -46,6 +46,8 @@ export type IntakePreferences = {
     zoneDiameter: number
     parentNode: string | undefined
     showZoneAlways: boolean
+    maxPieces: number
+    ejectOrder: 'FIFO' | 'LIFO'
 }
 
 export type EjectorPreferences = {
@@ -120,6 +122,8 @@ export function DefaultRobotPreferences(): RobotPreferences {
             zoneDiameter: 0.5,
             parentNode: undefined,
             showZoneAlways: false,
+            maxPieces: 1,
+            ejectOrder: 'FIFO'
         },
         ejector: {
             deltaTransformation: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],

--- a/fission/src/systems/preferences/PreferenceTypes.ts
+++ b/fission/src/systems/preferences/PreferenceTypes.ts
@@ -47,13 +47,13 @@ export type IntakePreferences = {
     parentNode: string | undefined
     showZoneAlways: boolean
     maxPieces: number
-    ejectOrder: 'FIFO' | 'LIFO'
 }
 
 export type EjectorPreferences = {
     deltaTransformation: number[]
     ejectorVelocity: number
     parentNode: string | undefined
+    ejectOrder: 'FIFO' | 'LIFO'
 }
 
 /** The behavior types that can be sequenced. */
@@ -122,13 +122,13 @@ export function DefaultRobotPreferences(): RobotPreferences {
             zoneDiameter: 0.5,
             parentNode: undefined,
             showZoneAlways: false,
-            maxPieces: 1,
-            ejectOrder: 'FIFO'
+            maxPieces: 1
         },
         ejector: {
             deltaTransformation: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
             ejectorVelocity: 1,
             parentNode: undefined,
+            ejectOrder: 'FIFO'
         },
         driveVelocity: 0,
         driveAcceleration: 0,

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
@@ -59,7 +59,6 @@ function save(
     selectedNode?: RigidNodeId,
     showZoneAlways?: boolean,
     maxPieces?: number,
-    ejectOrder?: 'FIFO' | 'LIFO'
 ) {
     if (!selectedRobot?.intakePreferences || !gizmo) {
         return
@@ -88,7 +87,6 @@ function save(
     }
 
     selectedRobot.intakePreferences.maxPieces = maxPieces!
-    selectedRobot.intakePreferences.ejectOrder = ejectOrder!
 
     PreferencesSystem.savePreferences()
 }
@@ -107,7 +105,6 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
     const [zoneSize, setZoneSize] = useState<number>((MIN_ZONE_SIZE + MAX_ZONE_SIZE) / 2.0)
     const [showZoneAlways, setShowZoneAlways] = useState<boolean>(false)
     const [maxPieces, setMaxPieces] = useState<number>(selectedRobot.intakePreferences?.maxPieces || 1)
-    const [ejectOrder, setEjectOrder] = useState<'FIFO'|'LIFO'>(selectedRobot.intakePreferences?.ejectOrder || 'FIFO')
 
     const gizmoRef = useRef<GizmoSceneObject | undefined>(undefined)
 
@@ -190,7 +187,6 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
             setZoneSize(selectedRobot.intakePreferences.zoneDiameter)
             setSelectedNode(selectedRobot.intakePreferences.parentNode)
             setMaxPieces(selectedRobot.intakePreferences.maxPieces)
-            setEjectOrder(selectedRobot.intakePreferences.ejectOrder)
             setShowZoneAlways(selectedRobot.intakePreferences.showZoneAlways ?? false)
         } else {
             setSelectedNode(undefined)
@@ -260,23 +256,10 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
                 min={1}
                 max={10}
                 step={1}
-                value={maxPieces}
+                value={maxPieces ?? 1} 
                 label="Max Pieces"
                 onChange={(_, v) => setMaxPieces(v as number)}
             />
-
-            {/* Toggle for adjusting eject order */}
-            <div className="mt-4 flex items-center space-x-2">
-                <span>Eject Order</span>
-                <ToggleButtonGroup
-                value={ejectOrder}
-                exclusive
-                onChange={(_, v) => v && setEjectOrder(v as "FIFO" | "LIFO")}
-                >
-                <ToggleButton value="FIFO">FIFO</ToggleButton>
-                <ToggleButton value="LIFO">LIFO</ToggleButton>
-                </ToggleButtonGroup>
-            </div>
 
             {/* Checkbox for showing intake zone indicator at all times */}
             <Box
@@ -350,7 +333,6 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
                     setZoneSize(0.5)
                     setSelectedNode(selectedRobot?.rootNodeId)
                     setMaxPieces(selectedRobot.intakePreferences?.maxPieces ?? 1)
-                    setEjectOrder(selectedRobot.intakePreferences?.ejectOrder ?? 'FIFO')
                 }}
             />
         </>

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
@@ -23,6 +23,7 @@ import { PAUSE_REF_ASSEMBLY_CONFIG } from "@/systems/physics/PhysicsSystem"
 import { Box } from "@mui/material"
 import { Switch } from "@mui/base/Switch"
 import Label, { LabelSize } from "@/ui/components/Label"
+import { ToggleButton, ToggleButtonGroup } from "@/ui/components/ToggleButtonGroup"
 
 // slider constants
 const MIN_ZONE_SIZE = 0.1
@@ -56,7 +57,9 @@ function save(
     gizmo: GizmoSceneObject,
     selectedRobot: MirabufSceneObject,
     selectedNode?: RigidNodeId,
-    showZoneAlways?: boolean
+    showZoneAlways?: boolean,
+    maxPieces?: number,
+    ejectOrder?: 'FIFO' | 'LIFO'
 ) {
     if (!selectedRobot?.intakePreferences || !gizmo) {
         return
@@ -84,6 +87,9 @@ function save(
         selectedRobot.intakePreferences.showZoneAlways = showZoneAlways
     }
 
+    selectedRobot.intakePreferences.maxPieces = maxPieces!
+    selectedRobot.intakePreferences.ejectOrder = ejectOrder!
+
     PreferencesSystem.savePreferences()
 }
 
@@ -100,6 +106,8 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
     const [selectedNode, setSelectedNode] = useState<RigidNodeId | undefined>(undefined)
     const [zoneSize, setZoneSize] = useState<number>((MIN_ZONE_SIZE + MAX_ZONE_SIZE) / 2.0)
     const [showZoneAlways, setShowZoneAlways] = useState<boolean>(false)
+    const [maxPieces, setMaxPieces] = useState<number>(selectedRobot.intakePreferences?.maxPieces || 1)
+    const [ejectOrder, setEjectOrder] = useState<'FIFO'|'LIFO'>(selectedRobot.intakePreferences?.ejectOrder || 'FIFO')
 
     const gizmoRef = useRef<GizmoSceneObject | undefined>(undefined)
 
@@ -181,6 +189,8 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
         if (selectedRobot?.intakePreferences) {
             setZoneSize(selectedRobot.intakePreferences.zoneDiameter)
             setSelectedNode(selectedRobot.intakePreferences.parentNode)
+            setMaxPieces(selectedRobot.intakePreferences.maxPieces)
+            setEjectOrder(selectedRobot.intakePreferences.ejectOrder)
             setShowZoneAlways(selectedRobot.intakePreferences.showZoneAlways ?? false)
         } else {
             setSelectedNode(undefined)
@@ -244,6 +254,30 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
                 }}
                 step={0.01}
             />
+
+            {/* Slider for adjusting max pieces the robot can intake */}
+            <Slider
+                min={1}
+                max={10}
+                step={1}
+                value={maxPieces}
+                label="Max Pieces"
+                onChange={(_, v) => setMaxPieces(v as number)}
+            />
+
+            {/* Toggle for adjusting eject order */}
+            <div className="mt-4 flex items-center space-x-2">
+                <span>Eject Order</span>
+                <ToggleButtonGroup
+                value={ejectOrder}
+                exclusive
+                onChange={(_, v) => v && setEjectOrder(v as "FIFO" | "LIFO")}
+                >
+                <ToggleButton value="FIFO">FIFO</ToggleButton>
+                <ToggleButton value="LIFO">LIFO</ToggleButton>
+                </ToggleButtonGroup>
+            </div>
+
             {/* Checkbox for showing intake zone indicator at all times */}
             <Box
                 display="flex"
@@ -315,6 +349,8 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
                     }
                     setZoneSize(0.5)
                     setSelectedNode(selectedRobot?.rootNodeId)
+                    setMaxPieces(selectedRobot.intakePreferences?.maxPieces ?? 1)
+                    setEjectOrder(selectedRobot.intakePreferences?.ejectOrder ?? 'FIFO')
                 }}
             />
         </>

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureShotTrajectoryInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureShotTrajectoryInterface.tsx
@@ -20,6 +20,7 @@ import { Spacer } from "@/ui/components/StyledComponents"
 import GizmoSceneObject from "@/systems/scene/GizmoSceneObject"
 import TransformGizmoControl from "@/ui/components/TransformGizmoControl"
 import { PAUSE_REF_ASSEMBLY_CONFIG } from "@/systems/physics/PhysicsSystem"
+import { ToggleButtonGroup, ToggleButton } from "@mui/material"
 
 // slider constants
 const MIN_VELOCITY = 0.0
@@ -52,7 +53,8 @@ function save(
     ejectorVelocity: number,
     gizmo: GizmoSceneObject,
     selectedRobot: MirabufSceneObject,
-    selectedNode?: RigidNodeId
+    selectedNode?: RigidNodeId,
+    ejectOrder?: 'FIFO' | 'LIFO'
 ) {
     if (!selectedRobot?.ejectorPreferences || !gizmo) {
         return
@@ -73,6 +75,8 @@ function save(
     selectedRobot.ejectorPreferences.parentNode = selectedNode
     selectedRobot.ejectorPreferences.ejectorVelocity = ejectorVelocity
 
+    selectedRobot.ejectorPreferences.ejectOrder = ejectOrder!
+
     PreferencesSystem.savePreferences()
 }
 
@@ -88,6 +92,7 @@ const ConfigureShotTrajectoryInterface: React.FC<ConfigEjectorProps> = ({ select
 
     const [selectedNode, setSelectedNode] = useState<RigidNodeId | undefined>(undefined)
     const [ejectorVelocity, setEjectorVelocity] = useState<number>((MIN_VELOCITY + MAX_VELOCITY) / 2.0)
+    const [ejectOrder, setEjectOrder] = useState<'FIFO'|'LIFO'>(selectedRobot.ejectorPreferences?.ejectOrder || 'FIFO')
 
     const gizmoRef = useRef<GizmoSceneObject | undefined>(undefined)
 
@@ -163,6 +168,7 @@ const ConfigureShotTrajectoryInterface: React.FC<ConfigEjectorProps> = ({ select
         if (selectedRobot?.ejectorPreferences) {
             setEjectorVelocity(selectedRobot.ejectorPreferences.ejectorVelocity)
             setSelectedNode(selectedRobot.ejectorPreferences.parentNode)
+            setEjectOrder(selectedRobot.ejectorPreferences.ejectOrder)
         } else {
             setSelectedNode(undefined)
         }
@@ -214,6 +220,20 @@ const ConfigureShotTrajectoryInterface: React.FC<ConfigEjectorProps> = ({ select
                 }}
                 step={0.01}
             />
+
+            {/* Toggle for adjusting eject order */}
+                <div className="mt-4 flex items-center space-x-2">
+                <span>Eject Order</span>
+                <ToggleButtonGroup
+                    value={ejectOrder}
+                    exclusive
+                    onChange={(_, v) => v && setEjectOrder(v as "FIFO" | "LIFO")}
+                >
+                <ToggleButton value="FIFO">FIFO</ToggleButton>
+                <ToggleButton value="LIFO">LIFO</ToggleButton>
+                </ToggleButtonGroup>
+            </div>
+            
             {gizmoComponent}
             {Spacer(10)}
             <Button
@@ -228,6 +248,7 @@ const ConfigureShotTrajectoryInterface: React.FC<ConfigEjectorProps> = ({ select
                     }
                     setEjectorVelocity(1)
                     setSelectedNode(selectedRobot?.rootNodeId)
+                    setEjectOrder(selectedRobot.ejectorPreferences?.ejectOrder ?? 'FIFO')
                 }}
             />
         </>


### PR DESCRIPTION
Adds support for buffered gamepiece intake and configurable ejection order. Robots can now:

- Intake up to `maxPieces` simultaneously (from `intakePreferences`)
- Eject in either FIFO or LIFO order (based on `ejectorPreferences.ejectOrder`)

Behavior is integrated into existing intake/eject flow and scoring logic.
![Screenshot 2025-06-23 135551](https://github.com/user-attachments/assets/cc28a836-e2a5-4138-82ca-f92a34236cdc)
![Screenshot 2025-06-23 135625](https://github.com/user-attachments/assets/3fb0efd0-a385-46fb-b718-e93606b27193)

