### PR TITLE
Maximum quality settings `[AARD-1928]`

### DIFF
--- a/fission/src/systems/PerformanceMonitor.ts
+++ b/fission/src/systems/PerformanceMonitor.ts
@@ -21,17 +21,17 @@ export class PerformanceMonitorSystem extends WorldSystem {
             this.activeCount++
         } else {
             this.antiCount++
-            if (this.antiCount > 10 && this.antiCount > 0.5 * this.activeCount) {
-                this.isCritical = newIsCritical
-                const oldActive = this.activeCount
-                this.activeCount = this.antiCount
-                this.antiCount = oldActive
-                if (this.isCritical) {
-                    PreferencesSystem.resetGraphicsPreferences()
-                    World.SceneRenderer.changeCSMSettings(PreferencesSystem.getGraphicsPreferences())
-                    Global_OpenPanel?.("graphics-settings")
-                    Global_AddToast?.("warning", "Performance Issues Detected", "Reverting to simple graphics")
-                }
+            if (this.antiCount <= 10 || this.antiCount <= 0.5 * this.activeCount) return
+            
+            this.isCritical = newIsCritical
+            const oldActive = this.activeCount
+            this.activeCount = this.antiCount
+            this.antiCount = oldActive
+            if (this.isCritical) {
+                PreferencesSystem.resetGraphicsPreferences()
+                World.SceneRenderer.changeCSMSettings(PreferencesSystem.getGraphicsPreferences())
+                Global_OpenPanel?.("graphics-settings")
+                Global_AddToast?.("warning", "Performance Issues Detected", "Reverting to simple graphics")
             }
         }
 

--- a/fission/src/systems/PerformanceMonitor.ts
+++ b/fission/src/systems/PerformanceMonitor.ts
@@ -3,7 +3,7 @@ import { Global_AddToast, Global_OpenPanel } from "@/components/GlobalUIControls
 import World from "@/systems/World.ts"
 import PreferencesSystem from "@/systems/preferences/PreferencesSystem.ts"
 
-export class PerformanceMonitorSystem extends WorldSystem {
+export class PerformanceMonitoringSystem extends WorldSystem {
     isCritical: boolean = false
     activeCount: number = 0
     antiCount: number = 0
@@ -22,7 +22,7 @@ export class PerformanceMonitorSystem extends WorldSystem {
         } else {
             this.antiCount++
             if (this.antiCount <= 10 || this.antiCount <= 0.5 * this.activeCount) return
-            
+
             this.isCritical = newIsCritical
             const oldActive = this.activeCount
             this.activeCount = this.antiCount

--- a/fission/src/systems/PerformanceMonitor.ts
+++ b/fission/src/systems/PerformanceMonitor.ts
@@ -1,0 +1,47 @@
+import WorldSystem from "@/systems/WorldSystem.ts"
+import { Global_AddToast, Global_OpenPanel } from "@/components/GlobalUIControls.ts"
+import World from "@/systems/World.ts"
+import PreferencesSystem from "@/systems/preferences/PreferencesSystem.ts"
+
+export class PerformanceMonitorSystem extends WorldSystem {
+    isCritical: boolean = false
+    activeCount: number = 0
+    antiCount: number = 0
+    lastTime = performance.now()
+    constructor() {
+        super()
+        setInterval(() => {
+            this.Reset()
+        }, 15000)
+    }
+    public Update(_: number) {
+        const time = performance.now() - this.lastTime
+        const newIsCritical = time > 150
+        if (newIsCritical == this.isCritical) {
+            this.activeCount++
+        } else {
+            this.antiCount++
+            if (this.antiCount > 10 && this.antiCount > 0.5 * this.activeCount) {
+                this.isCritical = newIsCritical
+                const oldActive = this.activeCount
+                this.activeCount = this.antiCount
+                this.antiCount = oldActive
+                if (this.isCritical) {
+                    PreferencesSystem.resetGraphicsPreferences()
+                    World.SceneRenderer.changeCSMSettings(PreferencesSystem.getGraphicsPreferences())
+                    Global_OpenPanel?.("graphics-settings")
+                    Global_AddToast?.("warning", "Performance Issues Detected", "Reverting to simple graphics")
+                }
+            }
+        }
+
+        this.lastTime = performance.now()
+    }
+
+    public Reset() {
+        this.activeCount = 0
+        this.antiCount = 0
+    }
+
+    public Destroy() {}
+}

--- a/fission/src/systems/World.ts
+++ b/fission/src/systems/World.ts
@@ -6,7 +6,7 @@ import SimulationSystem from "./simulation/SimulationSystem"
 import InputSystem from "./input/InputSystem"
 import AnalyticsSystem, { AccumTimes } from "./analytics/AnalyticsSystem"
 import DragModeSystem from "./scene/DragModeSystem"
-import { PerformanceMonitorSystem } from "@/systems/PerformanceMonitor.ts"
+import { PerformanceMonitoringSystem } from "@/systems/PerformanceMonitor.ts"
 
 class World {
     private static _isAlive: boolean = false
@@ -19,7 +19,7 @@ class World {
     private static _inputSystem: InputSystem
     private static _analyticsSystem: AnalyticsSystem | undefined = undefined
     private static _dragModeSystem: DragModeSystem
-    private static _performanceMonitorSystem: PerformanceMonitorSystem
+    private static _performanceMonitorSystem: PerformanceMonitoringSystem
 
     private static _accumTimes: AccumTimes = {
         frames: 0,
@@ -79,7 +79,7 @@ class World {
         World._simulationSystem = new SimulationSystem()
         World._inputSystem = new InputSystem()
         World._dragModeSystem = new DragModeSystem()
-        World._performanceMonitorSystem = new PerformanceMonitorSystem()
+        World._performanceMonitorSystem = new PerformanceMonitoringSystem()
         try {
             World._analyticsSystem = new AnalyticsSystem()
         } catch (_) {

--- a/fission/src/systems/World.ts
+++ b/fission/src/systems/World.ts
@@ -6,6 +6,7 @@ import SimulationSystem from "./simulation/SimulationSystem"
 import InputSystem from "./input/InputSystem"
 import AnalyticsSystem, { AccumTimes } from "./analytics/AnalyticsSystem"
 import DragModeSystem from "./scene/DragModeSystem"
+import { PerformanceMonitorSystem } from "@/systems/PerformanceMonitor.ts"
 
 class World {
     private static _isAlive: boolean = false
@@ -18,6 +19,7 @@ class World {
     private static _inputSystem: InputSystem
     private static _analyticsSystem: AnalyticsSystem | undefined = undefined
     private static _dragModeSystem: DragModeSystem
+    private static _performanceMonitorSystem: PerformanceMonitorSystem
 
     private static _accumTimes: AccumTimes = {
         frames: 0,
@@ -77,6 +79,7 @@ class World {
         World._simulationSystem = new SimulationSystem()
         World._inputSystem = new InputSystem()
         World._dragModeSystem = new DragModeSystem()
+        World._performanceMonitorSystem = new PerformanceMonitorSystem()
         try {
             World._analyticsSystem = new AnalyticsSystem()
         } catch (_) {
@@ -95,6 +98,7 @@ class World {
         World._inputSystem.Destroy()
         World._dragModeSystem.Destroy()
 
+        World._performanceMonitorSystem.Destroy()
         World._analyticsSystem?.Destroy()
     }
 
@@ -112,6 +116,7 @@ class World {
         })
 
         World._analyticsSystem?.Update(this._currentDeltaT)
+        World._performanceMonitorSystem?.Update(this._currentDeltaT)
     }
 
     public static get currentDeltaT(): number {

--- a/fission/src/systems/preferences/PreferencesSystem.ts
+++ b/fission/src/systems/preferences/PreferencesSystem.ts
@@ -1,18 +1,18 @@
 import {
     DefaultFieldPreferences,
     DefaultGlobalPreferences,
-    DefaultRobotPreferences,
-    DefaultMotorPreferences,
     DefaultGraphicsPreferences,
+    DefaultMotorPreferences,
+    DefaultRobotPreferences,
     FieldPreferences,
     FieldPreferencesKey,
     GlobalPreference,
-    RobotPreferences,
-    RobotPreferencesKey,
-    GraphicsPreferences,
     GraphicsPreferenceKey,
+    GraphicsPreferences,
     MotorPreferences,
     MotorPreferencesKey,
+    RobotPreferences,
+    RobotPreferencesKey,
 } from "./PreferenceTypes"
 
 /** An event that's triggered when a preference is changed. */
@@ -179,6 +179,11 @@ class PreferencesSystem {
         }
 
         return graphicsPrefs
+    }
+    /** Gets simulation quality preferences */
+    public static resetGraphicsPreferences() {
+        this._preferences[GraphicsPreferenceKey] = DefaultGraphicsPreferences()
+        this.savePreferences()
     }
 
     /** Loads all preferences from local storage. */

--- a/fission/src/systems/preferences/PreferencesSystem.ts
+++ b/fission/src/systems/preferences/PreferencesSystem.ts
@@ -180,7 +180,7 @@ class PreferencesSystem {
 
         return graphicsPrefs
     }
-    /** Gets simulation quality preferences */
+    /** Resets simulation quality preferences to default values */
     public static resetGraphicsPreferences() {
         this._preferences[GraphicsPreferenceKey] = DefaultGraphicsPreferences()
         this.savePreferences()


### PR DESCRIPTION
### Description
Opens settings panel and resets quality settings to default if framerate is consistently below 10fps. Once quality presets are merged it could change pretty easily to reset them to the low preset instead of default

### Objectives
- [X] Prevent users from getting stuck with high quality settings unable to change them back

### Testing Done
- Used chrome dev tools to simulate a slow machine on max quality settings

AARD-1928
