### PR TITLE
Exporter Reloading

### DIFF
--- a/exporter/SynthesisFusionAddin/Synthesis.py
+++ b/exporter/SynthesisFusionAddin/Synthesis.py
@@ -141,6 +141,8 @@ def register_ui() -> None:
     gm.elements.append(websiteButton)
 
 
+# Transition AARD-1997: Should revisit this once we start working on a re-write.
+# Jank solution for now - Brandon
 @logFailure
 def reload() -> None:
     """Reloads the imports of sub modules of the Synthesis package.

--- a/exporter/SynthesisFusionAddin/Synthesis.py
+++ b/exporter/SynthesisFusionAddin/Synthesis.py
@@ -1,6 +1,6 @@
+import importlib
 import os
 import sys
-import importlib
 from typing import Any
 
 import adsk.core

--- a/exporter/SynthesisFusionAddin/Synthesis.py
+++ b/exporter/SynthesisFusionAddin/Synthesis.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import importlib
 from typing import Any
 
 import adsk.core
@@ -50,6 +51,8 @@ def run(_context: dict[str, Any]) -> None:
     Arguments:
         **context** *context* -- Fusion context to derive app and UI.
     """
+
+    reload()
 
     # Remove all items prior to start just to make sure
     unregister_all()
@@ -136,3 +139,17 @@ def register_ui() -> None:
         command=True,
     )
     gm.elements.append(websiteButton)
+
+@logFailure
+def reload() -> None:
+    """Reloads the imports of sub modules of the Synthesis package.
+
+    Allows for reloading the package without restarting Fusion.
+    """
+    logger.info("here")
+    importlib.reload(HUI)
+    importlib.reload(Camera)
+    importlib.reload(ConfigCommand)
+    importlib.reload(MarkingMenu)
+    importlib.reload(ShowAPSAuthCommand)
+    importlib.reload(ShowWebsiteCommand)

--- a/exporter/SynthesisFusionAddin/Synthesis.py
+++ b/exporter/SynthesisFusionAddin/Synthesis.py
@@ -141,8 +141,6 @@ def register_ui() -> None:
     gm.elements.append(websiteButton)
 
 
-# Transition AARD-1997: Should revisit this once we start working on a re-write.
-# Jank solution for now - Brandon
 @logFailure
 def reload() -> None:
     """Reloads the imports of sub modules of the Synthesis package.

--- a/exporter/SynthesisFusionAddin/Synthesis.py
+++ b/exporter/SynthesisFusionAddin/Synthesis.py
@@ -140,6 +140,7 @@ def register_ui() -> None:
     )
     gm.elements.append(websiteButton)
 
+
 @logFailure
 def reload() -> None:
     """Reloads the imports of sub modules of the Synthesis package.

--- a/exporter/SynthesisFusionAddin/Synthesis.py
+++ b/exporter/SynthesisFusionAddin/Synthesis.py
@@ -146,10 +146,11 @@ def reload() -> None:
 
     Allows for reloading the package without restarting Fusion.
     """
-    logger.info("here")
     importlib.reload(HUI)
     importlib.reload(Camera)
     importlib.reload(ConfigCommand)
     importlib.reload(MarkingMenu)
     importlib.reload(ShowAPSAuthCommand)
     importlib.reload(ShowWebsiteCommand)
+
+    ConfigCommand.reload()

--- a/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
+++ b/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
@@ -31,6 +31,7 @@ logger = getLogger()
 
 INPUTS_ROOT: adsk.core.CommandInputs
 
+
 def reload() -> None:
     """Reloads the sub modules to reflect any changes made during development."""
     importlib.reload(GeneralConfigTab)
@@ -39,6 +40,7 @@ def reload() -> None:
 
     importlib.reload(Parser)
     logger.info("UI modules reloaded successfully.")
+
 
 class ConfigureCommandCreatedHandler(adsk.core.CommandCreatedEventHandler):
     """Called when the panel is initially created."""

--- a/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
+++ b/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
@@ -17,14 +17,14 @@ from src.Parser.ExporterOptions import ExporterOptions
 from src.Parser.SynthesisParser.Parser import Parser
 from src.Types import SELECTABLE_JOINT_TYPES, ExportLocation, ExportMode
 from src.UI import FileDialogConfig
-from src.UI.GamepieceConfigTab import GamepieceConfigTab
-from src.UI.GeneralConfigTab import GeneralConfigTab
 from src.UI.Handlers import PersistentEventHandler
-from src.UI.JointConfigTab import JointConfigTab
+import src.UI.GeneralConfigTab as GeneralConfigTab
+import src.UI.GamepieceConfigTab as GamepieceConfigTab
+import src.UI.JointConfigTab as JointConfigTab
 
-generalConfigTab: GeneralConfigTab
-jointConfigTab: JointConfigTab
-gamepieceConfigTab: GamepieceConfigTab
+generalConfigTab: GeneralConfigTab.GeneralConfigTab
+jointConfigTab: JointConfigTab.JointConfigTab
+gamepieceConfigTab: GamepieceConfigTab.GamepieceConfigTab
 
 logger = getLogger()
 
@@ -71,14 +71,14 @@ class ConfigureCommandCreatedHandler(adsk.core.CommandCreatedEventHandler):
         cmd.helpFile = os.path.join(".", "src", "Resources", "HTML", "info.html")
 
         global generalConfigTab
-        generalConfigTab = GeneralConfigTab(args, exporterOptions)
+        generalConfigTab = GeneralConfigTab.GeneralConfigTab(args, exporterOptions)
 
         global gamepieceConfigTab
-        gamepieceConfigTab = GamepieceConfigTab(args, exporterOptions)
+        gamepieceConfigTab = GamepieceConfigTab.GamepieceConfigTab(args, exporterOptions)
         generalConfigTab.gamepieceConfigTab = gamepieceConfigTab
 
         global jointConfigTab
-        jointConfigTab = JointConfigTab(args)
+        jointConfigTab = JointConfigTab.JointConfigTab(args)
         generalConfigTab.jointConfigTab = jointConfigTab
 
         if not exporterOptions.exportMode == ExportMode.FIELD:

--- a/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
+++ b/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
@@ -2,26 +2,26 @@
 Central location for which all UI is generated and handled for the main configuration panel.
 """
 
+import importlib
 import os
 import re
 import webbrowser
-import importlib
 from typing import Any
 
 import adsk.core
 import adsk.fusion
 
+import src.Parser.SynthesisParser.Parser as Parser
+import src.UI.GamepieceConfigTab as GamepieceConfigTab
+import src.UI.GeneralConfigTab as GeneralConfigTab
+import src.UI.JointConfigTab as JointConfigTab
 from src import APP_WEBSITE_URL, gm
 from src.APS.APS import getAuth, getUserInfo
 from src.Logging import getLogger, logFailure
 from src.Parser.ExporterOptions import ExporterOptions
-import src.Parser.SynthesisParser.Parser as Parser
 from src.Types import SELECTABLE_JOINT_TYPES, ExportLocation, ExportMode
 from src.UI import FileDialogConfig
 from src.UI.Handlers import PersistentEventHandler
-import src.UI.GeneralConfigTab as GeneralConfigTab
-import src.UI.GamepieceConfigTab as GamepieceConfigTab
-import src.UI.JointConfigTab as JointConfigTab
 
 generalConfigTab: GeneralConfigTab.GeneralConfigTab
 jointConfigTab: JointConfigTab.JointConfigTab

--- a/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
+++ b/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
@@ -5,6 +5,7 @@ Central location for which all UI is generated and handled for the main configur
 import os
 import re
 import webbrowser
+import importlib
 from typing import Any
 
 import adsk.core
@@ -14,7 +15,7 @@ from src import APP_WEBSITE_URL, gm
 from src.APS.APS import getAuth, getUserInfo
 from src.Logging import getLogger, logFailure
 from src.Parser.ExporterOptions import ExporterOptions
-from src.Parser.SynthesisParser.Parser import Parser
+import src.Parser.SynthesisParser.Parser as Parser
 from src.Types import SELECTABLE_JOINT_TYPES, ExportLocation, ExportMode
 from src.UI import FileDialogConfig
 from src.UI.Handlers import PersistentEventHandler
@@ -30,6 +31,14 @@ logger = getLogger()
 
 INPUTS_ROOT: adsk.core.CommandInputs
 
+def reload() -> None:
+    """Reloads the sub modules to reflect any changes made during development."""
+    importlib.reload(GeneralConfigTab)
+    importlib.reload(GamepieceConfigTab)
+    importlib.reload(JointConfigTab)
+
+    importlib.reload(Parser)
+    logger.info("UI modules reloaded successfully.")
 
 class ConfigureCommandCreatedHandler(adsk.core.CommandCreatedEventHandler):
     """Called when the panel is initially created."""
@@ -164,7 +173,7 @@ class ConfigureCommandExecuteHandler(PersistentEventHandler, adsk.core.CommandEv
             openSynthesisUponExport=generalConfigTab.openSynthesisUponExport,
         )
 
-        Parser(exporterOptions).export()
+        Parser.Parser(exporterOptions).export()
         exporterOptions.writeToDesign()
         jointConfigTab.reset()
         gamepieceConfigTab.reset()


### PR DESCRIPTION
## Description
Allow for reloading the exporter code by disabling and re-enabling the exporter plugin -> instead of restarting fusion.

### Testing
Make a change to one of the tabs then disable and re-run the Synthesis addin to see if your changes were loaded.

[JIRA Issue](https://jira.autodesk.com/browse/AARD-1997)
