### PR TITLE
Use Local Assets in Development If Possible `[AARD-2008]`

### DIFF
--- a/fission/tsconfig.node.json
+++ b/fission/tsconfig.node.json
@@ -5,7 +5,8 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
-    "strict": true
+    "strict": true,
+    "target": "ESNext"
   },
   "include": ["vite.config.ts"]
 }

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -41,7 +41,7 @@ const localAssetsExist = await fs.access("./public/Downloadables/Mira",fs.consta
 
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode, }) => {
+export default defineConfig(({ mode }) => {
     process.env = {...process.env, ...loadEnv(mode, process.cwd())};
 
     const useLocalAssets = localAssetsExist && (mode === "test" || process.env.NODE_ENV=="development")

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -4,7 +4,7 @@ import react from "@vitejs/plugin-react-swc"
 import basicSsl from "@vitejs/plugin-basic-ssl"
 import glsl from "vite-plugin-glsl"
 import { loadEnv, ProxyOptions } from "vite"
-
+import fs from "node:fs/promises"
 const basePath = "/fission/"
 const serverPort = 3000
 const dockerServerPort = 80
@@ -37,34 +37,45 @@ if (useSsl) {
     plugins.push(basicSsl())
 }
 
+const localAssetsExist = await fs.access("./public/Downloadables/Mira",fs.constants.R_OK).then(() => true).catch(() => false)
+
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode, }) => {
     process.env = {...process.env, ...loadEnv(mode, process.cwd())};
-    const useLocalAssets = mode === "test" || process.env.DEV
+
+    const useLocalAssets = localAssetsExist && (mode === "test" || process.env.NODE_ENV=="development")
+
+    if (!localAssetsExist && (mode === "test" || process.env.NODE_ENV=="development")) {
+        console.warn("Can't find local assets, do you need to run `npm run assetpack`?")
+    }
+
+    console.log(`Using ${useLocalAssets?"local":"remote"} mirabuf assets`)
+
     const proxies: Record<string, ProxyOptions> = {}
     proxies["/api/mira"] = useLocalAssets
         ? {
-              target: `http://localhost:${mode === "test" ? 3001 : serverPort}`,
-              changeOrigin: true,
-              secure: false,
-              rewrite: path => path.replace(/^\/api\/mira/, "/Downloadables/Mira").replace("robots", "Robots").replace("fields", "Fields"),
-          }
+            target: `http://localhost:${mode === "test" ? 3001 : serverPort}`,
+            changeOrigin: true,
+            secure: false,
+            rewrite: path => path.replace(/^\/api\/mira/, "/Downloadables/Mira").replace("robots", "Robots").replace("fields", "Fields"),
+        }
         : {
-              target: `https://synthesis.autodesk.com/`,
-              changeOrigin: true,
-              secure: true,
-          }
+            target: `https://synthesis.autodesk.com/`,
+            changeOrigin: true,
+            secure: true,
+        }
     proxies["/api/aps"] = useLocalAPS
         ? {
-              target: `http://localhost:${dockerServerPort}/`,
-              changeOrigin: true,
-              secure: false,
-          }
+            target: `http://localhost:${dockerServerPort}/`,
+            changeOrigin: true,
+            secure: false,
+        }
         : {
-              target: `https://synthesis.autodesk.com/`,
-              changeOrigin: true,
-              secure: true,
-          }
+            target: `https://synthesis.autodesk.com/`,
+            changeOrigin: true,
+            secure: true,
+        }
 
     return {
         plugins: plugins,

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -39,7 +39,6 @@ if (useSsl) {
 
 const localAssetsExist = await fs.access("./public/Downloadables/Mira",fs.constants.R_OK).then(() => true).catch(() => false)
 
-
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
     process.env = {...process.env, ...loadEnv(mode, process.cwd())};


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-2008

Use the local asset serving from #1225 in development too
<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->
When synthesis.autodesk.com is slow or otherwise difficult to use, assets can't be imported from the panel during development.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->
Served the local assets stored in git LFS if the asset folder exists, otherwise uses remote assets as before

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

Confirm that if you have the assets downloaded, it says "using local mirabuf assets" when running `npm run dev`. If you don't have the assets, confirm that it still falls back to the production server

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
