### PR TITLE
Add 2026 Field to Assetpack `[SYNTH-130]`

### DIFF
--- a/fission/package.json
+++ b/fission/package.json
@@ -23,6 +23,7 @@
     "style:fix": "bunx biome check src --write",
     "assetpack": "git lfs pull && (rm -rf public/Downloadables;tar -xf public/assetpack.zip -C public/)",
     "assetpack:update": "bun update_manifest.ts && cd public && zip -FS -r assetpack.zip Downloadables -x '**/.*' -x '**/__MACOSX'",
+    "assetpack:merge": "git checkout --theirs public/assetpack.zip && rm -rf public/Downloadables && tar -xf public/assetpack.zip -C public/ && git checkout --ours public/assetpack.zip && tar -xf public/assetpack.zip -C public/ && bun run assetpack:update",
     "playwright:install": "bun x playwright install",
     "electron:make": "electron-forge make",
     "electron:start": "electron-forge start",

--- a/fission/public/assetpack.zip
+++ b/fission/public/assetpack.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1f0547954c45a59449661ab92d2ea5f87aded1cb5978d1585575f7dd6330f0b1
-size 76503274
+oid sha256:7bd661ff21f9dd2d6638f86df1c9c31c6fcff153591b7ea43822082ad916b81c
+size 87167065


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-130

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->
2026 field assets are in the prod S3 container but not the dev assetpack (also the hashes are messed up in prod). Makes sense to add them here so the assetpack can be authoritative.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->
Added both versions of the field to the assetpack and updated manifest

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->
Can spawn field. Make sure to run `bun run assetpack` to update your local assets
<img width="1296" height="839" alt="image" src="https://github.com/user-attachments/assets/5cadc2ad-1217-4535-854f-d042f9923b1d" />

---

Before merging, ensure the following criteria are met:

- [X] All acceptance criteria outlined in the ticket are met.
- [X] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [X] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [X] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
