### PR TITLE
Bulk Actions Assets

### DIFF
--- a/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
+++ b/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
@@ -376,17 +376,23 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
             )
     }, [manifest?.fields, cachedFields, selectRemote])
 
-    const downloadAllRemotesRobots = useCallback(() => {
-        manifest?.robots
-            .filter(path => !cachedRobots.some(info => info.cacheKey.includes(path.src)))
-            .forEach(path => cacheRemoteOnly(path, MiraType.ROBOT))
-    }, [manifest, cachedRobots, cacheRemoteOnly])
+    function downloadAllRemote(cached: MirabufCacheInfo[]): () => void {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        return useCallback(() => {
+            const miraType: MiraType | undefined = cached[0]?.miraType
+            const property = miraType === MiraType.ROBOT ? "robots" : "fields"
+            const remotes = manifest ? manifest[property] : []
 
-    const downloadAllRemotesFields = useCallback(() => {
-        manifest?.fields
-            .filter(path => !cachedFields.some(info => info.cacheKey.includes(path.src)))
-            .forEach(path => cacheRemoteOnly(path, MiraType.FIELD))
-    }, [manifest, cachedFields, cacheRemoteOnly])
+            remotes
+                .filter(path => !cached.some(info => info.cacheKey.includes(path.src)))
+                .forEach(path => cacheRemoteOnly(path, miraType))
+
+            closePanel(panelId)
+        }, [manifest, cached, cacheRemoteOnly, closePanel, panelId])
+    }
+
+    const downloadAllRemoteRobots = downloadAllRemote(cachedRobots)
+    const downloadAllRemoteFields = downloadAllRemote(cachedFields)
 
     // Generate Item cards for APS robots and fields.
     const hubElements = useMemo(
@@ -484,7 +490,9 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
                         </SectionLabel>
                         <SectionDivider />
                         {remoteRobotElements}
-                        <PositiveButton value="Download All" onClick={downloadAllRemotesRobots} />
+                        <Box display="flex" justifyContent="center" mt={1}>
+                            <PositiveButton value="Download All" onClick={downloadAllRemoteRobots} />
+                        </Box>
                     </>
                 ) : (
                     <>
@@ -495,7 +503,9 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
                         </SectionLabel>
                         <SectionDivider />
                         {remoteFieldElements}
-                        <PositiveButton value="Download All" onClick={downloadAllRemotesFields} />
+                        <Box display="flex" justifyContent="center" mt={1}>
+                            <PositiveButton value="Download All" onClick={downloadAllRemoteFields} />
+                        </Box>
                     </>
                 )}
                 <Box alignSelf={"center"}>

--- a/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
+++ b/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
@@ -251,23 +251,20 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
     )
 
     // Cache a selected remote mirabuf assembly, without load.
-    const cacheRemoteOnly = useCallback(
-    (info: MirabufRemoteInfo, type: MiraType) => {
+    const cacheRemoteOnly = useCallback((info: MirabufRemoteInfo, type: MiraType) => {
         const status = new ProgressHandle(info.displayName)
         status.Update("Downloading from Synthesis...", 0.05)
 
         MirabufCachingService.CacheRemote(info.src, type)
-        .then(cacheInfo => {
-            if (cacheInfo) {
-            status.Done()
-            } else {
-            status.Fail("Failed to cache")
-            }
-        })
-        .catch(() => status.Fail())
-    },
-    []
-    )
+            .then(cacheInfo => {
+                if (cacheInfo) {
+                    status.Done()
+                } else {
+                    status.Fail("Failed to cache")
+                }
+            })
+            .catch(() => status.Fail())
+    }, [])
 
     const selectAPS = useCallback(
         (data: Data, type: MiraType) => {
@@ -380,16 +377,16 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
     }, [manifest?.fields, cachedFields, selectRemote])
 
     const downloadAllRemotesRobots = useCallback(() => {
-    manifest?.robots
-        .filter(path => !cachedRobots.some(info => info.cacheKey.includes(path.src)))
-        .forEach(path => cacheRemoteOnly(path, MiraType.ROBOT));
-    }, [manifest, cachedRobots, cacheRemoteOnly]);
+        manifest?.robots
+            .filter(path => !cachedRobots.some(info => info.cacheKey.includes(path.src)))
+            .forEach(path => cacheRemoteOnly(path, MiraType.ROBOT))
+    }, [manifest, cachedRobots, cacheRemoteOnly])
 
     const downloadAllRemotesFields = useCallback(() => {
-    manifest?.fields
-        .filter(path => !cachedFields.some(info => info.cacheKey.includes(path.src)))
-        .forEach(path => cacheRemoteOnly(path, MiraType.FIELD));
-    }, [manifest, cachedFields, cacheRemoteOnly]);
+        manifest?.fields
+            .filter(path => !cachedFields.some(info => info.cacheKey.includes(path.src)))
+            .forEach(path => cacheRemoteOnly(path, MiraType.FIELD))
+    }, [manifest, cachedFields, cacheRemoteOnly])
 
     // Generate Item cards for APS robots and fields.
     const hubElements = useMemo(
@@ -487,7 +484,7 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
                         </SectionLabel>
                         <SectionDivider />
                         {remoteRobotElements}
-                        <Button value="Download All" onClick={downloadAllRemotesRobots} />
+                        <PositiveButton value="Download All" onClick={downloadAllRemotesRobots} />
                     </>
                 ) : (
                     <>
@@ -498,7 +495,7 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
                         </SectionLabel>
                         <SectionDivider />
                         {remoteFieldElements}
-                        <Button value="Download All" onClick={downloadAllRemotesFields} />
+                        <PositiveButton value="Download All" onClick={downloadAllRemotesFields} />
                     </>
                 )}
                 <Box alignSelf={"center"}>

--- a/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
+++ b/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
@@ -250,6 +250,25 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
         [closePanel, panelId]
     )
 
+    // Cache a selected remote mirabuf assembly, without load.
+    const cacheRemoteOnly = useCallback(
+    (info: MirabufRemoteInfo, type: MiraType) => {
+        const status = new ProgressHandle(info.displayName)
+        status.Update("Downloading from Synthesis...", 0.05)
+
+        MirabufCachingService.CacheRemote(info.src, type)
+        .then(cacheInfo => {
+            if (cacheInfo) {
+            status.Done()
+            } else {
+            status.Fail("Failed to cache")
+            }
+        })
+        .catch(() => status.Fail())
+    },
+    []
+    )
+
     const selectAPS = useCallback(
         (data: Data, type: MiraType) => {
             const status = new ProgressHandle(data.attributes.displayName ?? data.id)
@@ -360,6 +379,18 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
             )
     }, [manifest?.fields, cachedFields, selectRemote])
 
+    const downloadAllRemotesRobots = useCallback(() => {
+    manifest?.robots
+        .filter(path => !cachedRobots.some(info => info.cacheKey.includes(path.src)))
+        .forEach(path => cacheRemoteOnly(path, MiraType.ROBOT));
+    }, [manifest, cachedRobots, cacheRemoteOnly]);
+
+    const downloadAllRemotesFields = useCallback(() => {
+    manifest?.fields
+        .filter(path => !cachedFields.some(info => info.cacheKey.includes(path.src)))
+        .forEach(path => cacheRemoteOnly(path, MiraType.FIELD));
+    }, [manifest, cachedFields, cacheRemoteOnly]);
+
     // Generate Item cards for APS robots and fields.
     const hubElements = useMemo(
         () =>
@@ -456,6 +487,7 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
                         </SectionLabel>
                         <SectionDivider />
                         {remoteRobotElements}
+                        <Button value="Download All" onClick={downloadAllRemotesRobots} />
                     </>
                 ) : (
                     <>
@@ -466,6 +498,7 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
                         </SectionLabel>
                         <SectionDivider />
                         {remoteFieldElements}
+                        <Button value="Download All" onClick={downloadAllRemotesFields} />
                     </>
                 )}
                 <Box alignSelf={"center"}>


### PR DESCRIPTION
Adds a "Download All" button to the "Default Robots" and "Default Fields" sections in the Configure Assets panel. It allows users to pre-cache all remote assets without spawning them into the scene. Existing individual asset selection behavior remains unchanged.

![Screenshot 2025-06-25 080534](https://github.com/user-attachments/assets/e30957e7-0d2a-47dd-9cb9-331bf2609f28)
![Screenshot 2025-06-25 080550](https://github.com/user-attachments/assets/947c1d3d-21a2-41ca-9a67-0b4ac09205a4)

