### PR TITLE
Remove init scripts

### DIFF
--- a/init.bat
+++ b/init.bat
@@ -1,6 +1,0 @@
-@echo off
-
-git submodule update --init --recursive
-cd protocols
-call proto_compile.bat
-cd ..

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-git submodule update --init --recursive
-cd protocols
-./proto_compile.sh
-cd ..


### PR DESCRIPTION
These files were left over after #987, and they persist in their stripped down version.

Currently the only thing they do is:
1. Update the submodules and
2. compile the protobuf protocols from within `/protocols/`.

But even for then they are just calling the compile scripts within `/protocols/`. As such I think its time to retire these scripts.