### PR TITLE
Update Spawn Assets Placement `[AARD-2083]`

### DIFF
--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -508,10 +508,12 @@ class MirabufCachingService {
     ): Promise<MirabufCacheInfo | undefined> {
         try {
             const backupID = Date.now().toString()
-            if (!miraType) {
-                console.debug("Double loading")
-                miraType = this.assemblyFromBuffer(miraBuff).dynamic ? MiraType.ROBOT : MiraType.FIELD
+            // Infer actual type from buffer to ensure correct categorization
+            const inferredType = this.assemblyFromBuffer(miraBuff).dynamic ? MiraType.ROBOT : MiraType.FIELD
+            if (miraType !== undefined && miraType !== inferredType) {
+                console.debug("Overriding provided MiraType with inferred type from assembly buffer")
             }
+            miraType = inferredType
 
             // Local cache map
             const map: MapCache = this.getCacheMap(miraType)

--- a/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
+++ b/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
@@ -85,21 +85,22 @@ function getCacheInfo(miraType: MiraType): MirabufCacheInfo[] {
 }
 
 export function spawnCachedMira(info: MirabufCacheInfo, type: MiraType, progressHandle?: ProgressHandle) {
-    // If spawning a field, then remove all other fields
-    if (type === MiraType.FIELD) {
-        World.sceneRenderer.removeAllFields()
-    }
+    // Use the entry's own type to load from the correct cache directory
+    const effectiveType = info.miraType ?? type
 
     if (!progressHandle) {
         progressHandle = new ProgressHandle(info.name ?? info.cacheKey)
     }
 
     World.physicsSystem.holdPause(PAUSE_REF_ASSEMBLY_SPAWNING)
-    MirabufCachingService.get(info.id, type)
+    MirabufCachingService.get(info.id, effectiveType)
         .then(assembly => {
             if (assembly) {
                 createMirabuf(assembly, progressHandle, info.id).then(mirabufSceneObject => {
                     if (mirabufSceneObject) {
+                        if (mirabufSceneObject.miraType === MiraType.FIELD) {
+                            World.sceneRenderer.removeAllFields()
+                        }
                         World.sceneRenderer.registerSceneObject(mirabufSceneObject)
                         progressHandle.done()
 
@@ -111,7 +112,7 @@ export function spawnCachedMira(info: MirabufCacheInfo, type: MiraType, progress
                     }
                 })
 
-                if (!info.name) MirabufCachingService.cacheInfo(info.cacheKey, type, assembly.info?.name ?? undefined)
+                if (!info.name) MirabufCachingService.cacheInfo(info.cacheKey, effectiveType, assembly.info?.name ?? undefined)
             } else {
                 progressHandle.fail()
                 console.error("Failed to spawn robot")

--- a/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
+++ b/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
@@ -112,7 +112,8 @@ export function spawnCachedMira(info: MirabufCacheInfo, type: MiraType, progress
                     }
                 })
 
-                if (!info.name) MirabufCachingService.cacheInfo(info.cacheKey, effectiveType, assembly.info?.name ?? undefined)
+                if (!info.name)
+                    MirabufCachingService.cacheInfo(info.cacheKey, effectiveType, assembly.info?.name ?? undefined)
             } else {
                 progressHandle.fail()
                 console.error("Failed to spawn robot")


### PR DESCRIPTION
## Task
Make sure all robots or fields in spawn assets are under their corresponding type.

## Symptom
Currently, if you import a custom robot file under the `fields` tab, it is correctly shown under the `robots` tab in Configure Assets, but stays under the `fields` tab in Spawn Assets.

## Solution
Correctly infer actual asset type when caching and spawn using entry's own type and actual object type.

## Verification
Imported dozer mira file in field tab, and it appears under robot in spawn assets now.

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
