### PR TITLE
Allow Cancelling Match Mode `[AARD-2009]`

### DIFF
--- a/fission/src/systems/MatchMode.ts
+++ b/fission/src/systems/MatchMode.ts
@@ -20,10 +20,13 @@ export const DEFAULT_ENDGAME_TIME = 20
 
 class MatchMode {
     private static _instance: MatchMode
-    private _matchEnabled: boolean = false
     private _endgame: boolean = false
     private _matchModeType: MatchModeType = MatchModeType.SANDBOX
 
+    private setMatchModeType(val:MatchModeType) {
+        this._matchModeType = val
+        new MatchStateChangeEvent(val).dispatch()
+    }
     private _initialTime: number = 0
     private _timeLeft: number = 0
     private _intervalId: number | null = null
@@ -77,7 +80,7 @@ class MatchMode {
 
     autonomousModeStart(openModal: (modalName: string) => void) {
         SoundPlayer.play(MatchStart)
-        this._matchModeType = MatchModeType.AUTONOMOUS
+        this.setMatchModeType(MatchModeType.AUTONOMOUS)
         this.startTimer(this._matchModeConfig.autonomousTime, () => this.autonomousModeEnd(openModal))
     }
 
@@ -88,7 +91,7 @@ class MatchMode {
 
     teleopModeStart(openModal: (modalName: string) => void) {
         SoundPlayer.play(MatchResume)
-        this._matchModeType = MatchModeType.TELEOP
+        this.setMatchModeType(MatchModeType.TELEOP)
         this.startTimer(this._matchModeConfig.teleopTime, () => this.matchEnded(openModal))
     }
 
@@ -98,7 +101,6 @@ class MatchMode {
     }
 
     start(openModal: (modalName: string) => void) {
-        this._matchEnabled = true
         this.autonomousModeStart(openModal)
         SimulationSystem.resetScores()
     }
@@ -106,14 +108,12 @@ class MatchMode {
     matchEnded(openModal: (modalName: string) => void) {
         SoundPlayer.play(MatchEnd)
         clearInterval(this._intervalId as number)
-        this._matchEnabled = false
-        this._matchModeType = MatchModeType.MATCH_ENDED
+        this.setMatchModeType(MatchModeType.MATCH_ENDED)
         if (openModal) openModal("match-results")
     }
 
     sandboxModeStart() {
-        this._matchEnabled = false
-        this._matchModeType = MatchModeType.SANDBOX
+        this.setMatchModeType(MatchModeType.SANDBOX)
         clearInterval(this._intervalId as number)
         this._initialTime = 0
         this._timeLeft = 0
@@ -122,7 +122,7 @@ class MatchMode {
     }
 
     isMatchEnabled(): boolean {
-        return this._matchEnabled
+        return !(this._matchModeType == MatchModeType.SANDBOX || this._matchModeType == MatchModeType.MATCH_ENDED)
     }
 
     isEndgame(): boolean {
@@ -132,6 +132,7 @@ class MatchMode {
     getMatchModeType(): MatchModeType {
         return this._matchModeType
     }
+
 }
 
 export default MatchMode
@@ -158,3 +159,26 @@ export class UpdateTimeLeft extends Event {
         window.removeEventListener(UpdateTimeLeft.EVENT_KEY, func as (e: Event) => void)
     }
 }
+
+export class MatchStateChangeEvent extends Event {
+    public static readonly EVENT_KEY = "MatchEnd"
+
+    public readonly matchModeType:MatchModeType
+    constructor(matchModeType:MatchModeType) {
+        super(MatchStateChangeEvent.EVENT_KEY)
+        this.matchModeType = matchModeType
+    }
+
+    public dispatch(): void {
+        window.dispatchEvent(this)
+    }
+
+    public static addListener(func: (e: MatchStateChangeEvent) => void) {
+        window.addEventListener(MatchStateChangeEvent.EVENT_KEY, func as (e: Event) => void)
+    }
+
+    public static removeListener(func: (e: MatchStateChangeEvent) => void) {
+        window.removeEventListener(MatchStateChangeEvent.EVENT_KEY, func as (e: Event) => void)
+    }
+}
+

--- a/fission/src/systems/MatchMode.ts
+++ b/fission/src/systems/MatchMode.ts
@@ -23,7 +23,7 @@ class MatchMode {
     private _endgame: boolean = false
     private _matchModeType: MatchModeType = MatchModeType.SANDBOX
 
-    private setMatchModeType(val:MatchModeType) {
+    private setMatchModeType(val: MatchModeType) {
         this._matchModeType = val
         new MatchStateChangeEvent(val).dispatch()
     }
@@ -132,7 +132,6 @@ class MatchMode {
     getMatchModeType(): MatchModeType {
         return this._matchModeType
     }
-
 }
 
 export default MatchMode
@@ -163,8 +162,8 @@ export class UpdateTimeLeft extends Event {
 export class MatchStateChangeEvent extends Event {
     public static readonly EVENT_KEY = "MatchEnd"
 
-    public readonly matchModeType:MatchModeType
-    constructor(matchModeType:MatchModeType) {
+    public readonly matchModeType: MatchModeType
+    constructor(matchModeType: MatchModeType) {
         super(MatchStateChangeEvent.EVENT_KEY)
         this.matchModeType = matchModeType
     }
@@ -181,4 +180,3 @@ export class MatchStateChangeEvent extends Event {
         window.removeEventListener(MatchStateChangeEvent.EVENT_KEY, func as (e: Event) => void)
     }
 }
-

--- a/fission/src/ui/components/MainHUD.tsx
+++ b/fission/src/ui/components/MainHUD.tsx
@@ -200,26 +200,27 @@ const MainHUD: React.FC = () => {
                         onClick={() => APS.requestAuthCode()}
                     />
                 )}
-                {!matchModeRunning ?
-                <MainHUDButton
-                    value={"Start Match Mode"}
-                    icon={SynthesisIcons.GAMEPAD}
-                    larger={true}
-                    onClick={() => {
-                        openPanel("match-mode-config")
-                        setIsOpen(false)
-                    }}
-                />:
-                <MainHUDButton
-                    value={"Abort Match Mode"}
-                    icon={SynthesisIcons.XMARK_LARGE}
-                    larger={true}
-                    onClick={() => {
-                        MatchMode.getInstance().sandboxModeStart()
-                        globalAddToast("info", "Match Mode Cancelled", "")
-                    }}
-                />
-                }
+                {!matchModeRunning ? (
+                    <MainHUDButton
+                        value={"Start Match Mode"}
+                        icon={SynthesisIcons.GAMEPAD}
+                        larger={true}
+                        onClick={() => {
+                            openPanel("match-mode-config")
+                            setIsOpen(false)
+                        }}
+                    />
+                ) : (
+                    <MainHUDButton
+                        value={"Abort Match Mode"}
+                        icon={SynthesisIcons.XMARK_LARGE}
+                        larger={true}
+                        onClick={() => {
+                            MatchMode.getInstance().sandboxModeStart()
+                            globalAddToast("info", "Match Mode Cancelled", "")
+                        }}
+                    />
+                )}
             </motion.div>
         </>
     )

--- a/fission/src/ui/components/MainHUD.tsx
+++ b/fission/src/ui/components/MainHUD.tsx
@@ -212,7 +212,7 @@ const MainHUD: React.FC = () => {
                 />:
                 <MainHUDButton
                     value={"Abort Match Mode"}
-                    icon={SynthesisIcons.XMARK}
+                    icon={SynthesisIcons.XMARK_LARGE}
                     larger={true}
                     onClick={() => {
                         MatchMode.getInstance().sandboxModeStart()

--- a/fission/src/ui/components/MainHUD.tsx
+++ b/fission/src/ui/components/MainHUD.tsx
@@ -13,7 +13,7 @@ import { Box } from "@mui/material"
 import { TouchControlsEvent, TouchControlsEventKeys } from "./TouchControls"
 import { setAddToast } from "./GlobalUIControls"
 import { SoundPlayer } from "@/systems/sound/SoundPlayer"
-import MatchMode from "@/systems/MatchMode"
+import MatchMode, { MatchStateChangeEvent } from "@/systems/MatchMode"
 import { globalAddToast } from "@/components/GlobalUIControls.ts"
 
 type ButtonProps = {
@@ -66,10 +66,17 @@ const MainHUD: React.FC = () => {
     setAddToast(addToast)
 
     const [userInfo, setUserInfo] = useState(APS.userInfo)
+    const [matchModeRunning, setMatchModeRunning] = useState(MatchMode.getInstance().isMatchEnabled())
 
     useEffect(() => {
         document.addEventListener(APS_USER_INFO_UPDATE_EVENT, () => {
             setUserInfo(APS.userInfo)
+        })
+    }, [])
+
+    useEffect(() => {
+        MatchStateChangeEvent.addListener(() => {
+            setMatchModeRunning(MatchMode.getInstance().isMatchEnabled())
         })
     }, [])
 
@@ -193,21 +200,26 @@ const MainHUD: React.FC = () => {
                         onClick={() => APS.requestAuthCode()}
                     />
                 )}
+                {!matchModeRunning ?
                 <MainHUDButton
                     value={"Start Match Mode"}
                     icon={SynthesisIcons.GAMEPAD}
                     larger={true}
                     onClick={() => {
-                        MatchMode.getInstance().isMatchEnabled()
-                            ? globalAddToast(
-                                  "error",
-                                  "Match Mode Already Running",
-                                  "You can't start match mode if its already running"
-                              )
-                            : openPanel("match-mode-config")
+                        openPanel("match-mode-config")
                         setIsOpen(false)
                     }}
+                />:
+                <MainHUDButton
+                    value={"Abort Match Mode"}
+                    icon={SynthesisIcons.XMARK}
+                    larger={true}
+                    onClick={() => {
+                        MatchMode.getInstance().sandboxModeStart()
+                        globalAddToast("info", "Match Mode Cancelled", "")
+                    }}
                 />
+                }
             </motion.div>
         </>
     )


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-2009

Add a way to abort a running match

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->
Currently you have to reload the page to exit match mode, and the match mode button tells you that you cannot start a second match. The only way to end match mode without waiting for it to end is reloading the page.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

There is now an "Abort Match Mode" button in place of the "Start Match Mode" button while a match is active. 

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

- Check that a match ending naturally updates the state of the button correctly
- Check that aborting a match works properly and a new match can be started
- Check that the button shows "abort" when the match is active


---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
