### PR TITLE
Show Alliance Color in Nametags `[AARD-2020]`

### DIFF
--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -491,6 +491,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
     /** Updates the position of the nametag relative to the robots position */
     private updateNameTag() {
         if (this._nameTag && PreferencesSystem.getGlobalPreference("RenderSceneTags")) {
+            this._nameTag.color = this._alliance
             const boundingBox = this.computeBoundingBox()
             this._nameTag.position = World.sceneRenderer.worldToPixelSpace(
                 new THREE.Vector3(

--- a/fission/src/ui/components/SceneOverlay.tsx
+++ b/fission/src/ui/components/SceneOverlay.tsx
@@ -38,7 +38,7 @@ const SceneOverlay: React.FC = () => {
                     position: "absolute",
                     left: x.position[0],
                     top: x.position[1],
-                    backgroundColor: "rgba(0, 0, 0, 0.5)",
+                    backgroundColor: x.getCSSColor(),
                     borderRadius: "8px",
                     padding: "8px",
                     whiteSpace: "nowrap",

--- a/fission/src/ui/components/SceneOverlayEvents.ts
+++ b/fission/src/ui/components/SceneOverlayEvents.ts
@@ -1,3 +1,5 @@
+import { Alliance } from "@/systems/preferences/PreferenceTypes.ts"
+
 let nextTagId = 0
 
 /* Coordinates for tags in world space */
@@ -22,9 +24,11 @@ export const enum SceneOverlayEventKey {
  * @param text The text to display
  * @param position The position of the tag in screen space (default: [0,0])
  */
+
 export class SceneOverlayTag {
     private _id: number
     public text: () => string
+    public color?: Alliance
     public position: PixelSpaceCoord // Screen Space
 
     public get id() {
@@ -32,17 +36,29 @@ export class SceneOverlayTag {
     }
 
     /** Create a new tag */
-    public constructor(text: () => string, position?: PixelSpaceCoord) {
+    public constructor(text: () => string, position?: PixelSpaceCoord, color?: Alliance) {
         this._id = nextTagId++
 
         this.text = text
         this.position = position ?? [0, 0]
+        this.color = color
         new SceneOverlayTagEvent(SceneOverlayTagEventKey.ADD, this)
     }
 
     /** Removing the tag */
     public dispose() {
         new SceneOverlayTagEvent(SceneOverlayTagEventKey.REMOVE, this)
+    }
+
+    public getCSSColor(): string {
+        switch (this.color) {
+            case "red":
+                return "rgba(166,22,27,0.5)"
+            case "blue":
+                return "rgba(0,74,129,0.5)"
+            default:
+                return "rgba(0,0,0,0.5)"
+        }
     }
 }
 


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-2020

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->
Currently the only way to identify the alliance of a robot is to open its configuration panel and check what the alliance is set to. 

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->
The nametags above each robot now render with the alliance color that the robot is configured for

<img width="1388" height="836" alt="image" src="https://github.com/user-attachments/assets/974eb816-68c2-429d-90f1-d00c3adac493" />


## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

Confirm that the colors match the assigned alliance, and that changing the alliance changes the colors

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
