### PR TITLE
Switch All Icons to SynthesisIcon `[SYNTH-202]`

### DIFF
--- a/fission/src/ui/components/AnalyticsConsent.tsx
+++ b/fission/src/ui/components/AnalyticsConsent.tsx
@@ -65,7 +65,7 @@ const AnalyticsConsent: React.FC<AnalyticsConsentProps> = ({ onConsent, onClose 
                     }}
                     aria-label="Decline cookies"
                 >
-                    {SynthesisIcons.STOP}
+                    <SynthesisIcons.STOP />
                 </Button>
             </Box>
         </Box>

--- a/fission/src/ui/components/AnalyticsConsent.tsx
+++ b/fission/src/ui/components/AnalyticsConsent.tsx
@@ -1,7 +1,6 @@
 import { Box } from "@mui/material"
-import { AiOutlineClose } from "react-icons/ai"
 import Label from "./Label"
-import { Button } from "./StyledComponents"
+import { Button, SynthesisIcons } from "./StyledComponents"
 
 interface AnalyticsConsentProps {
     onClose: () => void
@@ -66,7 +65,7 @@ const AnalyticsConsent: React.FC<AnalyticsConsentProps> = ({ onConsent, onClose 
                     }}
                     aria-label="Decline cookies"
                 >
-                    <AiOutlineClose />
+                    {SynthesisIcons.STOP}
                 </Button>
             </Box>
         </Box>

--- a/fission/src/ui/components/DragModeIndicator.tsx
+++ b/fission/src/ui/components/DragModeIndicator.tsx
@@ -27,7 +27,7 @@ const DragModeIndicator: React.FC = () => {
                 boxShadow: 6,
             }}
         >
-            <span className="self-center">{SynthesisIcons.HAND}</span>
+            <SynthesisIcons.HAND className="self-center" />
             <Label size="sm" color="text.primary">
                 Drag Mode
             </Label>

--- a/fission/src/ui/components/DragModeIndicator.tsx
+++ b/fission/src/ui/components/DragModeIndicator.tsx
@@ -1,9 +1,9 @@
 import { Stack } from "@mui/material"
 import { useEffect, useState } from "react"
-import { FaHandPaper } from "react-icons/fa"
 import EventSystem from "@/systems/EventSystem.ts"
 import { globalAddToast } from "./GlobalUIControls"
 import Label from "./Label"
+import { SynthesisIcons } from "./StyledComponents"
 
 const DragModeIndicator: React.FC = () => {
     const [enabled, setEnabled] = useState<boolean>(false)
@@ -27,7 +27,7 @@ const DragModeIndicator: React.FC = () => {
                 boxShadow: 6,
             }}
         >
-            <FaHandPaper className="self-center" />
+            <span className="self-center">{SynthesisIcons.HAND}</span>
             <Label size="sm" color="text.primary">
                 Drag Mode
             </Label>

--- a/fission/src/ui/components/MainHUD.tsx
+++ b/fission/src/ui/components/MainHUD.tsx
@@ -2,7 +2,6 @@ import { Box, ButtonGroup, type ButtonProps, Stack } from "@mui/material"
 import { motion } from "framer-motion"
 import type React from "react"
 import { useEffect, useState } from "react"
-import { FaXmark } from "react-icons/fa6"
 import APS from "@/aps/APS"
 import logo from "@/assets/autodesk_logo.png"
 import { globalAddToast } from "@/components/GlobalUIControls.ts"
@@ -175,7 +174,7 @@ const MainHUD: React.FC = () => {
                         }}
                         onClick={() => setIsOpen(false)}
                     >
-                        <FaXmark size={23} />
+                        {SynthesisIcons.XMARK_LARGE_HUD}
                     </IconButton>
                 </div>
                 <MainHUDButton

--- a/fission/src/ui/components/MainHUD.tsx
+++ b/fission/src/ui/components/MainHUD.tsx
@@ -131,7 +131,7 @@ const MainHUD: React.FC = () => {
                                     },
                                 }}
                             >
-                                {SynthesisIcons.OPEN_HUD_ICON}
+                                <SynthesisIcons.OPEN_HUD_ICON />
                             </IconButton>
                         </Stack>
                     </Box>
@@ -174,11 +174,11 @@ const MainHUD: React.FC = () => {
                         }}
                         onClick={() => setIsOpen(false)}
                     >
-                        {SynthesisIcons.XMARK_LARGE_HUD}
+                        <SynthesisIcons.XMARK_LARGE_HUD />
                     </IconButton>
                 </div>
                 <MainHUDButton
-                    startIcon={SynthesisIcons.ADD}
+                    startIcon={<SynthesisIcons.ADD />}
                     size="large"
                     onClick={() =>
                         openPanel(ImportMirabufPanel, {
@@ -189,11 +189,11 @@ const MainHUD: React.FC = () => {
                     Spawn Asset
                 </MainHUDButton>
                 <ButtonGroup orientation="vertical" variant="contained">
-                    <MainHUDButton startIcon={SynthesisIcons.WRENCH} onClick={() => openPanel(ConfigurePanel, {})}>
+                    <MainHUDButton startIcon={<SynthesisIcons.WRENCH />} onClick={() => openPanel(ConfigurePanel, {})}>
                         Configure Assets
                     </MainHUDButton>
                     <MainHUDButton
-                        startIcon={SynthesisIcons.GEAR}
+                        startIcon={<SynthesisIcons.GEAR />}
                         onClick={() =>
                             openModal(SettingsModal, undefined, undefined, {
                                 allowClickAway: false,
@@ -203,19 +203,19 @@ const MainHUD: React.FC = () => {
                         General Settings
                     </MainHUDButton>
                     <MainHUDButton
-                        startIcon={SynthesisIcons.CAMERA}
+                        startIcon={<SynthesisIcons.CAMERA />}
                         onClick={() => openPanel(CameraSelectionPanel, undefined)}
                     >
                         Configure Camera
                     </MainHUDButton>
                     <MainHUDButton
-                        startIcon={SynthesisIcons.CODE_SQUARE}
+                        startIcon={<SynthesisIcons.CODE_SQUARE />}
                         onClick={() => openPanel(DeveloperToolPanel, undefined)}
                     >
                         Developer Tool
                     </MainHUDButton>
                     <MainHUDButton
-                        startIcon={SynthesisIcons.BUG}
+                        startIcon={<SynthesisIcons.BUG />}
                         onClick={() => {
                             openPanel(DebugPanel, undefined)
                         }}
@@ -224,7 +224,7 @@ const MainHUD: React.FC = () => {
                     </MainHUDButton>
                     {touchCompatibility && (
                         <MainHUDButton
-                            startIcon={SynthesisIcons.GAMEPAD}
+                            startIcon={<SynthesisIcons.GAMEPAD />}
                             onClick={() => EventSystem.dispatch("ToggleTouchControlsVisibilityEvent")}
                         >
                             Touch Controls
@@ -238,13 +238,17 @@ const MainHUD: React.FC = () => {
                         onClick={() => openModal(APSManagementModal, undefined)}
                     >{`Hi, ${userInfo.givenName}`}</MainHUDButton>
                 ) : (
-                    <MainHUDButton startIcon={SynthesisIcons.PEOPLE} onClick={() => APS.requestAuthCode()} size="large">
+                    <MainHUDButton
+                        startIcon={<SynthesisIcons.PEOPLE />}
+                        onClick={() => APS.requestAuthCode()}
+                        size="large"
+                    >
                         APS Login
                     </MainHUDButton>
                 )}
                 {!matchModeRunning ? (
                     <MainHUDButton
-                        startIcon={SynthesisIcons.GAMEPAD}
+                        startIcon={<SynthesisIcons.GAMEPAD />}
                         size="large"
                         onClick={() => {
                             openPanel(MatchModeConfigPanel, undefined)
@@ -255,7 +259,7 @@ const MainHUD: React.FC = () => {
                     </MainHUDButton>
                 ) : (
                     <MainHUDButton
-                        startIcon={SynthesisIcons.XMARK_LARGE}
+                        startIcon={<SynthesisIcons.XMARK_LARGE />}
                         size="large"
                         onClick={() => {
                             MatchMode.getInstance().sandboxModeStart()

--- a/fission/src/ui/components/SelectMenu.tsx
+++ b/fission/src/ui/components/SelectMenu.tsx
@@ -78,7 +78,7 @@ const OptionCard: React.FC<OptionCardProps> = ({ value, index, onSelected, onDel
                     {Spacer(0, 10)}
                     {/*DeleteButton(onDelete !== undefined ? onDelete : () => {}, "select-menu-delete-button")&*/}
                     <Button color="error" onClick={() => onDelete?.()} id="select-menu-delete-button">
-                        {SynthesisIcons.DELETE_LARGE}
+                        <SynthesisIcons.DELETE_LARGE />
                     </Button>
                 </>
             )}
@@ -155,7 +155,7 @@ const SelectMenu: React.FC<SelectMenuProps> = ({
                         id="select-menu-back-button"
                         sx={{ mr: 1 }}
                     >
-                        {SynthesisIcons.LEFT_ARROW_LARGE}
+                        <SynthesisIcons.LEFT_ARROW_LARGE />
                     </IconButton>
                 )}
 
@@ -203,7 +203,7 @@ const SelectMenu: React.FC<SelectMenuProps> = ({
                                 onClick={onAddClicked}
                                 id="select-menu-add-button"
                             >
-                                {SynthesisIcons.ADD_LARGE}
+                                <SynthesisIcons.ADD_LARGE />
                             </Button>
                         )}
                     </Stack>

--- a/fission/src/ui/components/StyledComponents.tsx
+++ b/fission/src/ui/components/StyledComponents.tsx
@@ -20,7 +20,7 @@ import {
     type ToggleButtonProps,
     Tooltip,
 } from "@mui/material"
-import { AiFillWarning, AiOutlineDoubleRight, AiOutlineInfoCircle } from "react-icons/ai"
+import { AiFillWarning, AiOutlineDoubleRight, AiOutlineInfoCircle, AiOutlineClose } from "react-icons/ai"
 import { BiRefresh } from "react-icons/bi"
 import { BsCodeSquare } from "react-icons/bs"
 import {
@@ -31,9 +31,11 @@ import {
     FaCamera,
     FaCar,
     FaChessBoard,
+    FaCheck,
     FaFileImport,
     FaGamepad,
     FaGear,
+    FaInfinity,
     FaMagnifyingGlass,
     FaMinus,
     FaPlus,
@@ -42,10 +44,12 @@ import {
     FaWrench,
     FaXmark,
 } from "react-icons/fa6"
-import { GiSteeringWheel } from "react-icons/gi"
+import { FaHandPaper, FaUnlink } from "react-icons/fa"
+import { GiPerspectiveDiceSixFacesOne, GiSteeringWheel } from "react-icons/gi"
 import { GrConnect } from "react-icons/gr"
-import { HiDownload } from "react-icons/hi"
+import { HiDownload, HiUser } from "react-icons/hi"
 import { IoCheckmark, IoPencil, IoPeople, IoPlayOutline, IoTrashBin } from "react-icons/io5"
+import { MdExpandMore, MdFitScreen, MdZoomInMap, MdZoomOutMap } from "react-icons/md"
 import { SoundPlayer } from "@/systems/sound/SoundPlayer"
 import Label from "./Label"
 import React from "react"
@@ -72,9 +76,19 @@ export class SynthesisIcons {
     public static readonly OUTLINED_DOUBLE_RIGHT = <AiOutlineDoubleRight />
     public static readonly CONNECT = <GrConnect />
     public static readonly INFO = <AiOutlineInfoCircle />
+    public static readonly STOP = <AiOutlineClose />
     public static readonly BUG = <FaBug />
     public static readonly PLAY = <IoPlayOutline />
     public static readonly CAMERA = <FaCamera />
+    public static readonly HAND = <FaHandPaper />
+    public static readonly CHECK = <FaCheck />
+    public static readonly FIT_SCREEN = <MdFitScreen />
+    public static readonly ZOOM_IN = <MdZoomInMap />
+    public static readonly ZOOM_OUT = <MdZoomOutMap />
+    public static readonly USER = <HiUser />
+    public static readonly INFINITY = <FaInfinity />
+    public static readonly UNLINK = <FaUnlink />
+    public static readonly DICE = <GiPerspectiveDiceSixFacesOne />
 
     /** Large icons: used for icon buttons */
     public static readonly DELETE_LARGE = <IoTrashBin size={"1.25rem"} />
@@ -87,7 +101,9 @@ export class SynthesisIcons {
     public static readonly LEFT_ARROW_LARGE = <FaArrowLeft size={"1.25rem"} />
     public static readonly BUG_LARGE = <FaBug size={"1.25rem"} />
     public static readonly XMARK_LARGE = <FaXmark size={"1.25rem"} />
+    public static readonly XMARK_LARGE_HUD = <FaXmark size={23} />
     public static readonly PLAY_LARGE = <IoPlayOutline size={"1.25rem"} />
+    public static readonly EXPAND_MORE_LARGE = <MdExpandMore size={24} />
 
     public static readonly OPEN_HUD_ICON = (
         <FaAngleRight

--- a/fission/src/ui/components/StyledComponents.tsx
+++ b/fission/src/ui/components/StyledComponents.tsx
@@ -50,75 +50,79 @@ import { GrConnect } from "react-icons/gr"
 import { HiDownload, HiUser } from "react-icons/hi"
 import { IoCheckmark, IoPencil, IoPeople, IoPlayOutline, IoTrashBin } from "react-icons/io5"
 import { MdExpandMore, MdFitScreen, MdZoomInMap, MdZoomOutMap } from "react-icons/md"
+import type { IconBaseProps, IconType } from "react-icons"
 import { SoundPlayer } from "@/systems/sound/SoundPlayer"
 import Label from "./Label"
 import React from "react"
 
+/** Wraps an icon with default props (eg. a default size) that callers can still override. */
+function withDefaultProps(icon: IconType, defaultProps: IconBaseProps): IconType {
+    return (props?: IconBaseProps) => React.createElement(icon, { ...defaultProps, ...props })
+}
+
 export class SynthesisIcons {
     /** Regular icons: used for panels, modals, and main hud buttons */
-    public static readonly BASKET_BALL = <FaBasketball />
-    public static readonly GAMEPAD = <FaGamepad />
-    public static readonly GEAR = <FaGear />
-    public static readonly MAGNIFYING_GLASS = <FaMagnifyingGlass />
-    public static readonly ADD = <FaPlus />
-    public static readonly MINUS = <FaMinus />
-    public static readonly IMPORT = <FaFileImport />
-    public static readonly WRENCH = <FaWrench />
-    public static readonly SCREWDRIVER_WRENCH = <FaScrewdriverWrench />
-    public static readonly QUESTION = <FaQuestion />
-    public static readonly XMARK = <FaXmark />
-    public static readonly PEOPLE = <IoPeople />
-    public static readonly CHESS_BOARD = <FaChessBoard />
-    public static readonly FILL_WARNING = <AiFillWarning />
-    public static readonly CAR = <FaCar />
-    public static readonly CODE_SQUARE = <BsCodeSquare />
-    public static readonly STEERING_WHEEL = <GiSteeringWheel />
-    public static readonly OUTLINED_DOUBLE_RIGHT = <AiOutlineDoubleRight />
-    public static readonly CONNECT = <GrConnect />
-    public static readonly INFO = <AiOutlineInfoCircle />
-    public static readonly STOP = <AiOutlineClose />
-    public static readonly BUG = <FaBug />
-    public static readonly PLAY = <IoPlayOutline />
-    public static readonly CAMERA = <FaCamera />
-    public static readonly HAND = <FaHandPaper />
-    public static readonly CHECK = <FaCheck />
-    public static readonly FIT_SCREEN = <MdFitScreen />
-    public static readonly ZOOM_IN = <MdZoomInMap />
-    public static readonly ZOOM_OUT = <MdZoomOutMap />
-    public static readonly USER = <HiUser />
-    public static readonly INFINITY = <FaInfinity />
-    public static readonly UNLINK = <FaUnlink />
-    public static readonly DICE = <GiPerspectiveDiceSixFacesOne />
+    public static readonly BASKET_BALL = FaBasketball
+    public static readonly GAMEPAD = FaGamepad
+    public static readonly GEAR = FaGear
+    public static readonly MAGNIFYING_GLASS = FaMagnifyingGlass
+    public static readonly ADD = FaPlus
+    public static readonly MINUS = FaMinus
+    public static readonly IMPORT = FaFileImport
+    public static readonly WRENCH = FaWrench
+    public static readonly SCREWDRIVER_WRENCH = FaScrewdriverWrench
+    public static readonly QUESTION = FaQuestion
+    public static readonly XMARK = FaXmark
+    public static readonly PEOPLE = IoPeople
+    public static readonly CHESS_BOARD = FaChessBoard
+    public static readonly FILL_WARNING = AiFillWarning
+    public static readonly CAR = FaCar
+    public static readonly CODE_SQUARE = BsCodeSquare
+    public static readonly STEERING_WHEEL = GiSteeringWheel
+    public static readonly OUTLINED_DOUBLE_RIGHT = AiOutlineDoubleRight
+    public static readonly CONNECT = GrConnect
+    public static readonly INFO = AiOutlineInfoCircle
+    public static readonly STOP = AiOutlineClose
+    public static readonly BUG = FaBug
+    public static readonly PLAY = IoPlayOutline
+    public static readonly CAMERA = FaCamera
+    public static readonly HAND = FaHandPaper
+    public static readonly CHECK = FaCheck
+    public static readonly FIT_SCREEN = MdFitScreen
+    public static readonly ZOOM_IN = MdZoomInMap
+    public static readonly ZOOM_OUT = MdZoomOutMap
+    public static readonly USER = HiUser
+    public static readonly INFINITY = FaInfinity
+    public static readonly UNLINK = FaUnlink
+    public static readonly DICE = GiPerspectiveDiceSixFacesOne
 
     /** Large icons: used for icon buttons */
-    public static readonly DELETE_LARGE = <IoTrashBin size={"1.25rem"} />
-    public static readonly DOWNLOAD_LARGE = <HiDownload size={"1.25rem"} />
-    public static readonly ADD_LARGE = <FaPlus size={"1.25rem"} />
-    public static readonly GEAR_LARGE = <FaGear size={"1.25rem"} />
-    public static readonly REFRESH_LARGE = <BiRefresh size={"1.25rem"} />
-    public static readonly SELECT_LARGE = <IoCheckmark size={"1.25rem"} />
-    public static readonly EDIT_LARGE = <IoPencil size={"1.25rem"} />
-    public static readonly LEFT_ARROW_LARGE = <FaArrowLeft size={"1.25rem"} />
-    public static readonly BUG_LARGE = <FaBug size={"1.25rem"} />
-    public static readonly XMARK_LARGE = <FaXmark size={"1.25rem"} />
-    public static readonly XMARK_LARGE_HUD = <FaXmark size={23} />
-    public static readonly PLAY_LARGE = <IoPlayOutline size={"1.25rem"} />
-    public static readonly EXPAND_MORE_LARGE = <MdExpandMore size={24} />
+    public static readonly DELETE_LARGE = withDefaultProps(IoTrashBin, { size: "1.25rem" })
+    public static readonly DOWNLOAD_LARGE = withDefaultProps(HiDownload, { size: "1.25rem" })
+    public static readonly ADD_LARGE = withDefaultProps(FaPlus, { size: "1.25rem" })
+    public static readonly GEAR_LARGE = withDefaultProps(FaGear, { size: "1.25rem" })
+    public static readonly REFRESH_LARGE = withDefaultProps(BiRefresh, { size: "1.25rem" })
+    public static readonly SELECT_LARGE = withDefaultProps(IoCheckmark, { size: "1.25rem" })
+    public static readonly EDIT_LARGE = withDefaultProps(IoPencil, { size: "1.25rem" })
+    public static readonly LEFT_ARROW_LARGE = withDefaultProps(FaArrowLeft, { size: "1.25rem" })
+    public static readonly BUG_LARGE = withDefaultProps(FaBug, { size: "1.25rem" })
+    public static readonly XMARK_LARGE = withDefaultProps(FaXmark, { size: "1.25rem" })
+    public static readonly XMARK_LARGE_HUD = withDefaultProps(FaXmark, { size: 23 })
+    public static readonly PLAY_LARGE = withDefaultProps(IoPlayOutline, { size: "1.25rem" })
+    public static readonly EXPAND_MORE_LARGE = withDefaultProps(MdExpandMore, { size: 24 })
 
-    public static readonly OPEN_HUD_ICON = (
-        <FaAngleRight
-            size={"5vh"}
-            style={{
-                alignSelf: "middle",
-                justifySelf: "center",
-                minHeight: "40px",
-                minWidth: "40px",
-                maxHeight: "50px",
-                maxWidth: "50px",
-            }}
-            // color={colorNameToVar("BackgroundSecondary")}
-        />
-    )
+    public static readonly OPEN_HUD_ICON = withDefaultProps(FaAngleRight, {
+        size: "5vh",
+        style: {
+            alignSelf: "middle",
+            justifySelf: "center",
+            minHeight: "40px",
+            minWidth: "40px",
+            maxHeight: "50px",
+            maxWidth: "50px",
+        },
+        // color={colorNameToVar("BackgroundSecondary")}
+    })
 }
 
 export const Spacer = (heightPx?: number, widthPx?: number) => {
@@ -197,7 +201,7 @@ export const PositiveIconButton: React.FC<IconButtonProps> = ({ children, onClic
 export const DownloadButton = (onClick: () => void, props: IconButtonProps = {}) => {
     return (
         <PositiveIconButton onClick={onClick} {...props}>
-            {SynthesisIcons.DELETE_LARGE}
+            <SynthesisIcons.DELETE_LARGE />
         </PositiveIconButton>
     )
 }
@@ -205,7 +209,7 @@ export const DownloadButton = (onClick: () => void, props: IconButtonProps = {})
 export const AddButton = (onClick: () => void, props: IconButtonProps = {}) => {
     return (
         <PositiveIconButton onClick={onClick} {...props}>
-            {SynthesisIcons.ADD_LARGE}
+            <SynthesisIcons.ADD_LARGE />
         </PositiveIconButton>
     )
 }
@@ -213,7 +217,7 @@ export const AddButton = (onClick: () => void, props: IconButtonProps = {}) => {
 export const SelectButton = (onClick: () => void, props: IconButtonProps = {}) => {
     return (
         <PositiveIconButton onClick={onClick} {...props}>
-            {SynthesisIcons.SELECT_LARGE}
+            <SynthesisIcons.SELECT_LARGE />
         </PositiveIconButton>
     )
 }
@@ -221,7 +225,7 @@ export const SelectButton = (onClick: () => void, props: IconButtonProps = {}) =
 export const EditButton = (onClick: () => void, props: IconButtonProps = {}) => {
     return (
         <PositiveIconButton onClick={onClick} {...props}>
-            {SynthesisIcons.EDIT_LARGE}
+            <SynthesisIcons.EDIT_LARGE />
         </PositiveIconButton>
     )
 }
@@ -245,7 +249,7 @@ export const NegativeIconButton: React.FC<IconButtonProps> = ({ children, onClic
 export const DeleteButton = (onClick: () => void, id?: string, props: IconButtonProps = {}) => {
     return (
         <NegativeIconButton onClick={onClick} id={id} {...props}>
-            {SynthesisIcons.DELETE_LARGE}
+            <SynthesisIcons.DELETE_LARGE />
         </NegativeIconButton>
     )
 }
@@ -253,7 +257,7 @@ export const DeleteButton = (onClick: () => void, id?: string, props: IconButton
 export const RefreshButton = (onClick: () => void, props: IconButtonProps = {}) => {
     return (
         <IconButton onClick={onClick} {...props}>
-            {SynthesisIcons.REFRESH_LARGE}
+            <SynthesisIcons.REFRESH_LARGE />
         </IconButton>
     )
 }

--- a/fission/src/ui/components/UserIcon.tsx
+++ b/fission/src/ui/components/UserIcon.tsx
@@ -18,7 +18,7 @@ const UserIcon: React.FC<UserIconProps> = ({ className }) => {
     }, [])
 
     if (!userInfo) {
-        return SynthesisIcons.QUESTION
+        return <SynthesisIcons.QUESTION />
     } else {
         return <img src={userInfo.picture} className={`object-contain aspect-square ${className}`}></img>
     }

--- a/fission/src/ui/components/WPILibConnectionStatus.tsx
+++ b/fission/src/ui/components/WPILibConnectionStatus.tsx
@@ -24,9 +24,9 @@ const WPILibConnectionStatus: React.FC = () => {
             className="select-none absolute right-1 top-1 py-2 px-4 rounded-lg gap-2"
         >
             {status ? (
-                <span className="text-green-500 self-center">{SynthesisIcons.CHECK}</span>
+                <SynthesisIcons.CHECK className="text-green-500 self-center" />
             ) : (
-                <span className="text-cancel-button self-center">{SynthesisIcons.XMARK}</span>
+                <SynthesisIcons.XMARK className="text-cancel-button self-center" />
             )}
             <Label size="sm">Code Connection</Label>
         </Stack>

--- a/fission/src/ui/components/WPILibConnectionStatus.tsx
+++ b/fission/src/ui/components/WPILibConnectionStatus.tsx
@@ -1,9 +1,9 @@
 import { Stack } from "@mui/material"
 import type React from "react"
 import { useEffect, useState } from "react"
-import { FaCheck, FaXmark } from "react-icons/fa6"
 import { getIsConnected, hasSimBrain } from "@/systems/simulation/wpilib_brain/WPILibState"
 import Label from "@/ui/components/Label"
+import { SynthesisIcons } from "./StyledComponents"
 
 const WPILibConnectionStatus: React.FC = () => {
     const [status, setStatus] = useState<boolean>(false)
@@ -24,9 +24,9 @@ const WPILibConnectionStatus: React.FC = () => {
             className="select-none absolute right-1 top-1 py-2 px-4 rounded-lg gap-2"
         >
             {status ? (
-                <FaCheck className="text-green-500 self-center" />
+                <span className="text-green-500 self-center">{SynthesisIcons.CHECK}</span>
             ) : (
-                <FaXmark className="text-cancel-button self-center" />
+                <span className="text-cancel-button self-center">{SynthesisIcons.XMARK}</span>
             )}
             <Label size="sm">Code Connection</Label>
         </Stack>

--- a/fission/src/ui/components/simulation/FlowControls.tsx
+++ b/fission/src/ui/components/simulation/FlowControls.tsx
@@ -1,5 +1,4 @@
 import { Panel as FlowPanel, useReactFlow } from "@xyflow/react"
-import { cloneElement } from "react"
 import type { FlowControlsProps } from "@/systems/simulation/SimConfigShared"
 import { Button, SynthesisIcons } from "../StyledComponents"
 
@@ -9,16 +8,16 @@ function FlowControls({ onCreateJunction }: FlowControlsProps) {
     return (
         <FlowPanel position="bottom-left" className="flex flex-col-reverse gap-1">
             <Button variant="outlined" onClick={() => fitView()}>
-                {cloneElement(SynthesisIcons.FIT_SCREEN, { className: "w-full h-full" })}
+                <SynthesisIcons.FIT_SCREEN className="w-full h-full" />
             </Button>
             <Button variant="outlined" onClick={() => zoomOut()}>
-                {cloneElement(SynthesisIcons.ZOOM_OUT, { className: "w-full h-full" })}
+                <SynthesisIcons.ZOOM_OUT className="w-full h-full" />
             </Button>
             <Button variant="outlined" onClick={() => zoomIn()}>
-                {cloneElement(SynthesisIcons.ZOOM_IN, { className: "w-full h-full" })}
+                <SynthesisIcons.ZOOM_IN className="w-full h-full" />
             </Button>
             <Button variant="outlined" onClick={() => onCreateJunction?.()}>
-                {cloneElement(SynthesisIcons.ADD, { className: "w-full h-full" })}
+                <SynthesisIcons.ADD className="w-full h-full" />
             </Button>
         </FlowPanel>
     )

--- a/fission/src/ui/components/simulation/FlowControls.tsx
+++ b/fission/src/ui/components/simulation/FlowControls.tsx
@@ -1,8 +1,7 @@
 import { Panel as FlowPanel, useReactFlow } from "@xyflow/react"
-import { FaPlus } from "react-icons/fa6"
-import { MdFitScreen, MdZoomInMap, MdZoomOutMap } from "react-icons/md"
+import { cloneElement } from "react"
 import type { FlowControlsProps } from "@/systems/simulation/SimConfigShared"
-import { Button } from "../StyledComponents"
+import { Button, SynthesisIcons } from "../StyledComponents"
 
 function FlowControls({ onCreateJunction }: FlowControlsProps) {
     const { zoomIn, zoomOut, fitView } = useReactFlow()
@@ -10,16 +9,16 @@ function FlowControls({ onCreateJunction }: FlowControlsProps) {
     return (
         <FlowPanel position="bottom-left" className="flex flex-col-reverse gap-1">
             <Button variant="outlined" onClick={() => fitView()}>
-                <MdFitScreen className="w-full h-full" />
+                {cloneElement(SynthesisIcons.FIT_SCREEN, { className: "w-full h-full" })}
             </Button>
             <Button variant="outlined" onClick={() => zoomOut()}>
-                <MdZoomOutMap className="w-full h-full" />
+                {cloneElement(SynthesisIcons.ZOOM_OUT, { className: "w-full h-full" })}
             </Button>
             <Button variant="outlined" onClick={() => zoomIn()}>
-                <MdZoomInMap className="w-full h-full" />
+                {cloneElement(SynthesisIcons.ZOOM_IN, { className: "w-full h-full" })}
             </Button>
             <Button variant="outlined" onClick={() => onCreateJunction?.()}>
-                <FaPlus className="w-full h-full" />
+                {cloneElement(SynthesisIcons.ADD, { className: "w-full h-full" })}
             </Button>
         </FlowPanel>
     )

--- a/fission/src/ui/modals/APSManagementModal.tsx
+++ b/fission/src/ui/modals/APSManagementModal.tsx
@@ -22,7 +22,7 @@ const APSManagementModal: React.FC<ModalImplProps<void, void>> = ({ modal }) => 
             {userInfo?.picture ? (
                 <img alt={userInfo?.name} src={userInfo?.picture} className="h-10 rounded-full" />
             ) : (
-                SynthesisIcons.USER
+                <SynthesisIcons.USER />
             )}
         </Stack>
     )

--- a/fission/src/ui/modals/APSManagementModal.tsx
+++ b/fission/src/ui/modals/APSManagementModal.tsx
@@ -1,9 +1,9 @@
 import { Stack } from "@mui/material"
 import type React from "react"
 import { useEffect, useState } from "react"
-import { HiUser } from "react-icons/hi"
 import APS from "@/aps/APS"
 import type { ModalImplProps } from "@/ui/components/Modal"
+import { SynthesisIcons } from "@/ui/components/StyledComponents"
 import { useUIContext } from "../helpers/UIProviderHelpers"
 
 const APSManagementModal: React.FC<ModalImplProps<void, void>> = ({ modal }) => {
@@ -22,7 +22,7 @@ const APSManagementModal: React.FC<ModalImplProps<void, void>> = ({ modal }) => 
             {userInfo?.picture ? (
                 <img alt={userInfo?.name} src={userInfo?.picture} className="h-10 rounded-full" />
             ) : (
-                <HiUser />
+                SynthesisIcons.USER
             )}
         </Stack>
     )

--- a/fission/src/ui/modals/configuring/SettingsModal.tsx
+++ b/fission/src/ui/modals/configuring/SettingsModal.tsx
@@ -491,7 +491,7 @@ const ThemeEditorTab: React.FC<ThemeEditorTabProps> = ({ onActionsChange }) => {
             <ColorEditor label="Blue Alliance" color={tempBlue} setColor={setTempBlue} />
             <ColorEditor label="Red Alliance" color={tempRed} setColor={setTempRed} />
             <Button
-                startIcon={SynthesisIcons.DICE}
+                startIcon={<SynthesisIcons.DICE />}
                 onClick={() => {
                     setTempPrimary(randomColor())
                     setTempSecondary(randomColor())

--- a/fission/src/ui/modals/configuring/SettingsModal.tsx
+++ b/fission/src/ui/modals/configuring/SettingsModal.tsx
@@ -1,7 +1,6 @@
 import { Box, Stack, Tab, Tabs, TextField } from "@mui/material"
 import type React from "react"
 import { useCallback, useEffect, useReducer, useState } from "react"
-import { GiPerspectiveDiceSixFacesOne } from "react-icons/gi"
 import { globalAddToast, globalOpenModal } from "@/components/GlobalUIControls.ts"
 import PreferencesSystem from "@/systems/preferences/PreferencesSystem"
 import type { GlobalPreference, GlobalPreferences } from "@/systems/preferences/PreferenceTypes"
@@ -11,7 +10,7 @@ import Checkbox from "@/ui/components/Checkbox"
 import Label from "@/ui/components/Label"
 import type { ModalImplProps } from "@/ui/components/Modal"
 import StatefulSlider from "@/ui/components/StatefulSlider"
-import { Button, Spacer } from "@/ui/components/StyledComponents"
+import { Button, Spacer, SynthesisIcons } from "@/ui/components/StyledComponents"
 import { useThemeContext } from "@/ui/helpers/ThemeProviderHelpers"
 import { useUIContext } from "@/ui/helpers/UIProviderHelpers"
 import { randomColor } from "@/util/Random"
@@ -492,7 +491,7 @@ const ThemeEditorTab: React.FC<ThemeEditorTabProps> = ({ onActionsChange }) => {
             <ColorEditor label="Blue Alliance" color={tempBlue} setColor={setTempBlue} />
             <ColorEditor label="Red Alliance" color={tempRed} setColor={setTempRed} />
             <Button
-                startIcon={<GiPerspectiveDiceSixFacesOne />}
+                startIcon={SynthesisIcons.DICE}
                 onClick={() => {
                     setTempPrimary(randomColor())
                     setTempSecondary(randomColor())

--- a/fission/src/ui/panels/configuring/MatchModeConfigPanel.tsx
+++ b/fission/src/ui/panels/configuring/MatchModeConfigPanel.tsx
@@ -168,9 +168,13 @@ const ItemCard: React.FC<ItemCardProps> = ({ id, name, primaryOnClick, secondary
                 alignItems={"center"}
             >
                 {secondaryOnClick && (
-                    <NegativeButton onClick={secondaryOnClick}>{SynthesisIcons.DELETE_LARGE}</NegativeButton>
+                    <NegativeButton onClick={secondaryOnClick}>
+                        <SynthesisIcons.DELETE_LARGE />
+                    </NegativeButton>
                 )}
-                <PositiveButton onClick={primaryOnClick}>{SynthesisIcons.PLAY_LARGE}</PositiveButton>
+                <PositiveButton onClick={primaryOnClick}>
+                    <SynthesisIcons.PLAY_LARGE />
+                </PositiveButton>
             </Stack>
         </Stack>
     )

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/SequentialBehaviorsInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/SequentialBehaviorsInterface.tsx
@@ -91,7 +91,7 @@ const BehaviorCard: React.FC<BehaviorCardProps> = ({
 
                         // sx={hasChild ? { bgcolor: "background.default", "&:hover": { filter: "brightness(100%)" } } : {}}
                     >
-                        {hasParent ? SynthesisIcons.UNLINK : lookingForParent == behavior ? "Cancel" : "Follow"}
+                        {hasParent ? <SynthesisIcons.UNLINK /> : lookingForParent == behavior ? "Cancel" : "Follow"}
                     </Button>
                 </div>
             </Tooltip>

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/SequentialBehaviorsInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/SequentialBehaviorsInterface.tsx
@@ -8,8 +8,7 @@ import { defaultSequentialConfig, type SequentialBehaviorPreferences } from "@/s
 import GenericArmBehavior from "@/systems/simulation/behavior/synthesis/GenericArmBehavior"
 import SequenceableBehavior from "@/systems/simulation/behavior/synthesis/SequenceableBehavior"
 import type SynthesisBrain from "@/systems/simulation/synthesis_brain/SynthesisBrain"
-import { Button, Spacer } from "@/ui/components/StyledComponents"
-import { FaUnlink } from "react-icons/fa"
+import { Button, Spacer, SynthesisIcons } from "@/ui/components/StyledComponents"
 
 interface BehaviorCardProps {
     elementKey: number
@@ -92,7 +91,7 @@ const BehaviorCard: React.FC<BehaviorCardProps> = ({
 
                         // sx={hasChild ? { bgcolor: "background.default", "&:hover": { filter: "brightness(100%)" } } : {}}
                     >
-                        {hasParent ? <FaUnlink /> : lookingForParent == behavior ? "Cancel" : "Follow"}
+                        {hasParent ? SynthesisIcons.UNLINK : lookingForParent == behavior ? "Cancel" : "Follow"}
                     </Button>
                 </div>
             </Tooltip>

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/inputs/ConfigureSchemeInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/inputs/ConfigureSchemeInterface.tsx
@@ -58,7 +58,7 @@ const ConfigureSchemeInterface: React.FC<ConfigSchemeProps> = ({ selectedScheme,
                     <Stack direction="row" textAlign={"center"} minHeight={"30px"} key="selected-item">
                         {/** Back arrow button when an option is selected */}
                         <IconButton onClick={onBack} id="select-menu-back-button">
-                            {SynthesisIcons.LEFT_ARROW_LARGE}
+                            <SynthesisIcons.LEFT_ARROW_LARGE />
                         </IconButton>
 
                         <Stack alignSelf={"center"}>

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/inputs/InputSelectionComponents.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/inputs/InputSelectionComponents.tsx
@@ -120,7 +120,7 @@ export const KeyboardAxisSelection: React.FC<InputSelectionProps> = ({ input, se
                 <Label size="md">{toTitleCase(input.inputName)}</Label>
 
                 <Stack direction="row" gap="10px" alignItems={"center"}>
-                    {SynthesisIcons.ADD}
+                    <SynthesisIcons.ADD />
                     {/* Positive key */}
                     <Button
                         key={`pos${input.inputName}`}
@@ -133,7 +133,7 @@ export const KeyboardAxisSelection: React.FC<InputSelectionProps> = ({ input, se
                             ? "..."
                             : transformKeyName(input.posKeyCode, input.posKeyModifiers)}
                     </Button>
-                    {SynthesisIcons.MINUS}
+                    <SynthesisIcons.MINUS />
                     {/* Negative key */}
                     <Button
                         key={`neg${input.inputName}`}
@@ -221,7 +221,7 @@ export const GamepadButtonAxisSelection: React.FC<InputSelectionProps> = ({
 
             <Stack direction="row" gap="10px" alignItems={"center"}>
                 {/* Positive gamepad button */}
-                {SynthesisIcons.ADD}
+                <SynthesisIcons.ADD />
                 <Button
                     key={`pos${input.inputName}`}
                     onClick={() => {
@@ -235,7 +235,7 @@ export const GamepadButtonAxisSelection: React.FC<InputSelectionProps> = ({
                           : gamepadButtons[input.posGamepadButton]}
                 </Button>
                 {/* // Negative gamepad button */}
-                {SynthesisIcons.MINUS}
+                <SynthesisIcons.MINUS />
                 <Button
                     key={`neg${input.inputName}`}
                     onClick={() => {

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/scoring/ConfigureProtectedZonesInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/scoring/ConfigureProtectedZonesInterface.tsx
@@ -43,7 +43,7 @@ const ConfigureProtectedZonesInterface: React.FC<ConfigureZonesProps> = ({ selec
 
                         {/** Back arrow button when an option is selected */}
                         <Button
-                            startIcon={SynthesisIcons.LEFT_ARROW_LARGE}
+                            startIcon={<SynthesisIcons.LEFT_ARROW_LARGE />}
                             onClick={() => {
                                 EventSystem.dispatch("ConfigurationSavedEvent")
                                 setSelectedZone(undefined)

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/scoring/ConfigureScoringZonesInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/scoring/ConfigureScoringZonesInterface.tsx
@@ -43,7 +43,7 @@ const ConfigureScoringZonesInterface: React.FC<ConfigureZonesProps> = ({ selecte
 
                         {/** Back arrow button when an option is selected */}
                         <Button
-                            startIcon={SynthesisIcons.LEFT_ARROW_LARGE}
+                            startIcon={<SynthesisIcons.LEFT_ARROW_LARGE />}
                             onClick={() => {
                                 EventSystem.dispatch("ConfigurationSavedEvent")
                                 setSelectedZone(undefined)

--- a/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
+++ b/fission/src/ui/panels/configuring/initial-config/InputSchemeSelection.tsx
@@ -87,7 +87,7 @@ export default function InputSchemeSelection({
                                     update()
                                 }}
                             >
-                                {SynthesisIcons.SELECT_LARGE}
+                                <SynthesisIcons.SELECT_LARGE />
                             </PositiveButton>
                         </Box>
                         {/** Edit button - same as select but opens the inputs modal */}
@@ -203,7 +203,7 @@ export default function InputSchemeSelection({
                     onCreateNew?.()
                 }}
             >
-                {SynthesisIcons.ADD_LARGE}
+                <SynthesisIcons.ADD_LARGE />
             </Button>
         </>
     )

--- a/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
+++ b/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
@@ -1,7 +1,6 @@
 import { Box, CircularProgress, Stack, Tab, Tabs, Tooltip } from "@mui/material"
 import type React from "react"
 import { type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react"
-import { MdExpandMore } from "react-icons/md"
 import { type Data, getMirabufFiles, hasMirabufFiles, requestMirabufFiles } from "@/aps/APSDataManagement"
 import DefaultAssetLoader, { type DefaultAssetInfo } from "@/mirabuf/DefaultAssetLoader.ts"
 import MirabufCachingService, { type MirabufCacheInfo, MiraType } from "@/mirabuf/MirabufLoader"
@@ -437,7 +436,7 @@ const ImportMirabufPanel: React.FC<PanelImplProps<void, ImportMirabufPanelCustom
                 <Tab key="fields" value={MiraType.FIELD} label="FIELDS" />
             </Tabs>
             <Accordion defaultExpanded>
-                <AccordionSummary expandIcon={<MdExpandMore size={24} />}>
+                <AccordionSummary expandIcon={SynthesisIcons.EXPAND_MORE_LARGE}>
                     {viewType === MiraType.ROBOT ? (
                         <Label size="md" className="text-center mt-[4pt] mb-[2pt] mx-[5%]">
                             {cachedRobotElements
@@ -467,7 +466,7 @@ const ImportMirabufPanel: React.FC<PanelImplProps<void, ImportMirabufPanelCustom
                 </AccordionDetails>
             </Accordion>
             <Accordion>
-                <AccordionSummary expandIcon={<MdExpandMore size={24} />}>
+                <AccordionSummary expandIcon={SynthesisIcons.EXPAND_MORE_LARGE}>
                     <Stack
                         direction="row"
                         key={`remote-label-container`}
@@ -505,7 +504,7 @@ const ImportMirabufPanel: React.FC<PanelImplProps<void, ImportMirabufPanelCustom
                 </AccordionDetails>
             </Accordion>
             <Accordion>
-                <AccordionSummary expandIcon={<MdExpandMore size={24} />}>
+                <AccordionSummary expandIcon={SynthesisIcons.EXPAND_MORE_LARGE}>
                     {viewType === MiraType.ROBOT ? (
                         <Label size="md" className="text-center mt-[4pt] mb-[2pt] mx-[5%]">
                             {remoteRobotElements

--- a/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
+++ b/fission/src/ui/panels/mirabuf/ImportMirabufPanel.tsx
@@ -283,7 +283,7 @@ const ImportMirabufPanel: React.FC<PanelImplProps<void, ImportMirabufPanelCustom
                     ItemCard({
                         name: info.name || "Unnamed",
                         id: info.hash,
-                        primaryButtonNode: SynthesisIcons.ADD_LARGE,
+                        primaryButtonNode: <SynthesisIcons.ADD_LARGE />,
                         primaryOnClick: async () => {
                             console.log(`Selecting cached: ${info.name}`)
                             await selectCache(info)
@@ -325,7 +325,7 @@ const ImportMirabufPanel: React.FC<PanelImplProps<void, ImportMirabufPanelCustom
                 ItemCard({
                     name: item.name,
                     id: item.hash,
-                    primaryButtonNode: SynthesisIcons.DOWNLOAD_LARGE,
+                    primaryButtonNode: <SynthesisIcons.DOWNLOAD_LARGE />,
                     primaryOnClick: () => {
                         console.log(`Selecting remote: ${item.remotePath}`)
                         selectRemote(item)
@@ -345,7 +345,7 @@ const ImportMirabufPanel: React.FC<PanelImplProps<void, ImportMirabufPanelCustom
                 ItemCard({
                     name: asset.name,
                     id: asset.hash,
-                    primaryButtonNode: SynthesisIcons.DOWNLOAD_LARGE,
+                    primaryButtonNode: <SynthesisIcons.DOWNLOAD_LARGE />,
                     primaryOnClick: () => {
                         console.log(`Selecting remote: ${asset.remotePath}`)
                         selectRemote(asset)
@@ -410,7 +410,7 @@ const ImportMirabufPanel: React.FC<PanelImplProps<void, ImportMirabufPanelCustom
                     ItemCard({
                         name: `${file.attributes.displayName!.replace(".mira", "")}${file.attributes.versionNumber !== undefined ? ` (v${file.attributes.versionNumber})` : ""}`,
                         id: file.id,
-                        primaryButtonNode: SynthesisIcons.DOWNLOAD_LARGE,
+                        primaryButtonNode: <SynthesisIcons.DOWNLOAD_LARGE />,
                         primaryOnClick: () => {
                             console.debug(file.raw)
                             selectAPS(file, viewType)
@@ -436,7 +436,7 @@ const ImportMirabufPanel: React.FC<PanelImplProps<void, ImportMirabufPanelCustom
                 <Tab key="fields" value={MiraType.FIELD} label="FIELDS" />
             </Tabs>
             <Accordion defaultExpanded>
-                <AccordionSummary expandIcon={SynthesisIcons.EXPAND_MORE_LARGE}>
+                <AccordionSummary expandIcon={<SynthesisIcons.EXPAND_MORE_LARGE />}>
                     {viewType === MiraType.ROBOT ? (
                         <Label size="md" className="text-center mt-[4pt] mb-[2pt] mx-[5%]">
                             {cachedRobotElements
@@ -466,7 +466,7 @@ const ImportMirabufPanel: React.FC<PanelImplProps<void, ImportMirabufPanelCustom
                 </AccordionDetails>
             </Accordion>
             <Accordion>
-                <AccordionSummary expandIcon={SynthesisIcons.EXPAND_MORE_LARGE}>
+                <AccordionSummary expandIcon={<SynthesisIcons.EXPAND_MORE_LARGE />}>
                     <Stack
                         direction="row"
                         key={`remote-label-container`}
@@ -504,7 +504,7 @@ const ImportMirabufPanel: React.FC<PanelImplProps<void, ImportMirabufPanelCustom
                 </AccordionDetails>
             </Accordion>
             <Accordion>
-                <AccordionSummary expandIcon={SynthesisIcons.EXPAND_MORE_LARGE}>
+                <AccordionSummary expandIcon={<SynthesisIcons.EXPAND_MORE_LARGE />}>
                     {viewType === MiraType.ROBOT ? (
                         <Label size="md" className="text-center mt-[4pt] mb-[2pt] mx-[5%]">
                             {remoteRobotElements

--- a/fission/src/ui/panels/simulation/AutoTestPanel.tsx
+++ b/fission/src/ui/panels/simulation/AutoTestPanel.tsx
@@ -3,7 +3,6 @@ import { TextField } from "@mui/material"
 import { Stack, styled } from "@mui/system"
 import type React from "react"
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { FaInfinity } from "react-icons/fa6"
 import * as THREE from "three"
 import type MirabufSceneObject from "@/mirabuf/MirabufSceneObject"
 import SimDriverStation from "@/systems/simulation/wpilib_brain/sim/SimDriverStation"
@@ -11,7 +10,7 @@ import { type AllianceStation, RobotSimMode } from "@/systems/simulation/wpilib_
 import World from "@/systems/World"
 import Label from "@/ui/components/Label"
 import type { PanelImplProps } from "@/ui/components/Panel"
-import { Button, ToggleButton, ToggleButtonGroup } from "@/ui/components/StyledComponents"
+import { Button, SynthesisIcons, ToggleButton, ToggleButtonGroup } from "@/ui/components/StyledComponents"
 import TransformGizmoControl from "@/ui/components/TransformGizmoControl"
 import { useUIContext } from "@/ui/helpers/UIProviderHelpers"
 import JOLT from "@/util/loading/JoltSyncLoader"
@@ -254,9 +253,7 @@ const Staging: React.FC<StagingProps> = ({ assembly, setPlaying }) => {
                     <ToggleButton value={15}>15</ToggleButton>
                     <ToggleButton value={20}>20</ToggleButton>
                     <ToggleButton value={30}>30</ToggleButton>
-                    <ToggleButton value={-1}>
-                        <FaInfinity />
-                    </ToggleButton>
+                    <ToggleButton value={-1}>{SynthesisIcons.INFINITY}</ToggleButton>
                 </ToggleButtonGroup>
             </Stack>
             <Stack>

--- a/fission/src/ui/panels/simulation/AutoTestPanel.tsx
+++ b/fission/src/ui/panels/simulation/AutoTestPanel.tsx
@@ -253,7 +253,9 @@ const Staging: React.FC<StagingProps> = ({ assembly, setPlaying }) => {
                     <ToggleButton value={15}>15</ToggleButton>
                     <ToggleButton value={20}>20</ToggleButton>
                     <ToggleButton value={30}>30</ToggleButton>
-                    <ToggleButton value={-1}>{SynthesisIcons.INFINITY}</ToggleButton>
+                    <ToggleButton value={-1}>
+                        <SynthesisIcons.INFINITY />
+                    </ToggleButton>
                 </ToggleButtonGroup>
             </Stack>
             <Stack>


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-202

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Currently some icons are imported from "react-icons" and others from StyledComponents (SynthesisIcons), which is inconsistent. 

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Import all icons from StyledComponents.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

- [x] No more importing icons from "react-icons" (other than StyledComponents)
- [x] All icons still appear and work as before

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
