### PR TITLE
vite.config.ts Updated `[AARD-1953]`

### DIFF
--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -26,7 +26,7 @@ const plugins = [
         exclude: undefined, // Glob pattern, or array of glob patterns to ignore
         warnDuplicatedImports: true, // Warn if the same chunk was imported multiple times
         defaultExtension: "glsl", // Shader suffix when no extension is specified
-        compress: false, // Compress output shader code
+        minify: false, // Minify/optimize output shader code
         watch: true, // Recompile shader on change
         root: "/", // Directory for root imports
     }),

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "vitest/config"
-import * as path from "path"
-import react from "@vitejs/plugin-react-swc"
-import basicSsl from "@vitejs/plugin-basic-ssl"
-import glsl from "vite-plugin-glsl"
+import { defineConfig } from 'vitest/config'
+import * as path from 'path'
+import react from '@vitejs/plugin-react-swc'
+import basicSsl from '@vitejs/plugin-basic-ssl'
+import glsl from 'vite-plugin-glsl'
 
 const basePath = "/fission/"
 const serverPort = 3000
@@ -12,24 +12,19 @@ const useLocal = false
 const useSsl = false
 
 const plugins = [
-    react(),
-    glsl({
-        include: [
-            // Glob pattern, or array of glob patterns to import
-            "**/*.glsl",
-            "**/*.wgsl",
-            "**/*.vert",
-            "**/*.frag",
-            "**/*.vs",
-            "**/*.fs",
+    react(), glsl({
+        include: [                   // Glob pattern, or array of glob patterns to import
+          '**/*.glsl', '**/*.wgsl',
+          '**/*.vert', '**/*.frag',
+          '**/*.vs', '**/*.fs'
         ],
-        exclude: undefined, // Glob pattern, or array of glob patterns to ignore
+        exclude: undefined,          // Glob pattern, or array of glob patterns to ignore
         warnDuplicatedImports: true, // Warn if the same chunk was imported multiple times
-        defaultExtension: "glsl", // Shader suffix when no extension is specified
-        minify: false, // Minify/optimize output shader code
-        watch: true, // Recompile shader on change
-        root: "/", // Directory for root imports
-    }),
+        defaultExtension: 'glsl',    // Shader suffix when no extension is specified
+        minify: false,               // Minify/optimize output shader code
+        watch: true,                 // Recompile shader on change
+        root: '/'                    // Directory for root imports
+    })
 ]
 
 if (useSsl) {

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
         ],
     },
     test: {
-        testTimeout: 30000,
+        testTimeout: 60000,
         globals: true,
         environment: "jsdom",
         browser: {

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from 'vitest/config'
-import * as path from 'path'
-import react from '@vitejs/plugin-react-swc'
-import basicSsl from '@vitejs/plugin-basic-ssl'
-import glsl from 'vite-plugin-glsl'
+import { defineConfig } from "vitest/config"
+import * as path from "path"
+import react from "@vitejs/plugin-react-swc"
+import basicSsl from "@vitejs/plugin-basic-ssl"
+import glsl from "vite-plugin-glsl"
 
 const basePath = "/fission/"
 const serverPort = 3000
@@ -12,19 +12,24 @@ const useLocal = false
 const useSsl = false
 
 const plugins = [
-    react(), glsl({
-        include: [                   // Glob pattern, or array of glob patterns to import
-          '**/*.glsl', '**/*.wgsl',
-          '**/*.vert', '**/*.frag',
-          '**/*.vs', '**/*.fs'
+    react(),
+    glsl({
+        include: [
+            // Glob pattern, or array of glob patterns to import
+            "**/*.glsl",
+            "**/*.wgsl",
+            "**/*.vert",
+            "**/*.frag",
+            "**/*.vs",
+            "**/*.fs",
         ],
-        exclude: undefined,          // Glob pattern, or array of glob patterns to ignore
+        exclude: undefined, // Glob pattern, or array of glob patterns to ignore
         warnDuplicatedImports: true, // Warn if the same chunk was imported multiple times
-        defaultExtension: 'glsl',    // Shader suffix when no extension is specified
-        minify: false,               // Minify/optimize output shader code
-        watch: true,                 // Recompile shader on change
-        root: '/'                    // Directory for root imports
-    })
+        defaultExtension: "glsl", // Shader suffix when no extension is specified
+        minify: false, // Minify/optimize output shader code
+        watch: true, // Recompile shader on change
+        root: "/", // Directory for root imports
+    }),
 ]
 
 if (useSsl) {
@@ -43,7 +48,7 @@ export default defineConfig({
         ],
     },
     test: {
-        testTimeout: 60000,
+        testTimeout: 10000,
         globals: true,
         environment: "jsdom",
         browser: {

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from 'vitest/config'
-import * as path from 'path'
-import react from '@vitejs/plugin-react-swc'
-import basicSsl from '@vitejs/plugin-basic-ssl'
-import glsl from 'vite-plugin-glsl'
+import { defineConfig } from "vitest/config"
+import * as path from "path"
+import react from "@vitejs/plugin-react-swc"
+import basicSsl from "@vitejs/plugin-basic-ssl"
+import glsl from "vite-plugin-glsl"
 
 const basePath = "/fission/"
 const serverPort = 3000
@@ -12,19 +12,24 @@ const useLocal = false
 const useSsl = false
 
 const plugins = [
-    react(), glsl({
-        include: [                   // Glob pattern, or array of glob patterns to import
-          '**/*.glsl', '**/*.wgsl',
-          '**/*.vert', '**/*.frag',
-          '**/*.vs', '**/*.fs'
+    react(),
+    glsl({
+        include: [
+            // Glob pattern, or array of glob patterns to import
+            "**/*.glsl",
+            "**/*.wgsl",
+            "**/*.vert",
+            "**/*.frag",
+            "**/*.vs",
+            "**/*.fs",
         ],
-        exclude: undefined,          // Glob pattern, or array of glob patterns to ignore
+        exclude: undefined, // Glob pattern, or array of glob patterns to ignore
         warnDuplicatedImports: true, // Warn if the same chunk was imported multiple times
-        defaultExtension: 'glsl',    // Shader suffix when no extension is specified
-        compress: false,             // Compress output shader code
-        watch: true,                 // Recompile shader on change
-        root: '/'                    // Directory for root imports
-    })
+        defaultExtension: "glsl", // Shader suffix when no extension is specified
+        compress: false, // Compress output shader code
+        watch: true, // Recompile shader on change
+        root: "/", // Directory for root imports
+    }),
 ]
 
 if (useSsl) {
@@ -43,14 +48,24 @@ export default defineConfig({
         ],
     },
     test: {
-        testTimeout: 10000,
+        testTimeout: 30000,
         globals: true,
         environment: "jsdom",
         browser: {
             enabled: true,
-            name: "chromium",
-            headless: true,
             provider: "playwright",
+            instances: [
+                {
+                    name: "chromium",
+                    browser: "chromium",
+                    headless: true,
+                },
+                {
+                    name: "firefox",
+                    browser: "firefox",
+                    headless: true,
+                },
+            ],
         },
     },
     server: {


### PR DESCRIPTION
### Description
Update vite.config.ts to not use browser.name which is depreciated since Vite 3. All the unit tests also now run in both the Chromium and Firefox environment
<img width="1118" alt="Screenshot 2025-06-24 at 4 06 39 PM" src="https://github.com/user-attachments/assets/595715c2-4524-4815-8804-c4b550dedb61" />

### Testing Done
- Unit tests run and pass in Chromium
- Unit tests run and pass in Firefox

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1953)
