### PR TITLE
Exporter: Material Parsing std Error `[AARD-2109]`

### DIFF
--- a/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Materials.py
+++ b/exporter/SynthesisFusionAddin/src/Parser/SynthesisParser/Materials.py
@@ -142,7 +142,7 @@ def getPhysicalMaterialData(
     mechanicalProperties.damping_coefficient = materialProperties.itemById("structural_Damping_coefficient").value
 
     missingProperties: list[str] = [
-        k for k, v in vars(mechanicalProperties).items() if v is None and not k.startswith("__")
+        k for k, v in mechanicalProperties.ListFields() if v is None and not k.startswith("__")
     ]  # ignore: type
     if missingProperties.__len__() > 0:
         _: Err[None] = Err(f"Missing Mechanical Properties {missingProperties}", ErrorSeverity.Warning)
@@ -153,7 +153,7 @@ def getPhysicalMaterialData(
     strengthProperties.yield_strength = materialProperties.itemById("structural_Minimum_yield_stress").value
     strengthProperties.tensile_strength = materialProperties.itemById("structural_Minimum_tensile_strength").value
 
-    missingStrengthProperties: list[str] = [k for k, v in vars(strengthProperties).items() if v is None]  # ignore: type
+    missingStrengthProperties: list[str] = [k for k, v in strengthProperties.ListFields() if v is None]  # ignore: type
     if missingStrengthProperties.__len__() > 0:
         __: Err[None] = Err(f"Missing Strength Properties {missingProperties}", ErrorSeverity.Warning)
 


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form AARD-xxxx, where "AARD" is Jira project.
Include the same Jira ticket ID(s) in this section.
-->

AARD-2109

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

We were using some hacky "pythonic" code to retrieve internal objects from Fusion api types. This was broken in the most recent Fusion update.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Replace old hacky "pythonic" code with new hacky "pythonic" code that works to retrieve these hidden types.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

Synthesis Python Exporter no longer hangs and crashes upon the material parsing step.

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
