### PR TITLE
Spawn Intake/Ejector in the middle of the robot `[SYNTH-204]`

### DIFF
--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -326,6 +326,10 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
         return transform
     }
 
+    public getCenter(vec: THREE.Vector3 = new THREE.Vector3()): THREE.Vector3 {
+        return this.computeBoundingBox().getCenter(vec)
+    }
+
     public moveToSpawnLocation() {
         const referencePos = new THREE.Vector3()
         const pos =

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -46,6 +46,7 @@ import {
     convertJoltMat44ToThreeMatrix4,
     convertJoltRVec3ToJoltVec3,
     convertJoltVec3ToThreeVector3,
+    convertThreeMatrix4ToArray,
     convertThreeVector3ToJoltVec3,
 } from "@/util/TypeConversions"
 import { createMeshForShape } from "@/util/threejs/MeshCreation.ts"
@@ -292,6 +293,12 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
             simLayer.setBrain(this._brain)
         }
 
+        this.updateBatches()
+
+        if (this.miraType === MiraType.ROBOT) {
+            this.centerDefaultZoneTransformations()
+        }
+
         // Intake
         this.updateIntakeSensor()
         this.updateScoringZones()
@@ -300,8 +307,6 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
         if (this.isOwnObject) {
             setSpotlightAssembly(this)
         }
-
-        this.updateBatches()
 
         this._basePositionTransform = this.getPositionTransform()
 
@@ -328,6 +333,34 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
 
     public getCenter(vec: THREE.Vector3 = new THREE.Vector3()): THREE.Vector3 {
         return this.computeBoundingBox().getCenter(vec)
+    }
+
+    private centerDefaultZoneTransformations() {
+        if (this.intakePreferences.deltaTransformation.length === 0) {
+            this.intakePreferences.deltaTransformation = this.computeCenteredDeltaTransformation(
+                this.intakePreferences.parentNode
+            )
+        }
+
+        if (this.ejectorPreferences.deltaTransformation.length === 0) {
+            this.ejectorPreferences.deltaTransformation = this.computeCenteredDeltaTransformation(
+                this.ejectorPreferences.parentNode
+            )
+        }
+    }
+    private computeCenteredDeltaTransformation(parentNode: string | undefined): number[] {
+        const nodeBodyId =
+            this.mechanism.nodeToBody.get(parentNode ?? this.rootNodeId) ??
+            this.mechanism.nodeToBody.get(this.rootNodeId)!
+
+        const robotTransformation = convertJoltMat44ToThreeMatrix4(
+            World.physicsSystem.getBody(nodeBodyId)!.GetWorldTransform()
+        )
+
+        const centeredTransformation = robotTransformation.clone().setPosition(this.getCenter())
+        const deltaTransformation = centeredTransformation.premultiply(robotTransformation.invert())
+
+        return convertThreeMatrix4ToArray(deltaTransformation)
     }
 
     public moveToSpawnLocation() {

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -336,16 +336,25 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
     }
 
     public ensureDefaultZoneTransformations() {
+        let changed = false
+
         if (this.intakePreferences.deltaTransformation.length === 0) {
             this.intakePreferences.deltaTransformation = this.computeCenteredDeltaTransformation(
                 this.intakePreferences.parentNode
             )
+            changed = true
         }
 
         if (this.ejectorPreferences.deltaTransformation.length === 0) {
             this.ejectorPreferences.deltaTransformation = this.computeCenteredDeltaTransformation(
                 this.ejectorPreferences.parentNode
             )
+            changed = true
+        }
+
+        if (changed) {
+            PreferencesSystem.setRobotPreferences(this.assemblyName, this.robotPreferences)
+            PreferencesSystem.savePreferences()
         }
     }
 

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -335,7 +335,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
         return this.computeBoundingBox().getCenter(vec)
     }
 
-    private centerDefaultZoneTransformations() {
+    public ensureDefaultZoneTransformations() {
         if (this.intakePreferences.deltaTransformation.length === 0) {
             this.intakePreferences.deltaTransformation = this.computeCenteredDeltaTransformation(
                 this.intakePreferences.parentNode
@@ -347,6 +347,10 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
                 this.ejectorPreferences.parentNode
             )
         }
+    }
+
+    private centerDefaultZoneTransformations() {
+        this.ensureDefaultZoneTransformations()
     }
     private computeCenteredDeltaTransformation(parentNode: string | undefined): number[] {
         const nodeBodyId =
@@ -906,6 +910,10 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
 
         // Ensure backwards compatibility for showZoneAlways field
         this._robotPreferences.intake.showZoneAlways ??= false
+
+        if (this.miraType === MiraType.ROBOT) {
+            this.centerDefaultZoneTransformations()
+        }
 
         setTimeout(() => this.sendPreferences())
 

--- a/fission/src/systems/preferences/PreferenceTypes.ts
+++ b/fission/src/systems/preferences/PreferenceTypes.ts
@@ -225,7 +225,7 @@ export function defaultRobotPreferences(): RobotPreferences {
         inputsSchemes: [],
         motors: [],
         intake: {
-            deltaTransformation: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+            deltaTransformation: [],
             zoneDiameter: 0.5,
             parentNode: undefined,
             showZoneAlways: false,
@@ -233,7 +233,7 @@ export function defaultRobotPreferences(): RobotPreferences {
             animationDuration: 0.5,
         },
         ejector: {
-            deltaTransformation: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+            deltaTransformation: [],
             ejectorVelocity: 1,
             parentNode: undefined,
             ejectOrder: "FIFO",

--- a/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
@@ -258,7 +258,9 @@ const ConfigurePanel: React.FC<PanelImplProps<void, ConfigurePanelCustomProps>> 
         if (selectedAssembly) {
             const name = selectedAssembly.assemblyName
 
-            const robotPrefs = PreferencesSystem.getRobotPreferences(name)
+            selectedAssembly.ensureDefaultZoneTransformations()
+
+            const robotPrefs = selectedAssembly.robotPreferences
             const fieldPrefs = PreferencesSystem.getFieldPreferences(name)
             const motorPrefs = PreferencesSystem.getMotorPreferences(name)
 

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
@@ -23,9 +23,8 @@ import {
     convertThreeMatrix4ToArray,
 } from "@/util/TypeConversions"
 
-const IDENTITY_MATRIX = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
 function isDefaultDelta(delta: number[]): boolean {
-    return delta.length === IDENTITY_MATRIX.length && delta.every((v, i) => v === IDENTITY_MATRIX[i])
+    return !delta || delta.length === 0
 }
 
 // slider constants

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
@@ -23,6 +23,11 @@ import {
     convertThreeMatrix4ToArray,
 } from "@/util/TypeConversions"
 
+const IDENTITY_MATRIX = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+function isDefaultDelta(delta: number[]): boolean {
+    return delta.length === IDENTITY_MATRIX.length && delta.every((v, i) => v === IDENTITY_MATRIX[i])
+}
+
 // slider constants
 const MIN_ZONE_SIZE = 0.1
 const MAX_ZONE_SIZE = 1.0
@@ -163,6 +168,11 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
                 )
                 const gizmoTransformation = deltaTransformation.premultiply(robotTransformation)
 
+                // / Don't set to center if not default delta, as this will override the user's configuration
+                if (isDefaultDelta(selectedRobot.intakePreferences!.deltaTransformation)) {
+                    gizmoTransformation.setPosition(selectedRobot.getCenter())
+                }
+
                 gizmo.setTransform(gizmoTransformation)
             }
 
@@ -295,7 +305,7 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
                         const robotTransformation = convertJoltMat44ToThreeMatrix4(
                             World.physicsSystem.getBody(selectedRobot.getRootNodeId()!)!.GetWorldTransform()
                         )
-                        gizmoRef.current.obj.position.setFromMatrixPosition(robotTransformation)
+                        gizmoRef.current.obj.position.copy(selectedRobot.getCenter())
                         gizmoRef.current.obj.rotation.setFromRotationMatrix(robotTransformation)
                     }
                     setZoneSize(0.5)

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureGamepiecePickupInterface.tsx
@@ -23,10 +23,6 @@ import {
     convertThreeMatrix4ToArray,
 } from "@/util/TypeConversions"
 
-function isDefaultDelta(delta: number[]): boolean {
-    return !delta || delta.length === 0
-}
-
 // slider constants
 const MIN_ZONE_SIZE = 0.1
 const MAX_ZONE_SIZE = 1.0
@@ -166,11 +162,6 @@ const ConfigureGamepiecePickupInterface: React.FC<ConfigPickupProps> = ({ select
                     World.physicsSystem.getBody(nodeBodyId)!.GetWorldTransform()
                 )
                 const gizmoTransformation = deltaTransformation.premultiply(robotTransformation)
-
-                // / Don't set to center if not default delta, as this will override the user's configuration
-                if (isDefaultDelta(selectedRobot.intakePreferences!.deltaTransformation)) {
-                    gizmoTransformation.setPosition(selectedRobot.getCenter())
-                }
 
                 gizmo.setTransform(gizmoTransformation)
             }

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureShotTrajectoryInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureShotTrajectoryInterface.tsx
@@ -21,6 +21,11 @@ import {
     convertThreeMatrix4ToArray,
 } from "@/util/TypeConversions"
 
+const IDENTITY_MATRIX = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+function isDefaultDelta(delta: number[]): boolean {
+    return delta.length === IDENTITY_MATRIX.length && delta.every((v, i) => v === IDENTITY_MATRIX[i])
+}
+
 // slider constants
 const MIN_VELOCITY = 0.0
 const MAX_VELOCITY = 20.0
@@ -141,6 +146,11 @@ const ConfigureShotTrajectoryInterface: React.FC<ConfigEjectorProps> = ({ select
                 )
                 const gizmoTransformation = deltaTransformation.premultiply(robotTransformation)
 
+                // Don't set to center if not default delta, as this will override the user's configuration
+                if (isDefaultDelta(selectedRobot.ejectorPreferences!.deltaTransformation)) {
+                    gizmoTransformation.setPosition(selectedRobot.getCenter())
+                }
+
                 gizmo.obj.position.setFromMatrixPosition(gizmoTransformation)
                 gizmo.obj.rotation.setFromRotationMatrix(gizmoTransformation)
             }
@@ -250,7 +260,7 @@ const ConfigureShotTrajectoryInterface: React.FC<ConfigEjectorProps> = ({ select
                         const robotTransformation = convertJoltMat44ToThreeMatrix4(
                             World.physicsSystem.getBody(selectedRobot.getRootNodeId()!)!.GetWorldTransform()
                         )
-                        gizmoRef.current.obj.position.setFromMatrixPosition(robotTransformation)
+                        gizmoRef.current.obj.position.copy(selectedRobot.getCenter())
                         gizmoRef.current.obj.rotation.setFromRotationMatrix(robotTransformation)
                     }
                     setEjectorVelocity(1)

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureShotTrajectoryInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureShotTrajectoryInterface.tsx
@@ -21,9 +21,8 @@ import {
     convertThreeMatrix4ToArray,
 } from "@/util/TypeConversions"
 
-const IDENTITY_MATRIX = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
 function isDefaultDelta(delta: number[]): boolean {
-    return delta.length === IDENTITY_MATRIX.length && delta.every((v, i) => v === IDENTITY_MATRIX[i])
+    return !delta || delta.length === 0
 }
 
 // slider constants

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureShotTrajectoryInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/ConfigureShotTrajectoryInterface.tsx
@@ -21,10 +21,6 @@ import {
     convertThreeMatrix4ToArray,
 } from "@/util/TypeConversions"
 
-function isDefaultDelta(delta: number[]): boolean {
-    return !delta || delta.length === 0
-}
-
 // slider constants
 const MIN_VELOCITY = 0.0
 const MAX_VELOCITY = 20.0
@@ -144,11 +140,6 @@ const ConfigureShotTrajectoryInterface: React.FC<ConfigEjectorProps> = ({ select
                     World.physicsSystem.getBody(nodeBodyId)!.GetWorldTransform()
                 )
                 const gizmoTransformation = deltaTransformation.premultiply(robotTransformation)
-
-                // Don't set to center if not default delta, as this will override the user's configuration
-                if (isDefaultDelta(selectedRobot.ejectorPreferences!.deltaTransformation)) {
-                    gizmoTransformation.setPosition(selectedRobot.getCenter())
-                }
 
                 gizmo.obj.position.setFromMatrixPosition(gizmoTransformation)
                 gizmo.obj.rotation.setFromRotationMatrix(gizmoTransformation)

--- a/fission/src/util/TypeConversions.ts
+++ b/fission/src/util/TypeConversions.ts
@@ -15,15 +15,29 @@ export function convertThreeToJoltQuat(a: THREE.Euler | THREE.Quaternion | undef
 }
 
 export function convertArrayToThreeMatrix4(arr: number[]) {
-    // DO NOT ask me why retrieving and setting the same EXACT data is done is two DIFFERENT majors
-    // biome-ignore-start format: We would prefer to visualize this as a matrix
+    // return identity matrix if array is not valid
+    if (!arr || arr.length !== 16) {
+        return new THREE.Matrix4()
+    }
+
     return new THREE.Matrix4(
-        arr[0], arr[4], arr[8], arr[12],
-        arr[1], arr[5], arr[9], arr[13],
-        arr[2], arr[6], arr[10], arr[14],
-        arr[3], arr[7], arr[11], arr[15]
+        arr[0],
+        arr[4],
+        arr[8],
+        arr[12],
+        arr[1],
+        arr[5],
+        arr[9],
+        arr[13],
+        arr[2],
+        arr[6],
+        arr[10],
+        arr[14],
+        arr[3],
+        arr[7],
+        arr[11],
+        arr[15]
     )
-    // biome-ignore-end format: We would prefer to visualize this as a matrix
 }
 
 export function convertThreeMatrix4ToArray(mat: THREE.Matrix4) {

--- a/fission/src/util/TypeConversions.ts
+++ b/fission/src/util/TypeConversions.ts
@@ -23,6 +23,7 @@ export function convertArrayToThreeMatrix4(arr: number[]) {
         arr[2], arr[6], arr[10], arr[14],
         arr[3], arr[7], arr[11], arr[15]
     )
+    // biome-ignore-end format: We would prefer to visualize this as a matrix
 }
 
 export function convertThreeMatrix4ToArray(mat: THREE.Matrix4) {

--- a/fission/src/util/TypeConversions.ts
+++ b/fission/src/util/TypeConversions.ts
@@ -15,28 +15,13 @@ export function convertThreeToJoltQuat(a: THREE.Euler | THREE.Quaternion | undef
 }
 
 export function convertArrayToThreeMatrix4(arr: number[]) {
-    // return identity matrix if array is not valid
-    if (!arr || arr.length !== 16) {
-        return new THREE.Matrix4()
-    }
-
+    // DO NOT ask me why retrieving and setting the same EXACT data is done is two DIFFERENT majors
+    // biome-ignore-start format: We would prefer to visualize this as a matrix
     return new THREE.Matrix4(
-        arr[0],
-        arr[4],
-        arr[8],
-        arr[12],
-        arr[1],
-        arr[5],
-        arr[9],
-        arr[13],
-        arr[2],
-        arr[6],
-        arr[10],
-        arr[14],
-        arr[3],
-        arr[7],
-        arr[11],
-        arr[15]
+        arr[0], arr[4], arr[8], arr[12],
+        arr[1], arr[5], arr[9], arr[13],
+        arr[2], arr[6], arr[10], arr[14],
+        arr[3], arr[7], arr[11], arr[15]
     )
 }
 


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-204

<!--
Provide a brief description of what the task was here.
-->

Make intake/ejector config intially spawn in the center.

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

When Intake/Ejector is spawned for the first time, it is often distanced from the robot itself (sometimes underground), making the user configuration period take slightly longer. 

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Set gizmo to spawn at center after doing a check to make sure the transformation delta is not the intial one.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

---

- [ ] Ejector and Intake config spawn in the middle of the robot
- [ ] This only happens the first time.

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
