### PR TITLE
Fix Premature Performance Alert `[AARD-1928]`

### DIFF
--- a/fission/src/systems/PerformanceMonitor.ts
+++ b/fission/src/systems/PerformanceMonitor.ts
@@ -21,17 +21,17 @@ export class PerformanceMonitoringSystem extends WorldSystem {
             this.activeCount++
         } else {
             this.antiCount++
-            if (this.antiCount <= 10 || this.antiCount <= 0.5 * this.activeCount) return
-
-            this.isCritical = newIsCritical
-            const oldActive = this.activeCount
-            this.activeCount = this.antiCount
-            this.antiCount = oldActive
-            if (this.isCritical) {
-                PreferencesSystem.resetGraphicsPreferences()
-                World.SceneRenderer.changeCSMSettings(PreferencesSystem.getGraphicsPreferences())
-                Global_OpenPanel?.("graphics-settings")
-                Global_AddToast?.("warning", "Performance Issues Detected", "Reverting to simple graphics")
+            if (this.antiCount > 10 && this.antiCount > 0.5 * this.activeCount) {
+                this.isCritical = newIsCritical
+                const oldActive = this.activeCount
+                this.activeCount = this.antiCount
+                this.antiCount = oldActive
+                if (this.isCritical) {
+                    PreferencesSystem.resetGraphicsPreferences()
+                    World.SceneRenderer.changeCSMSettings(PreferencesSystem.getGraphicsPreferences())
+                    Global_OpenPanel?.("graphics-settings")
+                    Global_AddToast?.("warning", "Performance Issues Detected", "Reverting to simple graphics")
+                }
             }
         }
 


### PR DESCRIPTION
This reverts commit 0f6ac01f9e19c9a1a02ae6b60e5cab757d06d3b0, fixing the conditions for the performance monitor reset
