### PR TITLE
fix: remove move handle from modal headers `[SYNTH-186]`

### DIFF
--- a/fission/src/ui/components/Modal.tsx
+++ b/fission/src/ui/components/Modal.tsx
@@ -51,7 +51,6 @@ export const Modal = <T, P>({ children, modal, parent }: ModalElementProps<T, P>
                         className="select-none"
                         titleTypographyProps={{ variant: "h5" }}
                         sx={{
-                            cursor: "move",
                             py: 1,
                             px: 2,
                             borderBottom: theme => `1px solid ${theme.palette.divider}`,

--- a/fission/src/ui/components/Panel.tsx
+++ b/fission/src/ui/components/Panel.tsx
@@ -85,9 +85,8 @@ export const Panel = <T, P>({ children, panel, parent }: PanelElementProps<T, P>
                 {props.title && (
                     <CardHeader
                         title={props.title}
-                        className="panel-drag-handle select-none hover:cursor-grab active:cursor-grabbing"
+                        className="panel-drag-handle select-none cursor-move"
                         sx={{
-                            cursor: "move",
                             py: 1,
                             px: 2,
                             borderBottom: theme => `1px solid ${theme.palette.divider}`,


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-186

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.
The "move" cursor icon is visible on modal headers, which are not draggable. This is confusing.
Note: "Symptom" can include new product use cases, not just bugs.
-->
<img width="793" height="685" alt="image" src="https://github.com/user-attachments/assets/0bf8d5e1-7c55-4997-9507-1279c3c1d580" />


## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

I made the regular cursor render on the modal headers

<img width="793" height="685" alt="image" src="https://github.com/user-attachments/assets/ee528662-7dc3-472b-af41-ca93838f7266" />
## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

The pointers look as you would expect them to look

---

Before merging, ensure the following criteria are met:

- [X] All acceptance criteria outlined in the ticket are met.
- [X] Necessary test cases have been added and updated.
- [X] A feature toggle or safe disable path has been added (if applicable).
- [X] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [X] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
