### PR TITLE
Swerve Orientation Reset Button `[SYNTH-170]`

### DIFF
--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -1031,6 +1031,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
                 })
             }
         }
+
         if ((this.brain as SynthesisBrain | undefined)?.driveType === DriveType.SWERVE) {
             data.items.push({
                 name: "Reset Orientation",

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -13,6 +13,7 @@ import EventSystem from "@/systems/EventSystem.ts"
 import type Mechanism from "@/systems/physics/Mechanism"
 import type { LayerReserve } from "@/systems/physics/PhysicsSystem"
 import PreferencesSystem from "@/systems/preferences/PreferencesSystem"
+import { DriveType } from "@/systems/simulation/behavior/Behavior.ts"
 import {
     type Alliance,
     defaultFieldSpawnLocation,
@@ -1030,6 +1031,14 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
                 })
             }
         }
+        if ((this.brain as SynthesisBrain | undefined)?.driveType=== DriveType.SWERVE) {
+            data.items.push({    
+                name: "Reset Orientation",
+                func: () => {
+                    (this.brain as SynthesisBrain).resetSwerveOrientation()
+                }
+            })
+    }
 
         data.items.push({
             name: "Remove",

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -1031,14 +1031,14 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
                 })
             }
         }
-        if ((this.brain as SynthesisBrain | undefined)?.driveType=== DriveType.SWERVE) {
-            data.items.push({    
+        if ((this.brain as SynthesisBrain | undefined)?.driveType === DriveType.SWERVE) {
+            data.items.push({
                 name: "Reset Orientation",
                 func: () => {
                     (this.brain as SynthesisBrain).resetSwerveOrientation()
-                }
+                },
             })
-    }
+        }
 
         data.items.push({
             name: "Remove",

--- a/fission/src/systems/simulation/behavior/synthesis/drive/SwerveDriveBehavior.ts
+++ b/fission/src/systems/simulation/behavior/synthesis/drive/SwerveDriveBehavior.ts
@@ -98,7 +98,7 @@ class SwerveDriveBehavior extends DriveBehavior {
         }
 
         // Adjusts how much turning versus translation is favored.
-        turn *= 0.2
+        turn *= 1.5
 
         const chassisVelocity = robotForward
             .clone()

--- a/fission/src/systems/simulation/behavior/synthesis/drive/SwerveDriveBehavior.ts
+++ b/fission/src/systems/simulation/behavior/synthesis/drive/SwerveDriveBehavior.ts
@@ -67,6 +67,14 @@ class SwerveDriveBehavior extends DriveBehavior {
         return Math.abs(x) < threshold ? 0 : x
     }
 
+    // Reset field forward direction (may be a cleaner way to do this)
+    public resetFieldForward(): void {
+        const rootNodeId = this.resolveRootNodeId()
+        if (rootNodeId == undefined) return
+        const rotation = convertJoltQuatToThreeQuaternion(World.physicsSystem.getBody(rootNodeId)!.GetRotation())
+        this._fieldForward = new THREE.Vector3(0, 0, 1).applyQuaternion(rotation)
+    }
+
     private driveSpeeds(forward: number, strafe: number, turn: number) {
         const rootNodeId = this.resolveRootNodeId()
         if (rootNodeId == undefined) throw new Error("Robot root node should not be undefined")
@@ -76,7 +84,7 @@ class SwerveDriveBehavior extends DriveBehavior {
         const robotRight = new THREE.Vector3(1, 0, 0).applyQuaternion(rotation)
         const robotUp = new THREE.Vector3(0, 1, 0).applyQuaternion(rotation)
 
-        if (InputSystem.getInput("swerveResetFieldForward", this._brainIndex)) this._fieldForward = robotForward.clone()
+        if (InputSystem.getInput("swerveResetFieldForward", this._brainIndex)) this.resetFieldForward()
 
         forward = SwerveDriveBehavior.deadband(forward)
         strafe = SwerveDriveBehavior.deadband(strafe)
@@ -91,7 +99,7 @@ class SwerveDriveBehavior extends DriveBehavior {
         }
 
         // Adjusts how much turning versus translation is favored.
-        turn *= 1.5
+        turn *= 0.2
 
         const chassisVelocity = robotForward
             .clone()

--- a/fission/src/systems/simulation/behavior/synthesis/drive/SwerveDriveBehavior.ts
+++ b/fission/src/systems/simulation/behavior/synthesis/drive/SwerveDriveBehavior.ts
@@ -67,7 +67,6 @@ class SwerveDriveBehavior extends DriveBehavior {
         return Math.abs(x) < threshold ? 0 : x
     }
 
-    // Reset field forward direction (may be a cleaner way to do this)
     public resetFieldForward(): void {
         const rootNodeId = this.resolveRootNodeId()
         if (rootNodeId == undefined) return

--- a/fission/src/systems/simulation/synthesis_brain/SynthesisBrain.ts
+++ b/fission/src/systems/simulation/synthesis_brain/SynthesisBrain.ts
@@ -94,7 +94,6 @@ class SynthesisBrain extends Brain {
         existing.isArcade = driveType == DriveType.ARCADE
     }
 
-    // reset to robot current heading
     public resetSwerveOrientation(): void {
         const swerve = this._behaviors.find(b => b instanceof SwerveDriveBehavior) as SwerveDriveBehavior | undefined
         if (!swerve) return

--- a/fission/src/systems/simulation/synthesis_brain/SynthesisBrain.ts
+++ b/fission/src/systems/simulation/synthesis_brain/SynthesisBrain.ts
@@ -94,6 +94,13 @@ class SynthesisBrain extends Brain {
         existing.isArcade = driveType == DriveType.ARCADE
     }
 
+    // reset to robot current heading
+    public resetSwerveOrientation(): void {
+        const swerve = this._behaviors.find(b => b instanceof SwerveDriveBehavior) as SwerveDriveBehavior | undefined
+        if (!swerve) return
+        swerve.resetFieldForward()
+    }
+
     public configure(): void {
         this._behaviors = []
         this._currentJointIndex = 1


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-170

> [!NOTE]
> This is a PR into the existing PR #1343 (SYNTH-93)


<!--
Provide a brief description of what the task was here.
-->

Create a swerve drivetrain "Reset Orientation" button to reset field centric drive forward definition

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

While the keybind "r" exists for this functionality, there is no button on the object right click menu.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Add a simple reset field method in the `SwerveDriveBehavior` class that uses existing functionality to reset the `_fieldForward` variable. Also change keybind to use this method.

Add a new item to the `MirabufSceneObjectMenu`.

Link through `SynthesisBrain` by calling the method after finding the behavior.


## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

- [x] Reset orientation button resets swerve drive orientation. 

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
