### PR TITLE
Versioned Preference System

### DIFF
--- a/fission/package.json
+++ b/fission/package.json
@@ -1,7 +1,7 @@
 {
   "name": "synthesis-fission",
   "private": false,
-  "version": "0.0.1",
+  "version": "7.2.0",
   "type": "module",
   "scripts": {
     "init": "(bun run assetpack && bun run playwright:install) || (npm run assetpack && npm run playwright:install)",

--- a/fission/src/systems/preferences/PreferenceMigrations.ts
+++ b/fission/src/systems/preferences/PreferenceMigrations.ts
@@ -1,0 +1,27 @@
+
+import { Preferences } from "./PreferenceTypes"
+
+type Migration = (prefs: any) => any
+
+// Migrations are written to be forward-compatible
+const migrations: { [key: string]: Migration } = {
+    "7.2.0": prefs => {
+        prefs.version = "7.2.0"
+        return prefs
+    },
+}
+
+export function migratePreferences(prefs: Partial<Preferences>): Partial<Preferences> {
+    const version = prefs.version ?? "0.0.0"
+
+    const versionsToMigrate = Object.keys(migrations).sort()
+
+    let migratedPrefs = { ...prefs }
+    for (const v of versionsToMigrate) {
+        if (version < v) {
+            migratedPrefs = migrations[v](migratedPrefs)
+        }
+    }
+
+    return migratedPrefs
+}

--- a/fission/src/systems/preferences/PreferenceTypes.ts
+++ b/fission/src/systems/preferences/PreferenceTypes.ts
@@ -31,6 +31,7 @@ export type GlobalPreferences = {
 export type GlobalPreference = keyof GlobalPreferences
 
 export type Preferences = GlobalPreferences & {
+    version: string
     [ROBOT_PREFERENCE_KEY]: Record<string, RobotPreferences>
     [FIELD_PREFERENCE_KEY]: Record<string, FieldPreferences>
     [MOTOR_PREFERENCES_KEY]: Record<string, MotorPreferences>

--- a/fission/src/systems/preferences/PreferencesSystem.ts
+++ b/fission/src/systems/preferences/PreferencesSystem.ts
@@ -1,3 +1,5 @@
+import { migratePreferences } from "./PreferenceMigrations"
+import { version } from "../../../package.json"
 import {
     defaultFieldPreferences,
     defaultGlobalPreferences,
@@ -210,15 +212,17 @@ class PreferencesSystem {
         const loadedPrefs = window.localStorage.getItem(this._localStorageKey)
 
         if (loadedPrefs == undefined) {
-            this._preferences = {}
+            this._preferences = { version: version }
             return
         }
 
         try {
-            this._preferences = JSON.parse(loadedPrefs)
+            const parsed = JSON.parse(loadedPrefs)
+            this._preferences = migratePreferences(parsed)
+            this._preferences.version = version
         } catch (e) {
             console.error(e)
-            this._preferences = {}
+            this._preferences = { version: version }
         }
     }
 


### PR DESCRIPTION
AARD-2025

## Symptom

After removing/adding something to the preference system during development, users' preferences will be 'outdated' which can cause misalignments between what is stored in their local storage cache and 

## Task

Add a versioning to the Preference System that will enable Synthesis to migrate between versions when the production has been pushed to prevent users from running into issues when a new version is released and their local preferences are outdated.

## Solution

Added a `version` to global preferences to determine whether a client's versioning system is outdated & a migration system to translate the old preferences to be compatible with the new version of fission.

## Verification

Manually changing the version of the preference system and modifying any of the keys of the preferences themselves.

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
