### PR TITLE
Use JSON file for match mode configs `[AARD-2086]`

### DIFF
--- a/fission/public/assetpack.zip
+++ b/fission/public/assetpack.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97d5649e1a4e3252d4bdefaf6ecf1c53ec3505af2ad5bfefa8288fe4661cd15e
-size 193148562
+oid sha256:ea7be96ce500ebef474d55314ad0e547dac7015763664574978417016d64a6f6
+size 193148563

--- a/fission/public/assetpack.zip
+++ b/fission/public/assetpack.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23bfaf7899d84b00331c12bf1ada20d27d3c50856b14bb5733821b44848812ba
-size 193147860
+oid sha256:97d5649e1a4e3252d4bdefaf6ecf1c53ec3505af2ad5bfefa8288fe4661cd15e
+size 193148562

--- a/fission/src/main.tsx
+++ b/fission/src/main.tsx
@@ -4,5 +4,4 @@ import "./index.css"
 import APS from "./aps/APS"
 
 window.convertAuthToken = code => APS.convertAuthToken(code)
-
 ReactDOM.createRoot(document.getElementById("root")!).render(<Synthesis />)

--- a/fission/src/systems/match_mode/DefaultMatchModeConfigs.ts
+++ b/fission/src/systems/match_mode/DefaultMatchModeConfigs.ts
@@ -1,70 +1,44 @@
 import type { MatchModeConfig } from "@/ui/panels/configuring/MatchModeConfigPanel"
-import { convertFeetToMeters } from "@/util/UnitConversions"
+import { API_URL } from "@/util/Consts.ts"
+
+type ManifestMatchModeConfig = Omit<MatchModeConfig, "id"> & { id: string }
+interface MatchConfigManifest {
+    private: Record<string, ManifestMatchModeConfig>
+    public: Record<string, ManifestMatchModeConfig>
+}
 
 /** The purpose of this class is to store any defaults related to match mode configurations. */
 class DefaultMatchModeConfigs {
-    static frcReefscape2025 = (): MatchModeConfig => {
-        return {
-            id: "FRC-Reefscape-2025",
-            name: "FRC Reefscape 2025",
-            isDefault: true,
-            autonomousTime: 15,
-            teleopTime: 135,
-            endgameTime: 20,
-            ignoreRotation: true,
-            maxHeight: Number.MAX_SAFE_INTEGER,
-            heightLimitPenalty: 0,
-            sideMaxExtension: convertFeetToMeters(1.5),
-            sideExtensionPenalty: 0,
+    private static readonly MANIFEST_LOCATION = `${API_URL}/match_configs/manifest.json`
+    private static _configs: MatchModeConfig[] = []
+
+    static {
+        setTimeout(() => this.reload())
+    }
+    static async reload() {
+        const manifest = await fetch(this.MANIFEST_LOCATION)
+        const json: MatchConfigManifest | undefined = await manifest.json().catch(e => {
+            console.error(e)
+            return undefined
+        })
+        if (json == null) {
+            console.error("Could not load match mode manifest")
+            return
+        }
+        const keys: (keyof MatchConfigManifest)[] = import.meta.env.DEV
+            ? (["public", "private"] as const)
+            : (["public"] as const)
+        for (const key of keys) {
+            const configs = json[key as keyof MatchConfigManifest]
+            Object.entries(configs).forEach(([key, value]) => {
+                value.id = key
+                this._configs.push(value)
+            })
         }
     }
 
-    static frcCrescendo2024 = (): MatchModeConfig => {
-        return {
-            id: "FRC-Crescendo-2024",
-            name: "FRC Crescendo 2024",
-            isDefault: true,
-            autonomousTime: 15,
-            teleopTime: 135,
-            endgameTime: 20,
-            ignoreRotation: true,
-            maxHeight: convertFeetToMeters(4),
-            heightLimitPenalty: 2,
-            sideMaxExtension: convertFeetToMeters(1),
-            sideExtensionPenalty: 2,
-        }
-    }
-
-    static frcPowerUp2023 = (): MatchModeConfig => {
-        return {
-            id: "FRC-Power-Up-2023",
-            name: "FRC Power Up 2023",
-            isDefault: true,
-            autonomousTime: 15,
-            teleopTime: 135,
-            endgameTime: 30,
-            ignoreRotation: true,
-            maxHeight: convertFeetToMeters(6.5),
-            heightLimitPenalty: 5,
-            sideMaxExtension: convertFeetToMeters(4),
-            sideExtensionPenalty: 5,
-        }
-    }
-
-    static matchTest = (): MatchModeConfig => {
-        return {
-            id: "Match-Test",
-            name: "Match Test",
-            isDefault: true,
-            autonomousTime: 5,
-            teleopTime: 15,
-            endgameTime: 5,
-            ignoreRotation: true,
-            maxHeight: Number.MAX_SAFE_INTEGER,
-            heightLimitPenalty: 0,
-            sideMaxExtension: Number.MAX_SAFE_INTEGER,
-            sideExtensionPenalty: 0,
-        }
+    public static get configs(): MatchModeConfig[] {
+        return this._configs
     }
 
     static fallbackValues = (): MatchModeConfig => {
@@ -76,21 +50,11 @@ class DefaultMatchModeConfigs {
             teleopTime: 135,
             endgameTime: 20,
             ignoreRotation: true,
-            maxHeight: Number.MAX_SAFE_INTEGER,
+            maxHeight: -1,
             heightLimitPenalty: 2,
-            sideMaxExtension: Number.MAX_SAFE_INTEGER,
+            sideMaxExtension: -1,
             sideExtensionPenalty: 2,
         }
-    }
-
-    /** @returns {MatchModeConfig[]} New copies of the default match mode configs without reference to any others. */
-    public static get defaultMatchModeConfigCopies(): MatchModeConfig[] {
-        return [
-            DefaultMatchModeConfigs.frcReefscape2025(),
-            DefaultMatchModeConfigs.frcCrescendo2024(),
-            DefaultMatchModeConfigs.frcPowerUp2023(),
-            DefaultMatchModeConfigs.matchTest(),
-        ]
     }
 }
 

--- a/fission/src/systems/match_mode/DefaultMatchModeConfigs.ts
+++ b/fission/src/systems/match_mode/DefaultMatchModeConfigs.ts
@@ -23,7 +23,7 @@ class DefaultMatchModeConfigs {
         })
         if (json == null) {
             console.error("Could not load match mode manifest")
-            return
+            return undefined
         }
         const keys: (keyof MatchConfigManifest)[] = import.meta.env.DEV
             ? (["public", "private"] as const)

--- a/fission/src/systems/match_mode/RobotDimensionTracker.ts
+++ b/fission/src/systems/match_mode/RobotDimensionTracker.ts
@@ -34,7 +34,7 @@ class RobotDimensionTracker {
         World.sceneRenderer.mirabufSceneObjects.getRobots().forEach(robot => {
             const dimensions = this._ignoreRotation ? robot.getDimensionsWithoutRotation() : robot.getDimensions()
 
-            if (dimensions.height > this._maxHeight + BUFFER_HEIGHT) {
+            if (this._maxHeight !== -1 && dimensions.height > this._maxHeight + BUFFER_HEIGHT) {
                 if (!(this._robotLastFramePenalty.get(robot.id) ?? false)) {
                     SimulationSystem.robotPenalty(robot, this._heightLimitPenalty, "Height Expansion Limit")
                 }
@@ -44,8 +44,9 @@ class RobotDimensionTracker {
 
             const startingRobotSize = this._robotSize.get(robot.id) ?? { width: Infinity, depth: Infinity }
             if (
-                dimensions.width > startingRobotSize.width + this._sideMaxExtension + SIDE_BUFFER ||
-                dimensions.depth > startingRobotSize.depth + this._sideMaxExtension + SIDE_BUFFER
+                this._sideMaxExtension !== -1 &&
+                (dimensions.width > startingRobotSize.width + this._sideMaxExtension + SIDE_BUFFER ||
+                    dimensions.depth > startingRobotSize.depth + this._sideMaxExtension + SIDE_BUFFER)
             ) {
                 if (!(this._robotLastFramePenalty.get(robot.id) ?? false)) {
                     SimulationSystem.robotPenalty(robot, this._sideExtensionPenalty, "Side Expansion Limit")

--- a/fission/src/ui/panels/configuring/CreateNewMatchModeConfigPanel.tsx
+++ b/fission/src/ui/panels/configuring/CreateNewMatchModeConfigPanel.tsx
@@ -1,10 +1,10 @@
+import { Box, Button, Divider, FormControlLabel, Stack, TextField, Typography } from "@mui/material"
+import { useCallback, useEffect, useState } from "react"
+import DefaultMatchModeConfigs from "@/systems/match_mode/DefaultMatchModeConfigs"
+import Checkbox from "@/ui/components/Checkbox"
 import type { PanelImplProps } from "@/ui/components/Panel"
 import { CloseType, useUIContext } from "@/ui/helpers/UIProviderHelpers"
-import { Box, TextField, FormControlLabel, Stack, Divider, Button, Typography } from "@mui/material"
-import Checkbox from "@/ui/components/Checkbox"
-import { useEffect, useState, useCallback } from "react"
 import type { MatchModeConfig } from "./MatchModeConfigPanel"
-import DefaultMatchModeConfigs from "@/systems/match_mode/DefaultMatchModeConfigs"
 import { validateAndNormalizeMatchModeConfig } from "./MatchModeConfigPanel"
 
 interface ValidationRule {
@@ -91,7 +91,7 @@ const FIELD_CONFIGS: Record<string, FieldConfig> = {
         type: "checkbox",
     },
     maxHeight: {
-        defaultValue: fallbackConfig.maxHeight === Number.MAX_SAFE_INTEGER ? 1.2 : fallbackConfig.maxHeight,
+        defaultValue: fallbackConfig.maxHeight === -1 ? 1.2 : fallbackConfig.maxHeight,
         rules: [VALIDATION_RULES.nonNegativeNumber("Max height must be a non-negative number")],
         type: "decimal",
     },
@@ -106,8 +106,7 @@ const FIELD_CONFIGS: Record<string, FieldConfig> = {
         type: "checkbox",
     },
     sideMaxExtension: {
-        defaultValue:
-            fallbackConfig.sideMaxExtension === Number.MAX_SAFE_INTEGER ? 0.5 : fallbackConfig.sideMaxExtension,
+        defaultValue: fallbackConfig.sideMaxExtension === -1 ? 0.5 : fallbackConfig.sideMaxExtension,
         rules: [VALIDATION_RULES.nonNegativeNumber("Side max extension must be a non-negative number")],
         type: "decimal",
     },
@@ -260,15 +259,13 @@ const CreateNewMatchModeConfigPanel: React.FC<PanelImplProps<void, void>> = ({ p
             teleopTime: parseInt(formState.teleopTime.value as string, 10),
             endgameTime: parseInt(formState.endgameTime.value as string, 10),
             ignoreRotation: formState.ignoreRotation.value as boolean,
-            maxHeight: formState.enableHeightPenalty.value
-                ? parseFloat(formState.maxHeight.value as string)
-                : Number.MAX_SAFE_INTEGER,
+            maxHeight: formState.enableHeightPenalty.value ? parseFloat(formState.maxHeight.value as string) : -1,
             heightLimitPenalty: formState.enableHeightPenalty.value
                 ? parseFloat(formState.heightLimitPenalty.value as string)
                 : 0,
             sideMaxExtension: formState.enableSideExtensionPenalty.value
                 ? parseFloat(formState.sideMaxExtension.value as string)
-                : Number.MAX_SAFE_INTEGER,
+                : -1,
             sideExtensionPenalty: formState.enableSideExtensionPenalty.value
                 ? parseFloat(formState.sideExtensionPenalty.value as string)
                 : 0,

--- a/fission/src/ui/panels/configuring/MatchModeConfigPanel.tsx
+++ b/fission/src/ui/panels/configuring/MatchModeConfigPanel.tsx
@@ -1,5 +1,4 @@
 import { Box, Divider } from "@mui/material"
-import { Button } from "@/ui/components/StyledComponents"
 import { Stack } from "@mui/system"
 import type React from "react"
 import { type ChangeEvent, useEffect, useMemo, useRef, useState } from "react"
@@ -11,7 +10,7 @@ import Checkbox from "@/ui/components/Checkbox"
 import { globalAddToast } from "@/ui/components/GlobalUIControls"
 import Label from "@/ui/components/Label"
 import type { PanelImplProps } from "@/ui/components/Panel"
-import { NegativeButton, PositiveButton, SynthesisIcons } from "@/ui/components/StyledComponents"
+import { Button, NegativeButton, PositiveButton, SynthesisIcons } from "@/ui/components/StyledComponents"
 import { CloseType, useUIContext } from "@/ui/helpers/UIProviderHelpers"
 import CreateNewMatchModeConfigPanel from "./CreateNewMatchModeConfigPanel"
 
@@ -23,54 +22,54 @@ import CreateNewMatchModeConfigPanel from "./CreateNewMatchModeConfigPanel"
  */
 export interface MatchModeConfig {
     /** Unique identifier for this match mode configuration */
-    id: string
+    readonly id: string
 
     /** Human-readable name for this match mode configuration */
-    name: string
+    readonly name: string
 
     /** Whether this is a built-in default configuration (cannot be deleted) */
-    isDefault: boolean
+    readonly isDefault: boolean
 
     /** Duration of autonomous period in seconds (default: 15) */
-    autonomousTime: number
+    readonly autonomousTime: number
 
     /** Duration of teleoperated period in seconds (default: 135) */
-    teleopTime: number
+    readonly teleopTime: number
 
     /** Duration of endgame period in seconds (default: 20) */
-    endgameTime: number
+    readonly endgameTime: number
 
     /**
      * Whether to ignore robot rotation when calculating height violations.
      * If true, the height limit will be calculated relative to the base of the robot, rather than the base of the field
      * (default: true)
      */
-    ignoreRotation: boolean
+    readonly ignoreRotation: boolean
 
     /**
      * Maximum allowed robot height in meters (stored internally).
      * Set to Infinity for no height limit. (default: Infinity)
      */
-    maxHeight: number
+    readonly maxHeight: number
 
     /**
      * Points to penalize for height limit violations (default: 2).
      * Applied each time a robot exceeds maxHeight after cooldown period.
      */
-    heightLimitPenalty: number
+    readonly heightLimitPenalty: number
 
     /**
      * Maximum allowed robot side extension in meters
      * User input is in feet but converted to meters during config processing.
      * Set to Infinity for no side extension limit. (default: Infinity)
      */
-    sideMaxExtension: number
+    readonly sideMaxExtension: number
 
     /**
      * Points to penalize for side extension violations (default: 2).
      * Applied each time a robot exceeds sideMaxExtension after cooldown period.
      */
-    sideExtensionPenalty: number
+    readonly sideExtensionPenalty: number
 }
 
 const props: Readonly<{ id: keyof MatchModeConfig; expectedType: string; required: boolean }>[] = [
@@ -180,7 +179,8 @@ const MatchModeConfigPanel: React.FC<PanelImplProps<void, void>> = ({ panel }) =
     useEffect(() => {
         const loadConfigs = () => {
             try {
-                const defaultConfigs = DefaultMatchModeConfigs.defaultMatchModeConfigCopies
+                const defaultConfigs = DefaultMatchModeConfigs.configs
+                console.log(defaultConfigs)
                 const localConfigs = JSON.parse(window.localStorage.getItem("match-mode-configs") || "[]")
 
                 const combinedConfigs = [...defaultConfigs, ...localConfigs]

--- a/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
+++ b/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
@@ -1,5 +1,4 @@
 import { Accordion, AccordionDetails, AccordionSummary, Box, CircularProgress, Stack, Tooltip } from "@mui/material"
-import { Button, ToggleButton, ToggleButtonGroup } from "@/ui/components/StyledComponents"
 import type React from "react"
 import { type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react"
 import { MdExpandMore } from "react-icons/md"
@@ -21,22 +20,25 @@ import MirabufCachingService, {
 } from "@/mirabuf/MirabufLoader"
 import { createMirabuf } from "@/mirabuf/MirabufSceneObject"
 import { PAUSE_REF_ASSEMBLY_SPAWNING } from "@/systems/physics/PhysicsTypes"
-
 import World from "@/systems/World"
 import { globalOpenPanel } from "@/ui/components/GlobalUIControls"
 import Label from "@/ui/components/Label"
 import type { PanelImplProps } from "@/ui/components/Panel"
 import { ProgressHandle } from "@/ui/components/ProgressNotificationData"
 import {
+    Button,
     DeleteButton,
     PositiveButton,
     PositiveIconButton,
     RefreshButton,
     SynthesisIcons,
+    ToggleButton,
+    ToggleButtonGroup,
 } from "@/ui/components/StyledComponents"
 import { useStateContext } from "@/ui/helpers/StateProviderHelpers"
 import { CloseType, useUIContext } from "@/ui/helpers/UIProviderHelpers"
 import ImportLocalMirabufModal from "@/ui/modals/mirabuf/ImportLocalMirabufModal"
+import { API_URL } from "@/util/Consts.ts"
 import type TaskStatus from "@/util/TaskStatus"
 import type { ConfigurationType } from "../configuring/assembly-config/ConfigTypes"
 import InitialConfigPanel from "../configuring/initial-config/InitialConfigPanel"
@@ -191,18 +193,14 @@ const ImportMirabufPanel: React.FC<PanelImplProps<void, ImportMirabufPanelCustom
     useEffect(() => {
         // To remove the prettier warning
         const x = async () => {
-            // Detect if we're running in electron and use direct remote URL
-            const isElectron = window.electronAPI != null
-            const baseUrl = isElectron ? "https://synthesis.autodesk.com" : ""
-
-            fetch(`${baseUrl}/api/mira/manifest.json`)
+            fetch(`${API_URL}/mira/manifest.json`)
                 .then(x => x.json())
                 .then(x => {
                     const map = MirabufCachingService.getCacheMap(MiraType.ROBOT)
                     const robots: MirabufRemoteInfo[] = []
                     for (const src of x["robots"]) {
                         if (typeof src == "string") {
-                            const str = `${baseUrl}/api/mira/robots/${src}`
+                            const str = `${API_URL}/mira/robots/${src}`
                             if (!map[str]) robots.push({ displayName: src, src: str })
                         } else {
                             if (!map[src.src]) robots.push({ displayName: src.displayName, src: src.src })
@@ -211,7 +209,7 @@ const ImportMirabufPanel: React.FC<PanelImplProps<void, ImportMirabufPanelCustom
                     const fields: MirabufRemoteInfo[] = []
                     for (const src of x["fields"]) {
                         if (typeof src == "string") {
-                            const str = `${baseUrl}/api/mira/fields/${src}`
+                            const str = `${API_URL}/mira/fields/${src}`
                             if (!map[str]) fields.push({ displayName: src, src: str })
                         } else {
                             if (!map[src.src]) fields.push({ displayName: src.displayName, src: src.src })

--- a/fission/src/util/Consts.ts
+++ b/fission/src/util/Consts.ts
@@ -1,0 +1,3 @@
+const isElectron = window.electronAPI != null
+const baseUrl = isElectron ? "https://synthesis.autodesk.com" : ""
+export const API_URL = `${baseUrl}/api`

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -2,9 +2,9 @@ import fs from "node:fs/promises"
 import basicSsl from "@vitejs/plugin-basic-ssl"
 import react from "@vitejs/plugin-react-swc"
 import * as path from "path"
-import { loadEnv, type ProxyOptions } from "vite"
+import {loadEnv, type ProxyOptions} from "vite"
 import glsl from "vite-plugin-glsl"
-import { defineConfig } from "vitest/config"
+import {defineConfig} from "vitest/config"
 
 const basePath = "/fission/"
 const serverPort = 3000
@@ -58,14 +58,15 @@ export default defineConfig(async ({ mode }) => {
     console.log(`Using ${useLocalAssets ? "local" : "remote"} mirabuf assets`)
 
     const proxies: Record<string, ProxyOptions> = {}
-    proxies["/api/mira"] = useLocalAssets
+    const assetProxy:ProxyOptions = useLocalAssets
         ? {
               target: `http://localhost:${mode === "test" ? 3001 : serverPort}`,
               changeOrigin: true,
               secure: false,
               rewrite: path =>
                   path
-                      .replace(/^\/api\/mira/, "/Downloadables/Mira")
+                      .replace(/^\/api/, "/Downloadables")
+                      .replace("mira", "Mira")
                       .replace("robots", "Robots")
                       .replace("fields", "Fields"),
           }
@@ -74,6 +75,8 @@ export default defineConfig(async ({ mode }) => {
               changeOrigin: true,
               secure: true,
           }
+    proxies["/api/mira"] = assetProxy
+    proxies["/api/match_configs"] = assetProxy
     proxies["/api/aps"] = useLocalAPS
         ? {
               target: `http://localhost:${dockerServerPort}/`,


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-2086

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->
Currently default match mode configs are defined in-code, which means that updating the list (as would be necessary on kickoff) would require a redeploy of synthesis

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->
This changes them to be defined by a JSON file in the assetpack, which is loaded on startup

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

Check that the configurations still show up and work correctly
This does change the assetpack, so you'll have to run `bun run assetpack` before testing

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
