### PR TITLE
Hash-mismatch error on mobile `SYNTH-193`

### DIFF
--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -212,11 +212,15 @@ class MirabufCachingService {
                 fileSize: miraBuff.byteLength,
             })
 
-            const cached = await MirabufCachingService.storeInCache(miraBuff, {
-                miraType,
-                name,
-                remotePath: fetchLocation,
-            })
+            const cached = await MirabufCachingService.storeInCache(
+                miraBuff,
+                {
+                    miraType,
+                    name,
+                    remotePath: fetchLocation,
+                },
+                expectedHash
+            )
 
             if (expectedHash != null && cached?.hash != null && cached?.hash != expectedHash) {
                 globalAddToast("warning", "Hash Mismatch", `Try downloading again`)
@@ -445,10 +449,11 @@ class MirabufCachingService {
     // Optional name for when assembly is being decoded anyway like in CacheAndGetLocal()
     private static async storeInCache(
         buffer: ArrayBuffer,
-        extra: Omit<MirabufCacheInfo, "hash">
+        extra: Omit<MirabufCacheInfo, "hash">,
+        expectedHash?: string
     ): Promise<MirabufCacheInfo | undefined> {
         try {
-            const hash = await hashBuffer(buffer)
+            const hash = await hashBuffer(buffer, expectedHash)
 
             this._inMemoryCache[hash] = buffer
             const existing = this._cacheMap.get(hash)

--- a/fission/src/test/mirabuf/__snapshots__/MirabufLoader.test.ts.snap
+++ b/fission/src/test/mirabuf/__snapshots__/MirabufLoader.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`MirabufLoader > Real Fetch > Loads Asset ('/api/mira/fields/FRC Field 2023_v7.mi…') 1`] = `"FRC Field 2023 v7"`;
 
-exports[`MirabufLoader > Real Fetch > Loads Asset ('/api/mira/fields/FRC Field 2023_v7.mi…') 2`] = `"60440aa3010e1fa2f12877ae52aafbea68e81d"`;
+exports[`MirabufLoader > Real Fetch > Loads Asset ('/api/mira/fields/FRC Field 2023_v7.mi…') 2`] = `"604400aa30100e1fa2f12877ae52aafbea68e81d"`;
 
 exports[`MirabufLoader > Real Fetch > Loads Asset ('/api/mira/robots/Dozer_v10.mira') 1`] = `"Dozer v9"`;
 
-exports[`MirabufLoader > Real Fetch > Loads Asset ('/api/mira/robots/Dozer_v10.mira') 2`] = `"14c92b7f1e6b2ea22366d22c272994222a3a29"`;
+exports[`MirabufLoader > Real Fetch > Loads Asset ('/api/mira/robots/Dozer_v10.mira') 2`] = `"14c92b7f1e06b2ea22366d22c2720994222a3a29"`;

--- a/fission/src/util/Utility.ts
+++ b/fission/src/util/Utility.ts
@@ -27,13 +27,13 @@ export function findListDifference<T>(previousList: T[], currentList: T[]): { ad
     return { added, removed }
 }
 
-export async function hashBuffer(buffer: ArrayBuffer): Promise<string> {
+export async function hashBuffer(buffer: ArrayBuffer, fallbackHash?: string): Promise<string> {
     if (crypto?.subtle?.digest == null) {
-        console.warn("Crypto not available, using timestamp as key")
-        return Date.now().toString(16)
+        console.warn("Crypto not available, using fallback hash or timestamp as key")
+        return fallbackHash ?? Date.now().toString(16)
     }
     const hashBuffer = await crypto.subtle.digest("SHA-1", buffer)
     return Array.from(new Uint8Array(hashBuffer))
-        .map(x => x.toString(16))
+        .map(x => x.toString(16).padStart(2, "0"))
         .join("")
 }


### PR DESCRIPTION
## Task

When on mobile, you run into a hash mismatch error (toast) when spawning an assembly for the first time (from default assemblies). This is pretty confusing to users.

## Symptom

crypto.subtle can fail in non-ssl environments and overall can be quite strict.
https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle

This implementation will not have any impact on production (likely) because we use ssl, so this is more of a nice to have.

SYNTH-193

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
