### PR TITLE
feat: import unstable mira files with warnings

### DIFF
--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -511,7 +511,9 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
         let totalMass = 0
         this._mirabufInstance.parser.rigidNodes.forEach(rn => {
             if (!this._mirabufInstance.meshes.size) return // if this.dispose() has been ran then return
-            const body = World.physicsSystem.getBody(this._mechanism.getBodyByNodeId(rn.id)!)
+            const bodyId = this._mechanism.getBodyByNodeId(rn.id)!
+            const body = World.physicsSystem.getBody(bodyId)
+            if (!body) return
             const transform = convertJoltMat44ToThreeMatrix4(body.GetWorldTransform())
             this.updateNodeParts(rn, transform)
 

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -964,12 +964,22 @@ class PhysicsSystem extends WorldSystem {
                 const partDefinition =
                     parser.assembly.data!.parts!.partDefinitions![partInstance.partDefinitionReference!]!
 
+                const debugLabel = {
+                    rn: rn.id,
+                    partId,
+                    defRef: partInstance.partDefinitionReference,
+                    name: (partDefinition as any).name ?? (partInstance as any).name ?? "(unnamed)",
+                }
+
                 const partShapeResult = rn.isDynamic
                     ? this.createConvexShapeSettingsFromPart(partDefinition)
-                    : this.createConcaveShapeSettingsFromPart(partDefinition)
+                    : this.createConcaveShapeSettingsFromPart(partDefinition, debugLabel)
                 // const partShapeResult = this.CreateConvexShapeSettingsFromPart(partDefinition)
 
-                if (!partShapeResult) return
+                if (!partShapeResult) {
+                    console.warn("Skipping collider (no valid shape settings)", debugLabel)
+                    return
+                }
 
                 const [shapeSettings, partMin, partMax] = partShapeResult
 
@@ -1039,7 +1049,11 @@ class PhysicsSystem extends WorldSystem {
                 const shapeResult = compoundShapeSettings.Create()
 
                 if (!shapeResult.IsValid || shapeResult.HasError()) {
+                    // May want to consider crashing here.
+                    // Unclear if the whole import is impossible if we reach this control step.
                     console.error(`Failed to create shape for RigidNode ${rn.id}\n${shapeResult.GetError().c_str()}`)
+                    JOLT.destroy(compoundShapeSettings)
+                    return
                 }
 
                 const shape = shapeResult.Get()
@@ -1136,7 +1150,8 @@ class PhysicsSystem extends WorldSystem {
      * @returns If successful, the created convex hull shape settings from the given Part Definition.
      */
     private createConcaveShapeSettingsFromPart(
-        partDefinition: mirabuf.IPartDefinition
+        partDefinition: mirabuf.IPartDefinition,
+        debugLabel?: any
     ): [Jolt.ShapeSettings, Jolt.Vec3, Jolt.Vec3] | undefined {
         const settings = new JOLT.MeshShapeSettings()
 
@@ -1151,10 +1166,12 @@ class PhysicsSystem extends WorldSystem {
         const min = new JOLT.Vec3(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY)
         const max = new JOLT.Vec3(Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY)
 
+        let maxIndex = -1
         partDefinition.bodies!.forEach(body => {
             const vertArr = body.triangleMesh?.mesh?.verts
             const indexArr = body.triangleMesh?.mesh?.indices
             if (!vertArr || !indexArr) return
+            if (indexArr.length < 3 || indexArr.length % 3 !== 0) return
 
             for (let i = 0; i < vertArr.length; i += 3) {
                 const vert = convertMirabufFloatToArrJoltFloat3(vertArr, i)
@@ -1162,14 +1179,31 @@ class PhysicsSystem extends WorldSystem {
                 this.updateMinMaxBounds(new JOLT.Vec3(vert), min, max)
                 JOLT.destroy(vert)
             }
+
             for (let i = 0; i < indexArr.length; i += 3) {
-                settings.mIndexedTriangles.push_back(
-                    new JOLT.IndexedTriangle(indexArr.at(i)!, indexArr.at(i + 1)!, indexArr.at(i + 2)!, 0)
-                )
+                const a = indexArr.at(i)!
+                const b = indexArr.at(i + 1)!
+                const c = indexArr.at(i + 2)!
+                if (a > maxIndex) maxIndex = a
+                if (b > maxIndex) maxIndex = b
+                if (c > maxIndex) maxIndex = c
+                settings.mIndexedTriangles.push_back(new JOLT.IndexedTriangle(a, b, c, 0))
             }
         })
 
-        if (settings.mTriangleVertices.size() < 4) {
+        const vertCount = settings.mTriangleVertices.size()
+        const triCountBeforeSanitize = settings.mIndexedTriangles.size()
+
+        if (vertCount < 3 || triCountBeforeSanitize === 0 || maxIndex >= vertCount) {
+            if (debugLabel) {
+                console.warn("Concave collider invalid (no triangles or bad indices)", {
+                    ...debugLabel,
+                    vertCount,
+                    triCount: triCountBeforeSanitize,
+                    maxIndex,
+                })
+            }
+
             JOLT.destroy(settings)
             JOLT.destroy(min)
             JOLT.destroy(max)
@@ -1177,6 +1211,22 @@ class PhysicsSystem extends WorldSystem {
         }
 
         settings.Sanitize()
+        const triCount = settings.mIndexedTriangles.size()
+        if (triCount === 0) {
+            if (debugLabel) {
+                console.warn("Concave collider sanitized to zero triangles (degenerate)", {
+                    ...debugLabel,
+                    vertCount,
+                    triCountBeforeSanitize,
+                })
+            }
+
+            JOLT.destroy(settings)
+            JOLT.destroy(min)
+            JOLT.destroy(max)
+            return
+        }
+
         return [settings, min, max]
     }
 

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -968,7 +968,7 @@ class PhysicsSystem extends WorldSystem {
                     rn: rn.id,
                     partId,
                     defRef: partInstance.partDefinitionReference,
-                    name: (partDefinition as any).name ?? (partInstance as any).name ?? "(unnamed)",
+                    name: partDefinition.info?.name ?? partInstance.info?.name ?? "(unnamed)",
                 }
 
                 const partShapeResult = rn.isDynamic
@@ -1151,7 +1151,7 @@ class PhysicsSystem extends WorldSystem {
      */
     private createConcaveShapeSettingsFromPart(
         partDefinition: mirabuf.IPartDefinition,
-        debugLabel?: any
+        debugLabel?: Record<string, unknown>
     ): [Jolt.ShapeSettings, Jolt.Vec3, Jolt.Vec3] | undefined {
         const settings = new JOLT.MeshShapeSettings()
 


### PR DESCRIPTION
## Symptom

With CAD models imported from other pieces of software there is often geometry that is unresolvable causing the importer to crash.

<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Detect and log common fail points of "unstable" mira files and pass over objects that are not resolvable, rather than crashing. 

## Verification

Importing in fission works normally.

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
