### PR TITLE
Proper Error Handling When No Grounded Node Found

### DIFF
--- a/exporter/SynthesisFusionAddin/src/ErrorHandling.py
+++ b/exporter/SynthesisFusionAddin/src/ErrorHandling.py
@@ -129,6 +129,7 @@ def handle_err_top(func: Callable[..., Result[None]]) -> Callable[..., None]:
 
     def wrapper(*args, **kwargs):  # type: ignore
         result = func(*args, **kwargs)
+
         if result.is_err():
             message, severity = result.unwrap_err()
             if severity == ErrorSeverity.Fatal:

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/JointHierarchy.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/JointHierarchy.py
@@ -223,7 +223,7 @@ class JointParser:
 
         if self.grounded is None:
             message = "There is not a pinned component in this assembly, aborting kinematic export."
-            gm.ui.messageBox(message)
+            # gm.ui.messageBox(message)
             _____: Err[None] = Err(message, ErrorSeverity.Fatal)
             raise RuntimeError(message)
 

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/JointHierarchy.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/JointHierarchy.py
@@ -523,12 +523,9 @@ def buildJointPartHierarchy(
 
         return Ok(None)
 
-    # I'm fairly certain bubbling this back up is the way to go <- Actually it's ugly but doesn't really matter and there isn't a better option
     except:
         progressDialog.progressDialog.hide()
-        # We don't want two errors to pop up, we exit to prevent dealing with two error messages for the same issue and with re-exporting an empty file
         raise RuntimeError()
-        # sys.exit(1)
 
 
 def populateJoint(simNode: SimulationNode, joints: joint_pb2.Joints, progressDialog: PDMessage) -> Result[None]:

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/JointHierarchy.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/JointHierarchy.py
@@ -1,6 +1,7 @@
 import enum
 import sys
 from logging import ERROR
+from os import error
 from typing import Any, Iterator, cast
 
 import adsk.core
@@ -221,7 +222,7 @@ class JointParser:
         self.grounded = searchForGrounded(design.rootComponent)
 
         if self.grounded is None:
-            message = "These is no grounded component in this assembly, aborting kinematic export."
+            message = "There is not a grounded component in this assembly, aborting kinematic export."
             gm.ui.messageBox(message)
             _____: Err[None] = Err(message, ErrorSeverity.Fatal)
             raise RuntimeError()
@@ -522,12 +523,11 @@ def buildJointPartHierarchy(
 
         return Ok(None)
 
-    # I'm fairly certain bubbling this back up is the way to go
-    except Warning:
-        return Err(
-            "Instantiation of the JointParser failed, likely due to a lack of a grounded component in the assembly",
-            ErrorSeverity.Fatal,
-        )
+    # I'm fairly certain bubbling this back up is the way to go <- Actually it's ugly but doesn't really matter and there isn't a better option
+    except:
+        progressDialog.progressDialog.hide()
+        # We don't want two errors to pop up, we exit to prevent dealing with two error messages for the same issue and with re-exporting an empty file
+        sys.exit(1)
 
 
 def populateJoint(simNode: SimulationNode, joints: joint_pb2.Joints, progressDialog: PDMessage) -> Result[None]:

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/JointHierarchy.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/JointHierarchy.py
@@ -527,7 +527,8 @@ def buildJointPartHierarchy(
     except:
         progressDialog.progressDialog.hide()
         # We don't want two errors to pop up, we exit to prevent dealing with two error messages for the same issue and with re-exporting an empty file
-        sys.exit(1)
+        raise RuntimeError()
+        # sys.exit(1)
 
 
 def populateJoint(simNode: SimulationNode, joints: joint_pb2.Joints, progressDialog: PDMessage) -> Result[None]:

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/JointHierarchy.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/JointHierarchy.py
@@ -222,10 +222,10 @@ class JointParser:
         self.grounded = searchForGrounded(design.rootComponent)
 
         if self.grounded is None:
-            message = "There is not a grounded component in this assembly, aborting kinematic export."
+            message = "There is not a pinned component in this assembly, aborting kinematic export."
             gm.ui.messageBox(message)
             _____: Err[None] = Err(message, ErrorSeverity.Fatal)
-            raise RuntimeError()
+            raise RuntimeError(message)
 
         self.currentTraversal: dict[str, DynamicOccurrenceNode | bool] = dict()
         self.groundedConnections: list[adsk.fusion.Occurrence] = []
@@ -248,7 +248,7 @@ class JointParser:
             message = populate_node_result.unwrap_err()[0]
             gm.ui.messageBox(message)
             ____: Err[None] = Err(message, ErrorSeverity.Fatal)
-            raise RuntimeError()
+            raise RuntimeError(message)
 
         rootNode = populate_node_result.unwrap()
         self.groundSimNode = SimulationNode(rootNode, None, grounded=True)
@@ -523,9 +523,9 @@ def buildJointPartHierarchy(
 
         return Ok(None)
 
-    except:
+    except RuntimeError as e:
         progressDialog.progressDialog.hide()
-        raise RuntimeError()
+        raise e
 
 
 def populateJoint(simNode: SimulationNode, joints: joint_pb2.Joints, progressDialog: PDMessage) -> Result[None]:

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Parser.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Parser.py
@@ -148,7 +148,10 @@ class Parser:
             self.pdMessage,
         )
 
-        JointHierarchy.buildJointPartHierarchy(design, assembly_out.data.joints, self.exporterOptions, self.pdMessage)
+        try:
+            JointHierarchy.buildJointPartHierarchy(design, assembly_out.data.joints, self.exporterOptions, self.pdMessage)
+        except RuntimeError as e: 
+            raise e
 
         # These don't have an effect, I forgot how this is suppose to work
         # progressDialog.message = "Taking Photo for thumbnail..."

--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Parser.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Parser.py
@@ -149,8 +149,10 @@ class Parser:
         )
 
         try:
-            JointHierarchy.buildJointPartHierarchy(design, assembly_out.data.joints, self.exporterOptions, self.pdMessage)
-        except RuntimeError as e: 
+            JointHierarchy.buildJointPartHierarchy(
+                design, assembly_out.data.joints, self.exporterOptions, self.pdMessage
+            )
+        except RuntimeError as e:
             raise e
 
         # These don't have an effect, I forgot how this is suppose to work

--- a/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
+++ b/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
@@ -247,8 +247,7 @@ class IncomingHTMLMessageHandler(PersistentEventHandler, adsk.core.HTMLEventHand
             )
         elif html_args.action == "export":
             opts = moduleExporterOptions.ExporterOptions().readFromJSON(data)
-            export(opts)
-            html_args.returnData = "{}"
+            export(opts, html_args)
         elif html_args.action == "save":
             opts = moduleExporterOptions.ExporterOptions().readFromJSON(data)
             opts.writeToDesign()
@@ -336,7 +335,7 @@ def buildGamepiece(gamepiece: adsk.fusion.Occurrence) -> dict[str, Any]:
 
 
 @logFailure(messageBox=True)
-def export(exporterOptions: moduleExporterOptions.ExporterOptions) -> None:
+def export(exporterOptions: moduleExporterOptions.ExporterOptions, html_args: adsk.core.HTMLEventArgs) -> None:
     logger.info("NEWUI")
     logger.info(exporterOptions)
     design = adsk.fusion.Design.cast(adsk.core.Application.get().activeProduct)
@@ -363,9 +362,11 @@ def export(exporterOptions: moduleExporterOptions.ExporterOptions) -> None:
 
     try:
         Parser.Parser(exporterOptions).export()
-    except:
+    except RuntimeError as e:
+        html_args.returnData = json.dumps({"_err": str(e)})
         return
     exporterOptions.writeToDesign()
+    html_args.returnData = "{}"
 
     if exporterOptions.openSynthesisUponExport:
         res = webbrowser.open(APP_WEBSITE_URL)

--- a/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
+++ b/exporter/SynthesisFusionAddin/src/UI/ConfigCommand.py
@@ -361,7 +361,10 @@ def export(exporterOptions: moduleExporterOptions.ExporterOptions) -> None:
     exporterOptions.version = docVersion
     exporterOptions.materials = 0
 
-    Parser.Parser(exporterOptions).export()
+    try:
+        Parser.Parser(exporterOptions).export()
+    except:
+        return
     exporterOptions.writeToDesign()
 
     if exporterOptions.openSynthesisUponExport:
@@ -431,7 +434,10 @@ class ConfigureCommandExecuteHandler(PersistentEventHandler, adsk.core.CommandEv
         try:
             Parser.Parser(exporterOptions).export()
         except:
-            pass
+            jointConfigTab.reset()
+            gamepieceConfigTab.reset()
+
+            return
         exporterOptions.writeToDesign()
         jointConfigTab.reset()
         gamepieceConfigTab.reset()

--- a/exporter/SynthesisFusionAddin/web/src/App.tsx
+++ b/exporter/SynthesisFusionAddin/web/src/App.tsx
@@ -290,7 +290,7 @@ function App() {
                     variant="contained"
                     color="primary"
                     sx={{ flexGrow: 9 }}
-                    onClick={async () => sendData("export", await getFinalizedConfig())}
+                    onClick={async () => sendDataAndToast("export", await getFinalizedConfig(), "Exported!")}
                     startIcon={<DownloadIcon />}
                 >
                     Export

--- a/exporter/SynthesisFusionAddin/web/src/App.tsx
+++ b/exporter/SynthesisFusionAddin/web/src/App.tsx
@@ -290,7 +290,7 @@ function App() {
                     variant="contained"
                     color="primary"
                     sx={{ flexGrow: 9 }}
-                    onClick={async () => sendDataAndToast("export", await getFinalizedConfig(), "Exported!")}
+                    onClick={async () => sendData("export", await getFinalizedConfig())}
                     startIcon={<DownloadIcon />}
                 >
                     Export

--- a/exporter/SynthesisFusionAddin/web/src/lib/index.ts
+++ b/exporter/SynthesisFusionAddin/web/src/lib/index.ts
@@ -40,6 +40,12 @@ const errorMatchers: { text: string; cb: () => void }[] = [
             Global_SetAlert("info", "Selection cancelled")
         },
     },
+    {
+        text: "not a pinned",
+        cb: () => {
+            Global_SetAlert("error", "No Grounded Joint On Assembly")
+        },
+    },
 ]
 
 export async function sendData<A extends keyof Messages>(

--- a/exporter/SynthesisFusionAddin/web/src/lib/index.ts
+++ b/exporter/SynthesisFusionAddin/web/src/lib/index.ts
@@ -70,9 +70,10 @@ export async function sendData<A extends keyof Messages>(
             })
             if (!wasHandled) {
                 console.error({ action, errorResponse: parsed._err })
+                return undefined
             }
 
-            return undefined
+            return parsed as Messages[A][1] & { _err: string }
         }
         return parsed as Messages[A][1]
     } catch (error) {
@@ -91,9 +92,12 @@ export async function sendDataAndToast<A extends keyof Messages>(
 
     if (resp === undefined) {
         Global_SetAlert("error", failureMsg)
-    } else {
+    } else if (resp._err === undefined) {
         Global_SetAlert("info", sucessMsg)
+    } else {
+        return undefined
     }
+
     return resp
 }
 

--- a/exporter/SynthesisFusionAddin/web/src/lib/index.ts
+++ b/exporter/SynthesisFusionAddin/web/src/lib/index.ts
@@ -43,7 +43,7 @@ const errorMatchers: { text: string; cb: () => void }[] = [
     {
         text: "not a pinned",
         cb: () => {
-            Global_SetAlert("error", "No Grounded Joint On Assembly")
+            Global_SetAlert("error", "Please pin a component to export the assembly")
         },
     },
 ]


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-1995

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

When exporting is aborted due to there being no grounded node in the assembly (usually because there is no assembly), a traceback appeared and the progress dialogue did not close automatically.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

When the `buildJointPartHierarchy` function catches the raised error from `JointParser.__init__`, it hides the progress dialogue then calls raises another error to abort parsing. Additionally, when runtime exceptions are caught from `Parser.export()` in both `ConfigCommand.export()` (new UI) and `notify()` (old UI), the parent function returns instead of passing, aborting the export.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

Export a blank assembly, observe that no file is saved, the progress dialogue is closed, and no traceback is displayed.

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
