### PR TITLE
Spawning Fields without a Transform Gizmo

### DIFF
--- a/fission/src/ui/modals/mirabuf/ImportLocalMirabufModal.tsx
+++ b/fission/src/ui/modals/mirabuf/ImportLocalMirabufModal.tsx
@@ -54,11 +54,13 @@ const ImportLocalMirabufModal: React.FC<ModalImplProps<void, void>> = ({ modal }
                         }
                         return undefined
                     })
-                    .then(x => {
-                        if (x) {
-                            World.sceneRenderer.registerSceneObject(x)
+                    .then(mirabufSceneObject => {
+                        if (mirabufSceneObject) {
+                            World.sceneRenderer.registerSceneObject(mirabufSceneObject)
 
-                            openPanel(InitialConfigPanel, undefined, modal)
+                            if (mirabufSceneObject.miraType == MiraType.ROBOT) {
+                                openPanel(InitialConfigPanel, undefined, modal)
+                            }
                             closeModal(CloseType.Overwrite)
                         }
                     })

--- a/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
+++ b/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
@@ -108,12 +108,14 @@ export function spawnCachedMira(info: MirabufCacheInfo, type: MiraType, progress
     MirabufCachingService.get(info.id, type)
         .then(assembly => {
             if (assembly) {
-                createMirabuf(assembly, progressHandle, info.id).then(x => {
-                    if (x) {
-                        World.sceneRenderer.registerSceneObject(x)
+                createMirabuf(assembly, progressHandle, info.id).then(mirabufSceneObject => {
+                    if (mirabufSceneObject) {
+                        World.sceneRenderer.registerSceneObject(mirabufSceneObject)
                         progressHandle.done()
 
-                        globalOpenPanel(InitialConfigPanel, undefined)
+                        if (mirabufSceneObject.miraType == MiraType.ROBOT) {
+                            globalOpenPanel(InitialConfigPanel, undefined)
+                        }
                     } else {
                         progressHandle.fail()
                     }


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-2056

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Currently, when Fields are spawned, transform gizmos are applied to the field to allow users to move them. This is unnecessary since only 1 field can be spawned at a time regardless.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

The InitialConfig panel will only appear for Robots, also limiting the transform gizmos to only be applied to robots. To move a field, you can right click the field and click the "Move" button.

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
