### PR TITLE
Revert Chrome Hotfix `[SYNTH-124]`

### DIFF
--- a/fission/src/mirabuf/MirabufInstance.ts
+++ b/fission/src/mirabuf/MirabufInstance.ts
@@ -8,25 +8,6 @@ import { ParseErrorSeverity } from "./MirabufParser.ts"
 type MirabufPartInstanceGUID = string
 
 const WIREFRAME = false
-const CHROME_VERSION_FOR_INSTANCED_MESH = 139
-
-const detectInstancedMeshSupport = (): boolean => {
-    const userAgent = navigator.userAgent
-    const chromeMatch = userAgent.match(/Chrome\/(\d+)/)
-
-    if (chromeMatch) {
-        const chromeVersion = parseInt(chromeMatch[1], 10)
-        console.log(
-            `Detected Chrome ${chromeVersion}, using ${chromeVersion >= CHROME_VERSION_FOR_INSTANCED_MESH ? "InstancedMesh" : "BatchedMesh"}`
-        )
-        return chromeVersion >= CHROME_VERSION_FOR_INSTANCED_MESH
-    }
-
-    console.log(`Non-Chrome browser detected (${userAgent}), using BatchedMesh`)
-    return false
-}
-
-const USE_INSTANCED_MESH = detectInstancedMeshSupport()
 
 export enum MaterialStyle {
     REGULAR = 0,
@@ -112,8 +93,8 @@ const transformGeometry = (geometry: THREE.BufferGeometry, mesh: mirabuf.IMesh) 
 class MirabufInstance {
     private _mirabufParser: MirabufParser
     private _materials: Map<string, THREE.Material>
-    private _meshes: Map<MirabufPartInstanceGUID, Array<[THREE.InstancedMesh | THREE.BatchedMesh, number]>>
-    private _batches: Array<THREE.InstancedMesh | THREE.BatchedMesh>
+    private _meshes: Map<MirabufPartInstanceGUID, Array<[THREE.BatchedMesh, number]>>
+    private _batches: Array<THREE.BatchedMesh>
 
     public get parser() {
         return this._mirabufParser
@@ -141,7 +122,7 @@ class MirabufInstance {
         this.loadMaterials(materialStyle ?? MaterialStyle.REGULAR)
 
         progressHandle?.update("Creating meshes...", 0.5)
-        this.createMeshes()
+        this.createBatchedMeshes()
     }
 
     /**
@@ -176,64 +157,10 @@ class MirabufInstance {
     }
 
     /**
-     * Creates ThreeJS meshes from the parsed mirabuf file.
-     */
-    private createMeshes() {
-        if (USE_INSTANCED_MESH) {
-            this.createInstancedMeshes()
-        } else {
-            this.createBatchedMeshes()
-        }
-    }
-
-    /**
-     * Creates InstancedMesh objects, as newer version of Chrome break with BatchedMesh
-     */
-    private createInstancedMeshes() {
-        const assembly = this._mirabufParser.assembly
-        const instances = assembly.data!.parts!.partInstances!
-
-        Object.values(instances).forEach(instance => {
-            const definition = assembly.data!.parts!.partDefinitions![instance.partDefinitionReference!]
-            const bodies = definition?.bodies ?? []
-
-            bodies.forEach(body => {
-                const mesh = body?.triangleMesh?.mesh
-                if (!mesh?.verts || !mesh.normals || !mesh.uv || !mesh.indices) return
-
-                const appearanceOverride = body.appearanceOverride
-                const material = WIREFRAME
-                    ? new THREE.MeshStandardMaterial({ wireframe: true, color: 0x000000 })
-                    : appearanceOverride && this._materials.has(appearanceOverride)
-                      ? this._materials.get(appearanceOverride)!
-                      : fillerMaterials[nextFillerMaterial++ % fillerMaterials.length]
-
-                const geometry = new THREE.BufferGeometry()
-                transformGeometry(geometry, mesh)
-
-                // Create InstancedMesh with count of 1 for this body
-                const instancedMesh = new THREE.InstancedMesh(geometry, material, 1)
-                instancedMesh.castShadow = true
-                instancedMesh.receiveShadow = true
-
-                const mat = this._mirabufParser.globalTransforms.get(instance.info!.GUID!)!
-                instancedMesh.setMatrixAt(0, mat)
-                instancedMesh.instanceMatrix.needsUpdate = true
-
-                this._batches.push(instancedMesh)
-
-                let bodies = this._meshes.get(instance.info!.GUID!)
-                if (!bodies) {
-                    bodies = []
-                    this._meshes.set(instance.info!.GUID!, bodies)
-                }
-                bodies.push([instancedMesh, 0])
-            })
-        })
-    }
-
-    /**
-     * Creates BatchedMesh, more efficient, but broken in newer versions of Chrome
+     * Creates BatchedMesh, more efficient than InstancedMeshes
+     * 
+     * Some versions of Chrome broke BatchedMeshes, one solution could be to use InstancedMeshes. See PR
+     * https://github.com/Autodesk/synthesis/pull/1262
      */
     private createBatchedMeshes() {
         const assembly = this._mirabufParser.assembly

--- a/fission/src/mirabuf/MirabufInstance.ts
+++ b/fission/src/mirabuf/MirabufInstance.ts
@@ -158,7 +158,7 @@ class MirabufInstance {
 
     /**
      * Creates BatchedMesh, more efficient than InstancedMeshes
-     * 
+     *
      * Some versions of Chrome broke BatchedMeshes, one solution could be to use InstancedMeshes. See PR
      * https://github.com/Autodesk/synthesis/pull/1262
      */

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -558,13 +558,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
                 .clone()
                 .premultiply(transform)
             const meshes = this._mirabufInstance.meshes.get(part) ?? []
-            meshes.forEach(([mesh, index]) => {
-                mesh.setMatrixAt(index, partTransform)
-                // Only update instanceMatrix for InstancedMesh
-                if ("instanceMatrix" in mesh) {
-                    mesh.instanceMatrix.needsUpdate = true
-                }
-            })
+            meshes.forEach(([batch, id]) => batch.setMatrixAt(id, partTransform))
         })
     }
 


### PR DESCRIPTION

## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

Last year, a Chrome update broke ThreeJS rendering, resulting in all of our robots and fields spawning improperly. As a temporary fix we switched from BatchedMeshes to InstancedMeshes, fixing the issue on our side. However, this came at a performance cost, and Chrome has since fixed this bug.

See PR: https://github.com/Autodesk/synthesis/pull/1262

SYNTH-124

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

InstancedMesh usage results in lower performance.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Switch back to using BatchedMeshes.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

- [x] Robots still spawn properly
- [x] Fields still spawn properly
- [x] There is an increase in performance (FPS)

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
