### PR TITLE
Sensitivity Sliders

### DIFF
--- a/fission/src/systems/preferences/PreferenceTypes.ts
+++ b/fission/src/systems/preferences/PreferenceTypes.ts
@@ -7,6 +7,8 @@ export type GlobalPreference =
     | "ZoomSensitivity"
     | "PitchSensitivity"
     | "YawSensitivity"
+    | "SceneRotationSensitivity"
+    | "ViewCubeRotationSensitivity"
     | "ReportAnalytics"
     | "UseMetric"
     | "RenderScoringZones"
@@ -32,6 +34,8 @@ export const DefaultGlobalPreferences: { [key: string]: unknown } = {
     ZoomSensitivity: 15,
     PitchSensitivity: 10,
     YawSensitivity: 3,
+    SceneRotationSensitivity: 0.5,
+    ViewCubeRotationSensitivity: 0.025,
     ReportAnalytics: false,
     UseMetric: false,
     RenderScoringZones: true,

--- a/fission/src/systems/scene/CameraControls.ts
+++ b/fission/src/systems/scene/CameraControls.ts
@@ -251,8 +251,10 @@ export class CustomOrbitControls extends CameraControls {
               }
             : { theta: 0, phi: 0, r: 0 }
 
-        this._coords.theta += omega.theta * deltaT * PreferencesSystem.getGlobalPreference<number>("SceneRotationSensitivity")
-        this._coords.phi += omega.phi * deltaT * PreferencesSystem.getGlobalPreference<number>("SceneRotationSensitivity")
+        this._coords.theta +=
+            omega.theta * deltaT * PreferencesSystem.getGlobalPreference<number>("SceneRotationSensitivity")
+        this._coords.phi +=
+            omega.phi * deltaT * PreferencesSystem.getGlobalPreference<number>("SceneRotationSensitivity")
         this._coords.r += omega.r * deltaT * CO_SENSITIVITY_ZOOM * Math.pow(this._coords.r, 1.4)
 
         this._coords.phi = Math.min(CO_MAX_PHI, Math.max(CO_MIN_PHI, this._coords.phi))

--- a/fission/src/systems/scene/CameraControls.ts
+++ b/fission/src/systems/scene/CameraControls.ts
@@ -7,6 +7,7 @@ import ScreenInteractionHandler, {
     PRIMARY_MOUSE_INTERACTION,
     SECONDARY_MOUSE_INTERACTION,
 } from "./ScreenInteractionHandler"
+import PreferencesSystem from "@/systems/preferences/PreferencesSystem"
 
 export type CameraControlsType = "Orbit"
 
@@ -43,8 +44,6 @@ const CO_MAX_PHI = Math.PI / 2.1
 const CO_MIN_PHI = -Math.PI / 2.1
 
 const CO_SENSITIVITY_ZOOM = 4.0
-const CO_SENSITIVITY_PHI = 0.5
-const CO_SENSITIVITY_THETA = 0.5
 
 const CO_DEFAULT_ZOOM = 3.5
 const CO_DEFAULT_PHI = -Math.PI / 6.0
@@ -252,8 +251,8 @@ export class CustomOrbitControls extends CameraControls {
               }
             : { theta: 0, phi: 0, r: 0 }
 
-        this._coords.theta += omega.theta * deltaT * CO_SENSITIVITY_THETA
-        this._coords.phi += omega.phi * deltaT * CO_SENSITIVITY_PHI
+        this._coords.theta += omega.theta * deltaT * PreferencesSystem.getGlobalPreference<number>("SceneRotationSensitivity")
+        this._coords.phi += omega.phi * deltaT * PreferencesSystem.getGlobalPreference<number>("SceneRotationSensitivity")
         this._coords.r += omega.r * deltaT * CO_SENSITIVITY_ZOOM * Math.pow(this._coords.r, 1.4)
 
         this._coords.phi = Math.min(CO_MAX_PHI, Math.max(CO_MIN_PHI, this._coords.phi))

--- a/fission/src/ui/components/ViewCube.tsx
+++ b/fission/src/ui/components/ViewCube.tsx
@@ -3,6 +3,7 @@ import * as THREE from "three"
 import { Box } from "@mui/material"
 import World from "@/systems/World"
 import { CustomOrbitControls } from "@/systems/scene/CameraControls"
+import PreferencesSystem from "@/systems/preferences/PreferencesSystem"
 
 interface ViewCubeProps {
     size?: number
@@ -67,7 +68,7 @@ const ViewCube: React.FC<ViewCubeProps> = ({
                 const deltaX = event.clientX - lastMousePos.x
                 const deltaY = event.clientY - lastMousePos.y
 
-                const sensitivity = 0.025
+                const sensitivity = PreferencesSystem.getGlobalPreference<number>("ViewCubeRotationSensitivity")
 
                 const controls = World.SceneRenderer.currentCameraControls
                 if (controls instanceof CustomOrbitControls) {
@@ -821,7 +822,7 @@ const ViewCube: React.FC<ViewCubeProps> = ({
             const deltaX = event.clientX - lastMousePos.x
             const deltaY = event.clientY - lastMousePos.y
 
-            const sensitivity = 0.004
+            const sensitivity = PreferencesSystem.getGlobalPreference<number>("ViewCubeRotationSensitivity")
 
             const controls = World.SceneRenderer.currentCameraControls
             if (controls instanceof CustomOrbitControls) {

--- a/fission/src/ui/modals/configuring/SettingsModal.tsx
+++ b/fission/src/ui/modals/configuring/SettingsModal.tsx
@@ -53,6 +53,12 @@ const SettingsModal: React.FC<ModalPropsImpl> = ({ modalId }) => {
         PreferencesSystem.getGlobalPreference<boolean>("MuteAllSound")
     )
     const [sfxVolume, setSFXVolume] = useState<number>(PreferencesSystem.getGlobalPreference<number>("SFXVolume"))
+    const [sceneRotationSensitivity, setSceneRotationSensitivity] = useState<number>(
+        PreferencesSystem.getGlobalPreference<number>("SceneRotationSensitivity")
+    )
+    const [viewCubeRotationSensitivity, setViewCubeRotationSensitivity] = useState<number>(
+        PreferencesSystem.getGlobalPreference<number>("ViewCubeRotationSensitivity")
+    )
 
     const saveSettings = () => {
         PreferencesSystem.setGlobalPreference<boolean>("ReportAnalytics", reportAnalytics)
@@ -63,6 +69,8 @@ const SettingsModal: React.FC<ModalPropsImpl> = ({ modalId }) => {
         PreferencesSystem.setGlobalPreference<boolean>("ShowViewCube", showViewCube)
         PreferencesSystem.setGlobalPreference<boolean>("MuteAllSound", muteAllSound)
         PreferencesSystem.setGlobalPreference<number>("SFXVolume", sfxVolume)
+        PreferencesSystem.setGlobalPreference<number>("SceneRotationSensitivity", sceneRotationSensitivity)
+        PreferencesSystem.setGlobalPreference<number>("ViewCubeRotationSensitivity", viewCubeRotationSensitivity)
 
         SoundPlayer.changeVolume() // Apply the new sound volume
 
@@ -126,6 +134,29 @@ const SettingsModal: React.FC<ModalPropsImpl> = ({ modalId }) => {
                     onChange={(_, value) => setYawSensitivity(value as number)}
                     tooltipText="Moving the camera left and right."
                 />*/}
+                {Spacer(5)}
+                <Label size={LabelSize.Medium}>Camera Settings</Label>
+                <Slider
+                    min={0.1}
+                    max={2.0}
+                    value={sceneRotationSensitivity}
+                    label={"Scene Rotation Sensitivity"}
+                    format={{ maximumFractionDigits: 2 }}
+                    onChange={(_, value) => setSceneRotationSensitivity(value as number)}
+                    step={0.1}
+                    tooltipText="Controls how fast the scene rotates when dragging with the mouse."
+                />
+                {Spacer(2)}
+                <Slider
+                    min={0.001}
+                    max={0.1}
+                    value={viewCubeRotationSensitivity}
+                    label={"ViewCube Rotation Sensitivity"}
+                    format={{ maximumFractionDigits: 3 }}
+                    onChange={(_, value) => setViewCubeRotationSensitivity(value as number)}
+                    step={0.001}
+                    tooltipText="Controls how fast the view changes when dragging on the view cube."
+                />
                 {Spacer(10)}
                 <Label size={LabelSize.Medium}>Preferences</Label>
                 <Box display="flex" flexDirection={"column"}>

--- a/fission/src/ui/modals/configuring/SettingsModal.tsx
+++ b/fission/src/ui/modals/configuring/SettingsModal.tsx
@@ -57,7 +57,7 @@ const SettingsModal: React.FC<ModalPropsImpl> = ({ modalId }) => {
         PreferencesSystem.getGlobalPreference<number>("SceneRotationSensitivity")
     )
     const [viewCubeRotationSensitivity, setViewCubeRotationSensitivity] = useState<number>(
-        PreferencesSystem.getGlobalPreference<number>("ViewCubeRotationSensitivity")
+        PreferencesSystem.getGlobalPreference<number>("ViewCubeRotationSensitivity") * 60
     )
 
     const saveSettings = () => {
@@ -70,7 +70,7 @@ const SettingsModal: React.FC<ModalPropsImpl> = ({ modalId }) => {
         PreferencesSystem.setGlobalPreference<boolean>("MuteAllSound", muteAllSound)
         PreferencesSystem.setGlobalPreference<number>("SFXVolume", sfxVolume)
         PreferencesSystem.setGlobalPreference<number>("SceneRotationSensitivity", sceneRotationSensitivity)
-        PreferencesSystem.setGlobalPreference<number>("ViewCubeRotationSensitivity", viewCubeRotationSensitivity)
+        PreferencesSystem.setGlobalPreference<number>("ViewCubeRotationSensitivity", viewCubeRotationSensitivity / 60)
 
         SoundPlayer.changeVolume() // Apply the new sound volume
 
@@ -148,13 +148,13 @@ const SettingsModal: React.FC<ModalPropsImpl> = ({ modalId }) => {
                 />
                 {Spacer(2)}
                 <Slider
-                    min={0.001}
-                    max={0.1}
+                    min={0.06}
+                    max={6.0}
                     value={viewCubeRotationSensitivity}
                     label={"ViewCube Rotation Sensitivity"}
-                    format={{ maximumFractionDigits: 3 }}
+                    format={{ maximumFractionDigits: 2 }}
                     onChange={(_, value) => setViewCubeRotationSensitivity(value as number)}
-                    step={0.001}
+                    step={0.06}
                     tooltipText="Controls how fast the view changes when dragging on the view cube."
                 />
                 {Spacer(10)}


### PR DESCRIPTION
This PR adds sensitivity sliders to general settings that allow the user to modify the DPI required to rotate the scene, and to rotate the scene using the Viewcube. The bounds on the sensitivity are higher on the Viewcube, because it's typically used for faster rotation (giving a "zoomed out" feel).

<img width="297" alt="image" src="https://github.com/user-attachments/assets/56a46a0c-0bfa-41d3-89e8-99fc83f0dfb6" />
