### PR TITLE
Open Function Type Mismatch [AARD-2078]

### DIFF
--- a/fission/src/ui/helpers/UIProviderHelpers.ts
+++ b/fission/src/ui/helpers/UIProviderHelpers.ts
@@ -81,16 +81,16 @@ export interface Panel<T, P> extends UIScreen<T, P> {
 }
 
 export type OpenModalFn = <T, P>(
-    contents: FunctionComponent<ModalImplProps<T, P>>,
+    content: FunctionComponent<ModalImplProps<T, P>>,
     customProps: P,
     parent?: UIScreen<any, any>,
-    props?: Omit<ModalProps<P>, "type" | "configured" | "custom">
+    props?: Omit<ModalProps<P>, "type" | "configured" | "custom"> & Omit<UIScreenCallbacks<T>, "onBeforeAccept">
 ) => string
 export type OpenPanelFn = <T, P>(
-    contents: FunctionComponent<PanelImplProps<T, P>>,
+    content: FunctionComponent<PanelImplProps<T, P>>,
     customProps: P,
     parent?: UIScreen<any, any>,
-    props?: Omit<PanelProps<P>, "type" | "configured" | "custom">
+    props?: Omit<PanelProps<P>, "type" | "configured" | "custom"> & Omit<UIScreenCallbacks<T>, "onBeforeAccept">
 ) => string
 export type CloseModalFn = (closeType: CloseType) => void
 export type ClosePanelFn = (id: string, closeType: CloseType) => void


### PR DESCRIPTION
## Task

AARD-2078

## Symptom
The type of the `props` argument in the `OpenPanelFn` and `OpenModalFn` type definitions didn't allow for callbacks to be passed in, even though the parameter types in the function implementations did. This meant that the linter would complain about an unknown name even though passing in the callback would actually work.

## Solution
This was a trivial fix of just copying the types from the implementation to the type definition.

## Verification

The linter no longer complains about passing in the callbacks.

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
