### PR TITLE
Temporarily Revert Submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "mirabuf"]
 	path = mirabuf
-	url = https://github.com/synthesis-adsk/mirabuf.git
+	url = https://github.com/HiceS/mirabuf.git
 [submodule "jolt"]
 	path = jolt
-	url = https://github.com/synthesis-adsk/JoltPhysics.js.git
+	url = https://github.com/azaleacolburn/JoltPhysics.js.git


### PR DESCRIPTION
Temporarily revert submodules owned by `synthesis-adsk` back to the originals.