### PR TITLE
Make Global Functions Non-Optional `[AARD-1986]`

### DIFF
--- a/fission/src/aps/APS.ts
+++ b/fission/src/aps/APS.ts
@@ -205,7 +205,7 @@ class APS {
             } catch (e) {
                 console.error(e)
                 World.AnalyticsSystem?.Exception("APS Login Failure")
-                Global_AddToast?.("error", "Error signing in.", "Please try again.")
+                Global_AddToast("error", "Error signing in.", "Please try again.")
             }
         })
     }
@@ -236,7 +236,7 @@ class APS {
                 const json = await res.json()
                 if (!res.ok) {
                     if (shouldRelog) {
-                        Global_AddToast?.("warning", "Must Re-signin.", json.userMessage)
+                        Global_AddToast("warning", "Must Re-signin.", json.userMessage)
                         this.auth = undefined
                         await this.requestAuthCode()
                         return false
@@ -249,13 +249,13 @@ class APS {
                 if (this.auth) {
                     await this.loadUserInfo(this.auth)
                     if (APS.userInfo) {
-                        Global_AddToast?.("info", "ADSK Login", `Hello, ${APS.userInfo.givenName}`)
+                        Global_AddToast("info", "ADSK Login", `Hello, ${APS.userInfo.givenName}`)
                     }
                 }
                 return true
             } catch (e) {
                 World.AnalyticsSystem?.Exception("APS Login Failure")
-                Global_AddToast?.("error", "Error signing in.", "Please try again.")
+                Global_AddToast("error", "Error signing in.", "Please try again.")
                 this.auth = undefined
                 await this.requestAuthCode()
                 return false
@@ -281,7 +281,7 @@ class APS {
             const json = await res.json()
             if (!res.ok) {
                 World.AnalyticsSystem?.Exception("APS Login Failure")
-                Global_AddToast?.("error", "Error signing in.", json.userMessage)
+                Global_AddToast("error", "Error signing in.", json.userMessage)
                 this.auth = undefined
                 return
             }
@@ -293,7 +293,7 @@ class APS {
             if (auth) {
                 await this.loadUserInfo(auth)
                 if (APS.userInfo) {
-                    Global_AddToast?.("info", "ADSK Login", `Hello, ${APS.userInfo.givenName}`)
+                    Global_AddToast("info", "ADSK Login", `Hello, ${APS.userInfo.givenName}`)
                 }
             } else {
                 console.error("Couldn't get auth data.")
@@ -306,7 +306,7 @@ class APS {
         if (retry_login) {
             this.auth = undefined
             World.AnalyticsSystem?.Exception("APS Login Failure")
-            Global_AddToast?.("error", "Error signing in.", "Please try again.")
+            Global_AddToast("error", "Error signing in.", "Please try again.")
         }
     }
 
@@ -327,7 +327,7 @@ class APS {
             const json = await res.json()
             if (!res.ok) {
                 World.AnalyticsSystem?.Exception("APS Failure: User Info")
-                Global_AddToast?.("error", "Error fetching user data.", json.userMessage)
+                Global_AddToast("error", "Error fetching user data.", json.userMessage)
                 this.auth = undefined
                 await this.requestAuthCode()
                 return
@@ -343,7 +343,7 @@ class APS {
         } catch (e) {
             console.error(e)
             World.AnalyticsSystem?.Exception("APS Login Failure: User Info")
-            Global_AddToast?.("error", "Error signing in.", "Please try again.")
+            Global_AddToast("error", "Error signing in.", "Please try again.")
             this.auth = undefined
         }
     }
@@ -359,7 +359,7 @@ class APS {
         } catch (e) {
             console.error(e)
             World.AnalyticsSystem?.Exception("APS Login Failure: Code Challenge")
-            Global_AddToast?.("error", "Error signing in.", "Please try again.")
+            Global_AddToast("error", "Error signing in.", "Please try again.")
         }
     }
 }

--- a/fission/src/aps/APSDataManagement.ts
+++ b/fission/src/aps/APSDataManagement.ts
@@ -140,9 +140,9 @@ export async function getHubs(): Promise<Hub[] | undefined> {
         console.log(auth)
         console.log(APS.userInfo)
         if (e instanceof APSDataError) {
-            Global_AddToast?.("error", e.title, e.detail)
+            Global_AddToast("error", e.title, e.detail)
         } else if (e instanceof Error) {
-            Global_AddToast?.("error", "Failed to get hubs.", e.message)
+            Global_AddToast("error", "Failed to get hubs.", e.message)
         }
         return undefined
     }
@@ -179,7 +179,7 @@ export async function getProjects(hub: Hub): Promise<Project[] | undefined> {
     } catch (e) {
         console.error("Failed to get hubs")
         if (e instanceof Error) {
-            Global_AddToast?.("error", "Failed to get hubs.", e.message)
+            Global_AddToast("error", "Failed to get hubs.", e.message)
         }
         return undefined
     }
@@ -224,7 +224,7 @@ export async function getFolderData(project: Project, folder: Folder): Promise<D
     } catch (e) {
         console.error("Failed to get folder data")
         if (e instanceof Error) {
-            Global_AddToast?.("error", "Failed to get folder data.", e.message)
+            Global_AddToast("error", "Failed to get folder data.", e.message)
         }
         return undefined
     }
@@ -250,7 +250,7 @@ export async function searchFolder(project: Project, folder: Folder, filters?: F
         },
     })
     if (!res.ok) {
-        Global_AddToast?.("error", "Error getting cloud files.", "Please sign in again.")
+        Global_AddToast("error", "Error getting cloud files.", "Please sign in again.")
         return []
     }
     const json = await res.json()

--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -140,11 +140,7 @@ class MirabufCachingService {
 
             if (cached) return cached
 
-            Global_AddToast?.(
-                "error",
-                "Cache Fallback",
-                `Unable to cache “${fetchLocation}”. Using raw buffer instead.`
-            )
+            Global_AddToast("error", "Cache Fallback", `Unable to cache “${fetchLocation}”. Using raw buffer instead.`)
 
             // fallback: return raw buffer wrapped in MirabufCacheInfo
             return {

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -10,11 +10,12 @@ import JOLT from "@/util/loading/JoltSyncLoader"
 import { BodyAssociate, LayerReserve } from "@/systems/physics/PhysicsSystem"
 import Mechanism from "@/systems/physics/Mechanism"
 import {
+    Alliance,
     EjectorPreferences,
     FieldPreferences,
     IntakePreferences,
-    ScoringZonePreferences,
     ProtectedZonePreferences,
+    ScoringZonePreferences,
 } from "@/systems/preferences/PreferenceTypes"
 import PreferencesSystem from "@/systems/preferences/PreferencesSystem"
 import { MiraType } from "./MirabufLoader"
@@ -40,7 +41,6 @@ import {
 } from "@/ui/panels/configuring/assembly-config/ConfigurationType"
 import { SimConfigData } from "@/ui/panels/simulation/SimConfigShared"
 import WPILibBrain from "@/systems/simulation/wpilib_brain/WPILibBrain"
-import { Alliance } from "@/systems/preferences/PreferenceTypes"
 import { OnContactAddedEvent } from "@/systems/physics/ContactEvents"
 
 const DEBUG_BODIES = false
@@ -524,7 +524,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
             const now = Date.now()
             if (now - this._lastEjectableToastTime > MirabufSceneObject.EJECTABLE_TOAST_COOLDOWN_MS) {
                 console.log(`Configure an ejectable first.`)
-                Global_AddToast?.("info", "Configure Ejectable", "Configure an ejectable first.")
+                Global_AddToast("info", "Configure Ejectable", "Configure an ejectable first.")
                 this._lastEjectableToastTime = now
             }
             return false
@@ -705,7 +705,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
                         configMode: ConfigMode.MOVE,
                         selectedAssembly: this,
                     })
-                    Global_OpenPanel?.("configure")
+                    Global_OpenPanel("configure")
                 },
             },
             {
@@ -718,7 +718,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
                         configMode: undefined,
                         selectedAssembly: this,
                     })
-                    Global_OpenPanel?.("configure")
+                    Global_OpenPanel("configure")
                 },
             }
         )
@@ -727,7 +727,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
             data.items.push({
                 name: "Auto Testing",
                 func: () => {
-                    Global_OpenPanel?.("auto-test")
+                    Global_OpenPanel("auto-test")
                 },
             })
         }

--- a/fission/src/systems/PerformanceMonitor.ts
+++ b/fission/src/systems/PerformanceMonitor.ts
@@ -29,8 +29,8 @@ export class PerformanceMonitoringSystem extends WorldSystem {
                 if (this.isCritical) {
                     PreferencesSystem.resetGraphicsPreferences()
                     World.SceneRenderer.changeCSMSettings(PreferencesSystem.getGraphicsPreferences())
-                    Global_OpenPanel?.("graphics-settings")
-                    Global_AddToast?.("warning", "Performance Issues Detected", "Reverting to simple graphics")
+                    Global_OpenPanel("graphics-settings")
+                    Global_AddToast("warning", "Performance Issues Detected", "Reverting to simple graphics")
                 }
             }
         }

--- a/fission/src/systems/scene/SceneRenderer.ts
+++ b/fission/src/systems/scene/SceneRenderer.ts
@@ -533,7 +533,7 @@ class SceneRenderer extends WorldSystem {
             miraSupplierData.items.push({
                 name: "Add",
                 func: () => {
-                    Global_OpenPanel?.("import-mirabuf")
+                    Global_OpenPanel("import-mirabuf")
                 },
             })
         }

--- a/fission/src/systems/simulation/SimulationSystem.ts
+++ b/fission/src/systems/simulation/SimulationSystem.ts
@@ -74,7 +74,7 @@ class SimulationSystem extends WorldSystem {
 
     public static RobotPenalty(robot: MirabufSceneObject, penaltyPoints: number, penaltyInfo: string): void {
         // Display a toast showing that a penalty was committed
-        Global_AddToast?.(
+        Global_AddToast(
             "warning",
             "PENALTY COMMITTED",
             `Robot ${robot.nameTag?.text()} (${robot.assemblyName}), Committed Penalty: ${penaltyInfo}`

--- a/fission/src/ui/components/DragModeIndicator.tsx
+++ b/fission/src/ui/components/DragModeIndicator.tsx
@@ -20,7 +20,7 @@ export default function DragModeIndicator() {
 
     const handleClick = () => {
         window.dispatchEvent(new CustomEvent("disableDragMode"))
-        Global_AddToast?.("info", "Drag Mode", "Drag mode has been disabled")
+        Global_AddToast("info", "Drag Mode", "Drag mode has been disabled")
     }
 
     return enabled ? (

--- a/fission/src/ui/components/GlobalUIComponent.tsx
+++ b/fission/src/ui/components/GlobalUIComponent.tsx
@@ -22,7 +22,7 @@ function GlobalUIComponent() {
         setOpenModal(openModal)
 
         return () => {
-            setOpenModal(undefined)
+            setOpenModal(() => {})
         }
     }, [openModal])
 
@@ -30,7 +30,7 @@ function GlobalUIComponent() {
         setOpenPanel(openPanel)
 
         return () => {
-            setOpenPanel(undefined)
+            setOpenPanel(() => {})
         }
     }, [openPanel])
 
@@ -38,7 +38,7 @@ function GlobalUIComponent() {
         setAddToast(addToast)
 
         return () => {
-            setAddToast(undefined)
+            setAddToast(() => {})
         }
     }, [addToast])
 

--- a/fission/src/ui/components/GlobalUIControls.ts
+++ b/fission/src/ui/components/GlobalUIControls.ts
@@ -5,9 +5,9 @@
 
 import { ToastType } from "@/ui/ToastContext"
 
-export let Global_AddToast: ((type: ToastType, title: string, description: string) => void) | undefined = undefined
-export let Global_OpenPanel: ((panelId: string) => void) | undefined = undefined
-export let Global_OpenModal: ((modalId: string) => void) | undefined = undefined
+export let Global_AddToast: (type: ToastType, title: string, description: string) => void = () => {}
+export let Global_OpenPanel: (panelId: string) => void = () => {}
+export let Global_OpenModal: (modalId: string) => void = () => {}
 
 export function setAddToast(func: typeof Global_AddToast) {
     Global_AddToast = func

--- a/fission/src/ui/components/MainHUD.tsx
+++ b/fission/src/ui/components/MainHUD.tsx
@@ -194,7 +194,7 @@ const MainHUD: React.FC = () => {
                     larger={true}
                     onClick={() => {
                         MatchMode.getInstance().isMatchEnabled()
-                            ? Global_AddToast?.(
+                            ? Global_AddToast(
                                   "error",
                                   "Match Mode Already Running",
                                   "You can't start match mode if its already running"

--- a/fission/src/ui/modals/MainMenuModal.tsx
+++ b/fission/src/ui/modals/MainMenuModal.tsx
@@ -33,7 +33,7 @@ const MainMenuModal: React.FC<ModalPropsImpl & { startSingleplayerCallback: () =
                 <Button
                     value={"Multiplayer"}
                     onClick={() => {
-                        Global_AddToast?.("error", "Not Supported", "Multiplayer is not yet supported. Come back soon!")
+                        Global_AddToast("error", "Not Supported", "Multiplayer is not yet supported. Come back soon!")
                     }}
                     className="w-full mt-1 mb-3"
                 />

--- a/fission/src/ui/modals/configuring/SettingsModal.tsx
+++ b/fission/src/ui/modals/configuring/SettingsModal.tsx
@@ -33,7 +33,7 @@ const SettingsModal: React.FC<ModalPropsImpl> = ({ modalId }) => {
     const save = () => {
         SoundPlayer.changeVolume()
         PreferencesSystem.savePreferences()
-        Global_AddToast?.("info", "Settings Saved", "")
+        Global_AddToast("info", "Settings Saved", "")
     }
     return (
         <Modal

--- a/fission/src/ui/modals/mirabuf/ImportLocalMirabufModal.tsx
+++ b/fission/src/ui/modals/mirabuf/ImportLocalMirabufModal.tsx
@@ -59,7 +59,7 @@ const ImportLocalMirabufModal: React.FC<ModalPropsImpl> = ({ modalId }) => {
                             if (x) {
                                 World.SceneRenderer.RegisterSceneObject(x)
 
-                                Global_OpenPanel?.("initial-config")
+                                Global_OpenPanel("initial-config")
                             }
                         })
                         .finally(() =>

--- a/fission/src/ui/panels/DebugPanel.tsx
+++ b/fission/src/ui/panels/DebugPanel.tsx
@@ -28,7 +28,7 @@ function ToggleDragMode() {
     if (dragSystem) {
         dragSystem.enabled = !dragSystem.enabled
         const status = dragSystem.enabled ? "enabled" : "disabled"
-        Global_AddToast?.("info", "Drag Mode", `Drag mode has been ${status}`)
+        Global_AddToast("info", "Drag Mode", `Drag mode has been ${status}`)
     }
 }
 
@@ -63,7 +63,7 @@ const DebugPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
                         value={"Toasts"}
                         onClick={() => {
                             const type: ToastType = ["info", "warning", "error"][Math.floor(Random() * 3)] as ToastType
-                            Global_AddToast?.(type, type, "This is a test toast to test the toast system")
+                            Global_AddToast(type, type, "This is a test toast to test the toast system")
                         }}
                         className="w-full"
                     />

--- a/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
+++ b/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
@@ -105,7 +105,7 @@ function SpawnCachedMira(info: MirabufCacheInfo, type: MiraType, progressHandle?
                         World.SceneRenderer.RegisterSceneObject(x)
                         progressHandle.Done()
 
-                        Global_OpenPanel?.("initial-config")
+                        Global_OpenPanel("initial-config")
                     } else {
                         progressHandle.Fail()
                     }
@@ -166,7 +166,7 @@ const ImportMirabufPanel: React.FC<PanelPropsImpl> = ({ panelId }) => {
     useLayoutEffect(() => {
         if (mirabufPanelState.hasUnconfirmedImport) {
             closePanel("import-mirabuf")
-            Global_AddToast?.(
+            Global_AddToast(
                 "warning",
                 "You're already importing a model!",
                 "Confirm that one before importing another."

--- a/fission/src/ui/panels/simulation/WiringPanel.tsx
+++ b/fission/src/ui/panels/simulation/WiringPanel.tsx
@@ -3,16 +3,16 @@ import Panel, { PanelPropsImpl } from "@/components/Panel"
 import { SectionDivider, SectionLabel, SynthesisIcons } from "@/ui/components/StyledComponents"
 import React, { ComponentType, useCallback, useEffect, useMemo, useReducer, useState } from "react"
 import {
-    ReactFlow,
-    Node as FlowNode,
-    Edge as FlowEdge,
-    useNodesState,
-    useEdgesState,
-    NodeProps,
     Connection,
+    Edge as FlowEdge,
     FinalConnectionState,
-    useReactFlow,
+    Node as FlowNode,
+    NodeProps,
+    ReactFlow,
     ReactFlowProvider,
+    useEdgesState,
+    useNodesState,
+    useReactFlow,
 } from "@xyflow/react"
 import {
     ConfigState,
@@ -22,6 +22,7 @@ import {
     NODE_ID_SIM_IN,
     NODE_ID_SIM_OUT,
     SimConfig,
+    SimConfigData,
 } from "./SimConfigShared"
 import Label, { LabelSize } from "@/ui/components/Label"
 import ScrollView from "@/ui/components/ScrollView"
@@ -31,7 +32,6 @@ import World from "@/systems/World"
 import Button from "@/ui/components/Button"
 import { usePanelControlContext } from "@/ui/helpers/UsePanelManager"
 import { Global_AddToast } from "@/ui/components/GlobalUIControls"
-import { SimConfigData } from "./SimConfigShared"
 import FlowControls from "./FlowControls"
 import WiringNode from "./WiringNode"
 import { SimType } from "@/systems/simulation/wpilib_brain/WPILibBrain"
@@ -401,7 +401,7 @@ function WiringPanel({ panelId }: PanelPropsImpl) {
             return miraObjs[0][1] as MirabufSceneObject
         } else {
             // TEMPORARY: Will be moved to config panel to ensure selected assembly
-            Global_AddToast?.("warning", "Missing Robot", "Must have at least one robot spawned for selection.")
+            Global_AddToast("warning", "Missing Robot", "Must have at least one robot spawned for selection.")
             closePanel(panelId)
         }
     }, [closePanel, panelId])


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-1986

Very small task to improve the typing on the `Global_*` functions

## Symptom

Currently the `Global_DoWhatever` functions are typed as potentially undefined and require optional chaining (`Global_DoWhatever?.(...)`) whenever they're called. This is ugly and somewhat unintuitive because these functions are, in practice, always defined when they'd be called

## Solution

I provided a default `() => {}` implementation so that they're always callable and don't include undefined in their type signature

## Verification

Type checking handles most of it, and I ran synthesis and checked that toasts still worked (they did)

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
