### PR TITLE
Bugfix: Can't Select Spacebar as Input `[AARD-1993]`

### DIFF
--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/inputs/EditInputInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/inputs/EditInputInterface.tsx
@@ -504,6 +504,7 @@ const EditInputInterface: React.FC<EditInputProps> = ({ input, useGamepad, useTo
     return (
         <Box
             onKeyUp={e => {
+                e.preventDefault()
                 if (selectedInput != "") setChosenKey(selectedInput ? e.code : "")
                 setModifierState({
                     ctrl: e.ctrlKey,


### PR DESCRIPTION
## Task
Fix a bug where the user can't select space to be a button input.
<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-1993

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->
In the configure assets panel, if you try to link the spacebar to an action, it successfully links, but the button text still shows Press anything.
<img width="331" height="57" alt="Screenshot 2025-07-11 083012" src="https://github.com/user-attachments/assets/90744630-9946-4235-8101-d90280d52a91" />

## Solution
Disable default key functionality if the user has the controls box selected.
<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

## Verification
If you try and set space to a button input it now works.
<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
