### PR TITLE
Run Panel `onCancel` behavior for all non-accept cases `[SYNTH-71]`

### DIFF
--- a/fission/src/ui/UIProvider.tsx
+++ b/fission/src/ui/UIProvider.tsx
@@ -95,7 +95,7 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
                     custom: customProps,
                 },
             } as Modal<T, P>
-            modal?.onClose?.(CloseType.Overwrite)
+            if (modal) closeCallbacks(modal, CloseType.Overwrite)
 
             newModal.props.configured = false
 
@@ -187,7 +187,8 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
                             return existing.id
                         }
                     }
-                    // Replace existing with the new one
+                    // Runs cancels cleanup on overwrite
+                    closeCallbacks(existing, CloseType.Overwrite)
                     setPanels(p => [...p.filter(x => x !== existing), panel as Panel<any, any>])
                     return id
                 }
@@ -207,7 +208,9 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
                 elem.onAccept?.(beforeAcceptResult)
                 break
             }
+            // If anything but accepted, run onCancel
             case CloseType.Cancel:
+            case CloseType.Overwrite:
                 elem.onCancel?.()
                 break
             default:


### PR DESCRIPTION
## TASK
SYNTH-71

## Symptom

When a modal is selected with a panel open, the panels "onCancel()" method is not run. This can cause unintended side effects with spawning/despawning.

## Solution

Treat overwrite behavior the same as cancel behavior regarding cleanup of panels.

## Verification

- [ ] Correct behavior takes place on panel overwrite. (No hanging objects)


Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
