### PR TITLE
Add Jira Ticket ID to PR Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,13 @@
 
 <!--
 Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
-Include the same Jira ticket ID(s) in the top of this section then provide a brief description of what the task was.
+Include the same Jira ticket ID(s) in this section.
+-->
+
+AARD-
+
+<!--
+Provide a brief description of what the task was here.
 -->
 
 ## Symptom


### PR DESCRIPTION
Just a small cleanup since a request was having the jira ID as a part of the template.

We have auto linking for this repository so once the tag is completed with a valid ticket number it will automatically link back to our project board.