### PR TITLE
Fix gamepiece early ejection direction `[SYNTH-78]`

### DIFF
--- a/fission/src/mirabuf/EjectableSceneObject.ts
+++ b/fission/src/mirabuf/EjectableSceneObject.ts
@@ -30,6 +30,9 @@ class EjectableSceneObject extends SceneObject {
 
     private _desiredQuatRotation?: THREE.Quaternion
 
+    // Set true once the animation has reached the ejection position at least once.
+    private _reachedEndPosition = false
+
     private static _defaultAnimationDuration = 0.5
 
     public static setAnimationDuration(duration: number) {
@@ -133,6 +136,9 @@ class EjectableSceneObject extends SceneObject {
                 // gradual acceleration via easedT
                 desiredPosition = new THREE.Vector3().lerpVectors(this._startTranslation, desiredPosition, easedT)
                 desiredRotation = new THREE.Quaternion().copy(this._startRotation).slerp(desiredRotation, easedT)
+            } else {
+                // animation finished pinning the piece at the ejection pose
+                this._reachedEndPosition = true
             }
 
             // apply the transform
@@ -174,7 +180,9 @@ class EjectableSceneObject extends SceneObject {
 
         World.physicsSystem.enablePhysicsForBody(this._gamePieceBodyId)
 
-        const ejectVector = convertThreeVector3ToJoltVec3(ejectDir.multiplyScalar(this._ejectVelocity))
+        const ejectVector = convertThreeVector3ToJoltVec3(
+            ejectDir.multiplyScalar(this._reachedEndPosition ? this._ejectVelocity : 0)
+        )
         // NOTE
         // Don't destroy these because it seems like `gpBody` takes ownership???
         gpBody.SetLinearVelocity(parentBody.GetLinearVelocity().Add(ejectVector))

--- a/fission/src/mirabuf/EjectableSceneObject.ts
+++ b/fission/src/mirabuf/EjectableSceneObject.ts
@@ -5,6 +5,7 @@ import World from "@/systems/World"
 import {
     convertArrayToThreeMatrix4,
     convertJoltMat44ToThreeMatrix4,
+    convertJoltQuatToThreeQuaternion,
     convertThreeQuaternionToJoltQuat,
     convertThreeVector3ToJoltRVec3,
     convertThreeVector3ToJoltVec3,
@@ -168,7 +169,8 @@ class EjectableSceneObject extends SceneObject {
 
         const parentBody = World.physicsSystem.getBody(this._parentBodyId)!
         const gpBody = World.physicsSystem.getBody(this._gamePieceBodyId)!
-        const ejectDir = new THREE.Vector3(0, 0, 1).applyQuaternion(this._desiredQuatRotation!).normalize()
+        const rot = this._desiredQuatRotation ?? convertJoltQuatToThreeQuaternion(gpBody.GetRotation())
+        const ejectDir = new THREE.Vector3(0, 0, 1).applyQuaternion(rot).normalize()
 
         World.physicsSystem.enablePhysicsForBody(this._gamePieceBodyId)
 

--- a/fission/src/mirabuf/EjectableSceneObject.ts
+++ b/fission/src/mirabuf/EjectableSceneObject.ts
@@ -5,7 +5,6 @@ import World from "@/systems/World"
 import {
     convertArrayToThreeMatrix4,
     convertJoltMat44ToThreeMatrix4,
-    convertJoltQuatToThreeQuaternion,
     convertThreeQuaternionToJoltQuat,
     convertThreeVector3ToJoltRVec3,
     convertThreeVector3ToJoltVec3,
@@ -27,6 +26,8 @@ class EjectableSceneObject extends SceneObject {
     private _animationDuration = EjectableSceneObject._defaultAnimationDuration
     private _startTranslation?: THREE.Vector3
     private _startRotation?: THREE.Quaternion
+
+    private _desiredQuatRotation?: THREE.Quaternion
 
     private static _defaultAnimationDuration = 0.5
 
@@ -125,6 +126,8 @@ class EjectableSceneObject extends SceneObject {
 
             desiredTransform.decompose(desiredPosition, desiredRotation, new THREE.Vector3(1, 1, 1))
 
+            this._desiredQuatRotation = desiredRotation.clone()
+
             if (t < 1 && this._startTranslation && this._startRotation) {
                 // gradual acceleration via easedT
                 desiredPosition = new THREE.Vector3().lerpVectors(this._startTranslation, desiredPosition, easedT)
@@ -165,9 +168,7 @@ class EjectableSceneObject extends SceneObject {
 
         const parentBody = World.physicsSystem.getBody(this._parentBodyId)!
         const gpBody = World.physicsSystem.getBody(this._gamePieceBodyId)!
-        const ejectDir = new THREE.Vector3(0, 0, 1)
-            .applyQuaternion(convertJoltQuatToThreeQuaternion(gpBody.GetRotation()))
-            .normalize()
+        const ejectDir = new THREE.Vector3(0, 0, 1).applyQuaternion(this._desiredQuatRotation!).normalize()
 
         World.physicsSystem.enablePhysicsForBody(this._gamePieceBodyId)
 

--- a/fission/src/mirabuf/ProtectedZoneSceneObject.ts
+++ b/fission/src/mirabuf/ProtectedZoneSceneObject.ts
@@ -1,5 +1,5 @@
-import Jolt from "@azaleacolburn/jolt-physics"
-import * as THREE from "three"
+import type Jolt from "@azaleacolburn/jolt-physics"
+import type * as THREE from "three"
 import EventSystem, { type SynthesisEventListener } from "@/systems/EventSystem.ts"
 import MatchMode from "@/systems/match_mode/MatchMode"
 import { MatchModeType } from "@/systems/match_mode/MatchModeTypes"
@@ -11,7 +11,7 @@ import { MiraType } from "./MirabufLoader"
 import type MirabufSceneObject from "./MirabufSceneObject"
 import type { RigidNodeAssociate } from "./MirabufSceneObject"
 import { ContactType } from "./ZoneTypes"
-import { ProtectedZonePreferences } from "@/systems/preferences/PreferenceTypes"
+import type { ProtectedZonePreferences } from "@/systems/preferences/PreferenceTypes"
 
 class ProtectedZoneSceneObject extends ZoneSceneObject<ProtectedZonePreferences> {
     private _robotsInside: Map<MirabufSceneObject, number> = new Map()

--- a/fission/src/mirabuf/ScoringZoneSceneObject.ts
+++ b/fission/src/mirabuf/ScoringZoneSceneObject.ts
@@ -1,5 +1,5 @@
-import Jolt from "@azaleacolburn/jolt-physics"
-import * as THREE from "three"
+import type Jolt from "@azaleacolburn/jolt-physics"
+import type * as THREE from "three"
 import ScoreTracker from "@/systems/match_mode/ScoreTracker"
 import EventSystem from "@/systems/EventSystem.ts"
 import PreferencesSystem from "@/systems/preferences/PreferencesSystem"

--- a/fission/src/mirabuf/ZoneSceneObject.ts
+++ b/fission/src/mirabuf/ZoneSceneObject.ts
@@ -11,7 +11,7 @@ import {
     convertThreeQuaternionToJoltQuat,
     convertThreeVector3ToJoltRVec3,
 } from "@/util/TypeConversions"
-import { deltaFieldTransformsPhysicalProp, VisualProperties } from "@/util/threejs/MeshCreation"
+import { deltaFieldTransformsPhysicalProp, type VisualProperties } from "@/util/threejs/MeshCreation"
 import type MirabufSceneObject from "./MirabufSceneObject"
 
 export default abstract class ZoneSceneObject<P extends object> extends SceneObject {


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-78

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

If you eject a gamepiece when while it is still being intaken and hasn't reached it's final desired position, it does not shoot in the direct direction.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Set the eject vector to the final desired eject vector rather than the gamepiece's immediate one.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

To Verify: First, spawn a robot in a field, and configure ejector and intake (make sure to make intake animation take 2 seconds for ease of use). Then intake and immediately eject.

- [ ] Game piece shoots in the right direction when being ejected right after intaking.

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
