### PR TITLE
Upload File Accepts Only Mira Files `[AARD-2046]`

### DIFF
--- a/fission/src/ui/modals/mirabuf/ImportLocalMirabufModal.tsx
+++ b/fission/src/ui/modals/mirabuf/ImportLocalMirabufModal.tsx
@@ -91,7 +91,7 @@ const ImportLocalMirabufModal: React.FC<ModalImplProps<void, void>> = ({ modal }
             </ToggleButtonGroup>
             <Button component="label" role={undefined}>
                 Upload File
-                <VisuallyHiddenInput type="file" onChange={onInputChanged} multiple />
+                <VisuallyHiddenInput type="file" onChange={onInputChanged} multiple accept=".mira" />
             </Button>
             {selectedFile && <Label className="text-center" size="sm">{`Selected File: ${selectedFile.name}`}</Label>}
         </Stack>


### PR DESCRIPTION
## Task
Change the Mira upload file for robot/field uploads to only accept .mira files.
<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-2046

<!--
Provide a brief description of what the task was here.
-->

## Symptom
Currently when navigating to spawn asset, and then import form file, you can select and upload any file (such as .mp4, .pdf, etc), even though uploading any of these formats will just result in an error message.

Trying to find where your .mira file in downloads is located, can also be annoying, but configuring the upload to only accept .mira files, makes it easier to find. This is because on Windows it automatically hides all unsuported file formats, and on MacOS it greys out unsupported files.
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

## Solution
Make it so that the input field only accepts .mira files
<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

## Verification
- Can't upload a non .mira file
- Can upload a .mira file
<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
