### PR TITLE
Clean Up Center of Mass Indicator on Dispose `[AARD-1987]`

### DIFF
--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -353,12 +353,14 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
         })
         this._debugBodies?.clear()
         this._physicsLayerReserve?.release()
-        this._centerOfMassIndicator?.geometry?.dispose()
+        if (this._centerOfMassIndicator) {
+            World.sceneRenderer.scene.remove(this._centerOfMassIndicator)
+            this._centerOfMassIndicator = undefined
+            this._centerOfMassListenerUnsubscribe?.()
+        }
+
         if (this._brain && this._brain instanceof SynthesisBrain) {
             this._brain.clearControls()
-        }
-        if (this._centerOfMassListenerUnsubscribe) {
-            this._centerOfMassListenerUnsubscribe()
         }
     }
 


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-1987

<!--
Provide a brief description of what the task was here.
-->


## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->
Center of mass indicator would persist after deleting a robot
<img width="200" height="128" alt="image" src="https://github.com/user-attachments/assets/220802de-f768-4f83-a906-cb7df33c6ca1" />


## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

COM indicator is now removed from the scene when the parent robot is disposed of

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

1. Spawned robot
2. Turned on center of mass indicators
3. Deleted robot
4. Observed that indicator was gone
---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
