### PR TITLE
Bug: Hides touch control schemes if not supported by device `AARD-1958`

### DIFF
--- a/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
+++ b/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
@@ -33,8 +33,7 @@ const InputSchemeSelection: React.FC<InputSchemeSelectionProps> = ({ brainIndex,
 
                 {/** Creates list items with buttons */}
                 {InputSchemeManager.availableInputSchemes.map(scheme => {
-                    if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) 
-                        return null 
+                    if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) return null
 
                     return (
                         <Box

--- a/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
+++ b/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
@@ -33,10 +33,9 @@ const InputSchemeSelection: React.FC<InputSchemeSelectionProps> = ({ brainIndex,
 
                 {/** Creates list items with buttons */}
                 {InputSchemeManager.availableInputSchemes.map(scheme => {
-                    // Skip schemes that use touch controls if the device does not support touch
-                    if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) {
-                        return null
-                    }
+                    if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) 
+                        return null 
+
                     return (
                         <Box
                             component={"div"}

--- a/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
+++ b/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
@@ -34,7 +34,7 @@ function InputSchemeSelection({ brainIndex, onSelect, onEdit, onCreateNew }: Inp
                 {/** Creates list items with buttons */}
                 {InputSchemeManager.availableInputSchemes.map(scheme => {
                     if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) {
-                        return <></>
+                        return null
                     } // Skip schemes that use touch controls if the device does not support touch
                     return (
                         <Box

--- a/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
+++ b/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
@@ -33,7 +33,9 @@ function InputSchemeSelection({ brainIndex, onSelect, onEdit, onCreateNew }: Inp
 
                 {/** Creates list items with buttons */}
                 {InputSchemeManager.availableInputSchemes.map(scheme => {
-                    if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) { return <></> } // Skip schemes that use touch controls if the device does not support touch
+                    if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) {
+                        return <></>
+                    } // Skip schemes that use touch controls if the device does not support touch
                     return (
                         <Box
                             component={"div"}

--- a/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
+++ b/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
@@ -33,9 +33,9 @@ const InputSchemeSelection: React.FC<InputSchemeSelectionProps> = ({ brainIndex,
 
                 {/** Creates list items with buttons */}
                 {InputSchemeManager.availableInputSchemes.map(scheme => {
-                    if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) {
+                    if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) { // Skip schemes that use touch controls if the device does not support touch
                         return null
-                    } // Skip schemes that use touch controls if the device does not support touch
+                    } 
                     return (
                         <Box
                             component={"div"}

--- a/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
+++ b/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
@@ -33,9 +33,10 @@ const InputSchemeSelection: React.FC<InputSchemeSelectionProps> = ({ brainIndex,
 
                 {/** Creates list items with buttons */}
                 {InputSchemeManager.availableInputSchemes.map(scheme => {
-                    if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) { // Skip schemes that use touch controls if the device does not support touch
+                    if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) {
+                        // Skip schemes that use touch controls if the device does not support touch
                         return null
-                    } 
+                    }
                     return (
                         <Box
                             component={"div"}

--- a/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
+++ b/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
@@ -33,6 +33,7 @@ function InputSchemeSelection({ brainIndex, onSelect, onEdit, onCreateNew }: Inp
 
                 {/** Creates list items with buttons */}
                 {InputSchemeManager.availableInputSchemes.map(scheme => {
+                    if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) { return <></> } // Skip schemes that use touch controls if the device does not support touch
                     return (
                         <Box
                             component={"div"}

--- a/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
+++ b/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
@@ -33,8 +33,8 @@ const InputSchemeSelection: React.FC<InputSchemeSelectionProps> = ({ brainIndex,
 
                 {/** Creates list items with buttons */}
                 {InputSchemeManager.availableInputSchemes.map(scheme => {
+                    // Skip schemes that use touch controls if the device does not support touch
                     if (scheme.usesTouchControls && !matchMedia("(hover: none)").matches) {
-                        // Skip schemes that use touch controls if the device does not support touch
                         return null
                     }
                     return (


### PR DESCRIPTION
## Task

AARD-1958

Prevent all touch control schemes to appear in the ChooseInputSchemePanel when spawning a robot if the device does not support touch capabilities.

## Symptom

If on any device, if spawning a robot assembly, the ChooseInputSchemePanel includes the "Brandon" touch control scheme. If selected, this scheme **spawns in touch control joysticks** which are impractical on a non-touch device. The only way to remove these is to clear all preferences since the MainHUD touch control button is hidden to all non-touch devices.

## Solution

Hides all touch control schemes if on a non-touch device.

## Verification

To test:
1. Spawn a robot on a non-touch device and look for the "Brandon" control scheme.
2. Reload the page
3. Inspect the web page
4. click the "device toolbar button" in the top left of the inspect panel
![Screenshot 2025-07-08 at 3 11 18 PM](https://github.com/user-attachments/assets/08908b05-341b-431e-ab58-5612ddb162bf)
5. Retest step 1 and see the "Brandon" control scheme appear.
---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
