### PR TITLE
Configure Ejectable Toast

### DIFF
--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -31,7 +31,7 @@ import {
     ConfigMode,
     setNextConfigurePanelSettings,
 } from "@/ui/panels/configuring/assembly-config/ConfigurePanelControls"
-import { Global_OpenPanel } from "@/ui/components/GlobalUIControls"
+import { Global_AddToast, Global_OpenPanel } from "@/ui/components/GlobalUIControls"
 import {
     ConfigurationType,
     setSelectedConfigurationType,
@@ -86,6 +86,8 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
 
     private _intakeActive = false
     private _ejectorActive = false
+
+    private _ejectableToastShown = false
 
     public get intakeActive() {
         return this._intakeActive
@@ -438,7 +440,15 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
         }
 
         if (!this._ejectorPreferences || !this._ejectorPreferences.parentNode || !bodyId) {
-            console.log(`Configure an ejectable first.`)
+            if (!this._ejectableToastShown) {
+                console.log(`Configure an ejectable first.`)
+                Global_AddToast?.(
+                    "info",
+                    "Configure Ejectable",
+                    `Configure an ejectable first.`
+                )
+                this._ejectableToastShown = true
+            }
             return false
         }
 


### PR DESCRIPTION
Replaces the hidden console.log in SetEjectable with an on-screen info toast. Now, if a user tries to intake before configuring the ejector, they won’t be left blindly testing everything—not realizing the message was buried in the console (speaking from experience).