### PR TITLE
Fix Configure Joint Panel Crashing `[SYNTH-167]`

### DIFF
--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -379,13 +379,13 @@ class PhysicsSystem extends WorldSystem {
             const miraMotor = jointData.motorDefinitions![jDef.motorReference]
 
             let maxVel = VELOCITY_DEFAULT
-            let maxForce
+            let maxAcceleration
             if (prefMotor && prefMotor[0]) {
                 maxVel = prefMotor[0].maxVelocity
-                maxForce = prefMotor[0].maxForce
+                maxAcceleration = prefMotor[0].maxAcceleration
             } else if (miraMotor && miraMotor.simpleMotor) {
                 maxVel = miraMotor.simpleMotor.maxVelocity ?? VELOCITY_DEFAULT
-                maxForce = miraMotor.simpleMotor.stallTorque
+                maxAcceleration = miraMotor.simpleMotor.stallTorque
             }
 
             let listener: Jolt.PhysicsStepListener | null = null
@@ -407,7 +407,7 @@ class PhysicsSystem extends WorldSystem {
                     if (this.isWheel(jDef)) {
                         const preferences = PreferencesSystem.getRobotPreferences(parser.assembly.info?.name ?? "")
                         if (preferences.driveVelocity > 0) maxVel = preferences.driveVelocity
-                        if (preferences.driveAcceleration > 0) maxForce = preferences.driveAcceleration
+                        if (preferences.driveAcceleration > 0) maxAcceleration = preferences.driveAcceleration
 
                         const [bodyOne, bodyTwo] = parser.directedGraph.getAdjacencyList(rnA.id).length
                             ? [bodyA, bodyB]
@@ -416,7 +416,7 @@ class PhysicsSystem extends WorldSystem {
                         const res = this.createWheelConstraint(
                             jointInst,
                             jDef,
-                            maxForce ?? 1.5,
+                            maxAcceleration ?? 1.5,
                             bodyOne,
                             bodyTwo,
                             parser.assembly.info!.version!
@@ -432,7 +432,7 @@ class PhysicsSystem extends WorldSystem {
                         this.createHingeConstraint(
                             jointInst,
                             jDef,
-                            maxForce ?? 50,
+                            maxAcceleration ?? 50,
                             bodyA,
                             bodyB,
                             parser.assembly.info!.version!
@@ -442,7 +442,7 @@ class PhysicsSystem extends WorldSystem {
                     break
 
                 case mirabuf.joint.JointMotion.SLIDER:
-                    addConstraint(this.createSliderConstraint(jointInst, jDef, maxForce ?? 200, bodyA, bodyB))
+                    addConstraint(this.createSliderConstraint(jointInst, jDef, maxAcceleration ?? 200, bodyA, bodyB))
                     break
                 case mirabuf.joint.JointMotion.BALL:
                     this.createBallConstraint(jointInst, jDef, bodyA, bodyB, mechanism)

--- a/fission/src/systems/preferences/PreferenceTypes.ts
+++ b/fission/src/systems/preferences/PreferenceTypes.ts
@@ -144,7 +144,7 @@ export type RobotPreferences = {
 export type MotorPreferences = {
     name: string
     maxVelocity: number
-    maxForce: number
+    maxAcceleration: number
 }
 
 export type Alliance = "red" | "blue"
@@ -245,6 +245,6 @@ export function defaultMotorPreferences(name: string): MotorPreferences {
     return {
         name: name,
         maxVelocity: 1,
-        maxForce: 1,
+        maxAcceleration: 1,
     }
 }

--- a/fission/src/systems/simulation/driver/HingeDriver.ts
+++ b/fission/src/systems/simulation/driver/HingeDriver.ts
@@ -30,11 +30,11 @@ class HingeDriver extends Driver {
         this._targetAngle = Math.max(this._constraint.GetLimitsMin(), Math.min(this._constraint.GetLimitsMax(), rads))
     }
 
-    public get maxForce() {
+    public get maxAcceleration() {
         return this._constraint.GetMotorSettings().mMaxTorqueLimit
     }
 
-    public set maxForce(nm: number) {
+    public set maxAcceleration(nm: number) {
         const motorSettings = this._constraint.GetMotorSettings()
         motorSettings.set_mMaxTorqueLimit(nm)
         motorSettings.set_mMinTorqueLimit(-nm)

--- a/fission/src/systems/simulation/driver/SliderDriver.ts
+++ b/fission/src/systems/simulation/driver/SliderDriver.ts
@@ -33,10 +33,10 @@ class SliderDriver extends Driver {
         )
     }
 
-    public get maxForce(): number {
+    public get maxAcceleration(): number {
         return this._constraint.GetMotorSettings().mMaxForceLimit
     }
-    public set maxForce(newtons: number) {
+    public set maxAcceleration(newtons: number) {
         const motorSettings = this._constraint.GetMotorSettings()
         motorSettings.set_mMaxForceLimit(newtons)
         motorSettings.set_mMinForceLimit(-newtons)

--- a/fission/src/test/PreferencesSystem.test.ts
+++ b/fission/src/test/PreferencesSystem.test.ts
@@ -102,8 +102,8 @@ describe("Preferences System Global Values", () => {
 
 describe("Preference System Robot/Field", () => {
     test("Setting motor preferences", () => {
-        const motorPreferences1: MotorPreferences = { name: "testName", maxForce: 10, maxVelocity: 5 }
-        const motorPreferences2: MotorPreferences = { name: "testName2", maxForce: 20, maxVelocity: 10 }
+        const motorPreferences1: MotorPreferences = { name: "testName", maxAcceleration: 10, maxVelocity: 5 }
+        const motorPreferences2: MotorPreferences = { name: "testName2", maxAcceleration: 20, maxVelocity: 10 }
 
         PreferencesSystem.setMotorPreferences("MotorPreferences1", motorPreferences1)
         PreferencesSystem.setMotorPreferences("MotorPreferences2", motorPreferences2)

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureSubsystemsInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureSubsystemsInterface.tsx
@@ -37,7 +37,6 @@ interface ConfigInterfaceProps {
 }
 
 const ConfigInterface: React.FC<ConfigInterfaceProps> = ({ configModeOption, selectedRobot, saveBehaviors }) => {
-    console.log("CONFIG INTERFACE SELECTED")
     return (
         <SubsystemRowInterface
             driver={configModeOption.driver!}

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureSubsystemsInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureSubsystemsInterface.tsx
@@ -37,6 +37,7 @@ interface ConfigInterfaceProps {
 }
 
 const ConfigInterface: React.FC<ConfigInterfaceProps> = ({ configModeOption, selectedRobot, saveBehaviors }) => {
+    console.log("CONFIG INTERFACE SELECTED")
     return (
         <SubsystemRowInterface
             driver={configModeOption.driver!}

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/SubsystemRowInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/SubsystemRowInterface.tsx
@@ -2,7 +2,7 @@ import { Divider, Stack } from "@mui/material"
 import { useCallback, useState } from "react"
 import type MirabufSceneObject from "@/mirabuf/MirabufSceneObject"
 import PreferencesSystem from "@/systems/preferences/PreferencesSystem"
-import type { SequentialBehaviorPreferences } from "@/systems/preferences/PreferenceTypes"
+import type { MotorPreferences, SequentialBehaviorPreferences } from "@/systems/preferences/PreferenceTypes"
 import type Driver from "@/systems/simulation/driver/Driver"
 import HingeDriver from "@/systems/simulation/driver/HingeDriver"
 import SliderDriver from "@/systems/simulation/driver/SliderDriver"
@@ -37,14 +37,14 @@ const SubsystemRowInterface: React.FC<SubsystemRowProps> = ({ robot, driver, seq
         ((driver as SliderDriver) || (driver as HingeDriver) || (driver as WheelDriver)).maxVelocity
     )
     const [force, setForce] = useState<number>(
-        ((driver as SliderDriver) || (driver as HingeDriver) || (driver as WheelDriver)).maxForce
+        ((driver as SliderDriver) || (driver as HingeDriver) || (driver as WheelDriver)).maxAcceleration
     )
     const [unstickForce, setUnstickForce] = useState<number>(
         PreferencesSystem.getRobotPreferences(robot.assemblyName).unstickForce
     )
 
     const onChange = useCallback(
-        (vel: number, force: number, unstick: number) => {
+        (vel: number, acceleration: number, unstick: number) => {
             if (driver instanceof WheelDriver) {
                 const wheelDrivers = robot?.mechanism
                     ? World.simulationSystem
@@ -52,13 +52,14 @@ const SubsystemRowInterface: React.FC<SubsystemRowProps> = ({ robot, driver, seq
                           ?.drivers.filter(x => x instanceof WheelDriver)
                     : undefined
                 wheelDrivers?.forEach(x => {
+                    console.log("Wheel Driver" + JSON.stringify(x))
                     x.maxVelocity = vel
-                    x.maxAcceleration = force
+                    x.maxAcceleration = acceleration
                 })
 
                 // Preferences
                 PreferencesSystem.getRobotPreferences(robot.assemblyName).driveVelocity = vel
-                PreferencesSystem.getRobotPreferences(robot.assemblyName).driveAcceleration = force
+                PreferencesSystem.getRobotPreferences(robot.assemblyName).driveAcceleration = acceleration
             } else {
                 // Preferences
                 if (driver.info?.name) {
@@ -72,13 +73,13 @@ const SubsystemRowInterface: React.FC<SubsystemRowProps> = ({ robot, driver, seq
                     removedMotor.push({
                         name: driver.info?.name ?? "",
                         maxVelocity: vel,
-                        maxForce: force,
-                    })
+                        maxAcceleration: acceleration,
+                    } satisfies MotorPreferences)
 
                     PreferencesSystem.getRobotPreferences(robot.assemblyName).motors = removedMotor
                 }
                 ;((driver as SliderDriver) || (driver as HingeDriver)).maxVelocity = vel
-                ;((driver as SliderDriver) || (driver as HingeDriver)).maxForce = force
+                ;((driver as SliderDriver) || (driver as HingeDriver)).maxAcceleration = acceleration
             }
 
             PreferencesSystem.getRobotPreferences(robot.assemblyName).unstickForce = unstick
@@ -87,6 +88,7 @@ const SubsystemRowInterface: React.FC<SubsystemRowProps> = ({ robot, driver, seq
         [driver, robot.mechanism, robot.assemblyName]
     )
 
+    console.log("SubsystemRowInterface")
     return (
         <>
             <Stack justifyContent={"space-between"} alignItems={"center"} gap={"1rem"}>

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/SubsystemRowInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/SubsystemRowInterface.tsx
@@ -52,7 +52,6 @@ const SubsystemRowInterface: React.FC<SubsystemRowProps> = ({ robot, driver, seq
                           ?.drivers.filter(x => x instanceof WheelDriver)
                     : undefined
                 wheelDrivers?.forEach(x => {
-                    console.log("Wheel Driver" + JSON.stringify(x))
                     x.maxVelocity = vel
                     x.maxAcceleration = acceleration
                 })
@@ -88,7 +87,6 @@ const SubsystemRowInterface: React.FC<SubsystemRowProps> = ({ robot, driver, seq
         [driver, robot.mechanism, robot.assemblyName]
     )
 
-    console.log("SubsystemRowInterface")
     return (
         <>
             <Stack justifyContent={"space-between"} alignItems={"center"} gap={"1rem"}>


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-167

<!--
Provide a brief description of what the task was here.
-->

## Symptom

<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Previously, the following would cause Synthesis to crash:

1. Spawn robot
2. Open the Configure menu on it
3. Click Configure Joints
4. Click Drivetrain

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

An untyped object in `SubsystemRowInterface.tsx` has an improperly named property. The property name was changed in `ca1fc9428e680926702f4348be6c23efd4de4dec`. The LSP rename didn't catch it because it was untyped.

In addition to the property being changed, every instance of the old name has been checked, and the object literal has been typed.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

Clicking "Drivetrain" no longer crashed Synthesis. All tests pass.

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: _"Is this ready-looking?"_
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
