### PR TITLE
Biome Readme Fix `[AARD-2015]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Fission - Unit Test](https://github.com/Autodesk/synthesis/actions/workflows/FissionUnitTest.yml/badge.svg?branch=prod)](https://github.com/Autodesk/synthesis/actions/workflows/FissionUnitTest.yml)
 [![Fission - Packaging](https://github.com/Autodesk/synthesis/actions/workflows/FissionPackage.yml/badge.svg?branch=prod)](https://github.com/Autodesk/synthesis/actions/workflows/FissionPackage.yml)
-[![Fission - Lint/Format](https://github.com/Autodesk/synthesis/actions/workflows/FissionESLintFormat.yml/badge.svg?branch=prod)](https://github.com/Autodesk/synthesis/actions/workflows/FissionESLintFormat.yml)
+[![Fission - Lint/Format](https://github.com/Autodesk/synthesis/actions/workflows/FissionBiome.yml/badge.svg?branch=prod)](https://github.com/Autodesk/synthesis/actions/workflows/FissionBiome.yml)
 [![Fusion - Format](https://github.com/Autodesk/synthesis/actions/workflows/BlackFormat.yml/badge.svg?branch=prod)](https://github.com/Autodesk/synthesis/actions/workflows/BlackFormat.yml)
 
 Synthesis is a robotics simulator designed by and for [FIRST®](https://www.firstinspires.org/) robotics students to help teams design, strategize, test and practice. Teams have the ability to import their own robots and fields using our [Fusion Exporter](/exporter/) or use the pre-made ones available within Synthesis.


### PR DESCRIPTION
## Task
A workflow was renamed, but the corresponding readme tag wasn't updated causing the readme to look like this.
<img width="811" height="180" alt="Screenshot 2025-07-23 at 11 22 27 AM" src="https://github.com/user-attachments/assets/7d042bc4-6cb0-480e-a2f1-9d92ead7fd11" />

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-2015

## Solution
Update the link so that the readme will look like this.

<img width="968" height="177" alt="Screenshot 2025-07-23 at 11 27 54 AM" src="https://github.com/user-attachments/assets/2bdb21aa-826b-431c-9385-0e32ac0f7f80" />


<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

## Verification
The new link leads to an actual image.
<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
