### PR TITLE
Scale Drag Mode Torque `[AARD-2035]`

### DIFF
--- a/fission/src/systems/scene/DragModeSystem.ts
+++ b/fission/src/systems/scene/DragModeSystem.ts
@@ -60,7 +60,7 @@ class DragModeSystem extends WorldSystem {
         // Precision and sensitivity
         MINIMUM_DISTANCE_THRESHOLD: 0.02, // Minimum distance to apply forces (smaller = more precision)
         WHEEL_SCROLL_SENSITIVITY: -0.01, // Mouse wheel scroll sensitivity for Z-axis
-        ROTATION_SPEED: 200.0, // speed of arrow key rotation. lower = more precise, higher = more
+        ROTATION_SPEED: 1500.0, // speed of arrow key rotation. lower = more precise, higher = more
     } as const
 
     private _enabled: boolean = false
@@ -566,17 +566,22 @@ class DragModeSystem extends WorldSystem {
             const joltForce = convertThreeVector3ToJoltVec3(forceNeeded)
             body.AddForce(joltForce)
 
+            const inertia = body.GetMotionProperties().GetInverseInertiaDiagonal()
+            const moi = 1.0 / inertia.Length()
             const yawRotation = new JOLT.Vec3(
                 0,
-                DragModeSystem.DRAG_FORCE_CONSTANTS.ROTATION_SPEED *
+                moi *
+                    DragModeSystem.DRAG_FORCE_CONSTANTS.ROTATION_SPEED *
                     (InputSystem.isKeyPressed("ArrowRight") ? 1 : 0 - (InputSystem.isKeyPressed("ArrowLeft") ? 1 : 0)),
                 0
             )
             const cameraVector = World.sceneRenderer.mainCamera.getWorldDirection(new THREE.Vector3(0, 0, 0))
             const pitchRotation = new JOLT.Vec3(cameraVector.z, 0, -cameraVector.x).Mul(
-                DragModeSystem.DRAG_FORCE_CONSTANTS.ROTATION_SPEED *
+                moi *
+                    DragModeSystem.DRAG_FORCE_CONSTANTS.ROTATION_SPEED *
                     (InputSystem.isKeyPressed("ArrowUp") ? 1 : 0 - (InputSystem.isKeyPressed("ArrowDown") ? 1 : 0))
             )
+
             body.AddTorque(yawRotation)
             body.AddTorque(pitchRotation)
         } else {


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-2035

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Currently using the arrows in drag mode is a reasonable speed for some gamepieces and very slow for robots, very fast for some other gamepieces

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

The torque is now proportional to the length of the diagonal inertia vector. This means it's not accounting for different moments in different axes, but it's close enough that everything goes at a reasonably similar speed and it's neither too fast nor too slow

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->
- Spin robots
- Spin 2018 Power Cube
- Spin 2023 Cone
- Spin 2023 Cube
---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
