### PR TITLE
Migrate APS UserInfo API from v1 to v2

### DIFF
--- a/fission/src/aps/APS.ts
+++ b/fission/src/aps/APS.ts
@@ -14,7 +14,7 @@ export const ENDPOINT_SYNTHESIS_CHALLENGE = `/api/aps/challenge`
 const ENDPOINT_AUTODESK_AUTHENTICATION_AUTHORIZE = "https://developer.api.autodesk.com/authentication/v2/authorize"
 const ENDPOINT_AUTODESK_AUTHENTICATION_TOKEN = "https://developer.api.autodesk.com/authentication/v2/token"
 const ENDPOINT_AUTODESK_AUTHENTICATION_REVOKE = "https://developer.api.autodesk.com/authentication/v2/revoke"
-const ENDPOINT_AUTODESK_USERINFO = "https://api.userprofile.autodesk.com/userinfo"
+const ENDPOINT_AUTODESK_USERINFO = "https://developer.api.autodesk.com/userinfo"
 
 // biome-ignore-start lint/style/useNamingConvention: returned from api
 export interface APSAuth {
@@ -190,7 +190,7 @@ class APS {
                     response_type: "code",
                     client_id: CLIENT_ID,
                     redirect_uri: callbackUrl,
-                    scope: "data:read",
+                    scope: "data:read openid profapi:core-std-profile:read profapi:img-profile:read",
                     nonce: Date.now().toString(),
                     prompt: "login",
                     code_challenge: challenge,
@@ -323,7 +323,8 @@ class APS {
             const res = await fetch(ENDPOINT_AUTODESK_USERINFO, {
                 method: "GET",
                 headers: {
-                    Authorization: auth.access_token,
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer " + auth.access_token,
                 },
             })
             const json = await res.json()
@@ -334,14 +335,12 @@ class APS {
                 await this.requestAuthCode()
                 return
             }
-            const info: APSUserInfo = {
+            this.userInfo = {
                 name: json.name,
                 givenName: json.given_name,
                 picture: json.picture,
                 email: json.email,
             }
-
-            this.userInfo = info
         } catch (e) {
             console.error(e)
             World.analyticsSystem?.exception("APS Login Failure: User Info")

--- a/fission/src/aps/APS.ts
+++ b/fission/src/aps/APS.ts
@@ -5,7 +5,7 @@ import { globalAddToast } from "@/ui/components/GlobalUIControls"
 
 const APS_AUTH_KEY = "aps_auth"
 const APS_USER_INFO_KEY = "aps_user_info"
-
+const APS_SCOPES = "data:read"
 const CLIENT_ID = "GCxaewcLjsYlK8ud7Ka9AKf9dPwMR3e4GlybyfhAK2zvl3tU"
 
 const ENDPOINT_SYNTHESIS_CODE = `/api/aps/code`
@@ -14,7 +14,7 @@ export const ENDPOINT_SYNTHESIS_CHALLENGE = `/api/aps/challenge`
 const ENDPOINT_AUTODESK_AUTHENTICATION_AUTHORIZE = "https://developer.api.autodesk.com/authentication/v2/authorize"
 const ENDPOINT_AUTODESK_AUTHENTICATION_TOKEN = "https://developer.api.autodesk.com/authentication/v2/token"
 const ENDPOINT_AUTODESK_AUTHENTICATION_REVOKE = "https://developer.api.autodesk.com/authentication/v2/revoke"
-const ENDPOINT_AUTODESK_USERINFO = "https://developer.api.autodesk.com/userinfo"
+const ENDPOINT_AUTODESK_USERINFO = "https://api.aps.autodesk.com/userinfo"
 
 // biome-ignore-start lint/style/useNamingConvention: returned from api
 export interface APSAuth {
@@ -190,7 +190,7 @@ class APS {
                     response_type: "code",
                     client_id: CLIENT_ID,
                     redirect_uri: callbackUrl,
-                    scope: "data:read openid profapi:core-std-profile:read profapi:img-profile:read",
+                    scope: APS_SCOPES,
                     nonce: Date.now().toString(),
                     prompt: "login",
                     code_challenge: challenge,
@@ -232,7 +232,7 @@ class APS {
                         client_id: CLIENT_ID,
                         grant_type: "refresh_token",
                         refresh_token: refreshToken,
-                        scope: "data:read",
+                        scope: APS_SCOPES,
                     }),
                 })
                 const json = await res.json()

--- a/fission/src/test/APSTesting.test.ts
+++ b/fission/src/test/APSTesting.test.ts
@@ -558,12 +558,12 @@ describe("APS Authentication System", () => {
                 await APS.loadUserInfo(mockAuth)
 
                 expect(mockFetch).toHaveBeenCalledWith(
-                    "https://api.userprofile.autodesk.com/userinfo",
+                    expect.stringContaining("autodesk.com"),
                     expect.objectContaining({
                         method: "GET",
-                        headers: {
-                            Authorization: mockAuth.access_token,
-                        },
+                        headers: expect.objectContaining({
+                            Authorization: "Bearer " + mockAuth.access_token,
+                        }),
                     })
                 )
             })


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-99

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->
The old profile v1 api was being depricated and we needed to migrate to v2 for continued support

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->
Followed migration guide and migrated to V2. I spent a long time trying to narrow the scopes (as `data:read` is extremely permissive) but ended up realizing that the APS storage api calls require `data:read` anyway so we just have to live with powerful tokens.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->
Can still log in and out, see photo, access assets in APS

---

Before merging, ensure the following criteria are met:

- [X] All acceptance criteria outlined in the ticket are met.
- [X] Necessary test cases have been added and updated.
- [X] A feature toggle or safe disable path has been added (if applicable).
- [X] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [X] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
