### PR TITLE
Fix Double Sliders on Manage Protected Zones Interface `[SYNTH-164]`

### DIFF
--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/zones/ManageZonesBase.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/zones/ManageZonesBase.tsx
@@ -7,7 +7,6 @@ import PreferencesSystem from "@/systems/preferences/PreferencesSystem"
 import type { Alliance } from "@/systems/preferences/PreferenceTypes"
 import World from "@/systems/World"
 import Label from "@/ui/components/Label"
-import ScrollView from "@/ui/components/ScrollView"
 import { AddButton, DeleteButton, EditButton } from "@/ui/components/StyledComponents"
 import type { BaseZonePreferences } from "./ZoneConfigBase"
 
@@ -72,51 +71,48 @@ export default function ManageZonesBase<TZone extends BaseZonePreferences>(props
     return (
         <>
             {zones?.length > 0 ? (
-                <ScrollView>
-                    <Stack gap={4}>
-                        {zones.map((zonePrefs: TZone, i: number) => {
-                            const item = getListItem(zonePrefs)
-                            return (
-                                <Stack
-                                    key={`${item.name}-${item.alliance}-${i}`}
-                                    justifyContent={"space-between"}
-                                    alignItems={"center"}
-                                    gap={"1rem"}
-                                >
-                                    <Stack direction="row" gap={8}>
-                                        <Box
-                                            className={`w-12 h-12 rounded-lg`}
-                                            sx={{
-                                                bgcolor:
-                                                    item.alliance === "red" ? "redAlliance.main" : "blueAlliance.main",
-                                            }}
-                                        />
-                                        <Stack direction="row" gap={4} className="w-max">
-                                            <Label size="sm">{item.name}</Label>
-                                            {item.pointsLabel ? <Label size="sm">{item.pointsLabel}</Label> : null}
-                                        </Stack>
-                                    </Stack>
-                                    <Stack
-                                        direction={"row-reverse"}
-                                        gap={"0.25rem"}
-                                        justifyContent={"center"}
-                                        alignItems={"center"}
-                                    >
-                                        {EditButton(() => {
-                                            selectZone(zonePrefs)
-                                            saveZonesGeneric(zones, selectedField, persistZones)
-                                        })}
-                                        {DeleteButton(() => {
-                                            const newZones = zones.filter((_, idx) => idx !== i)
-                                            setZones(newZones)
-                                            saveZonesGeneric(newZones, selectedField, persistZones)
-                                        })}
+                <Stack gap={4}>
+                    {zones.map((zonePrefs: TZone, i: number) => {
+                        const item = getListItem(zonePrefs)
+                        return (
+                            <Stack
+                                key={`${item.name}-${item.alliance}-${i}`}
+                                justifyContent={"space-between"}
+                                alignItems={"center"}
+                                gap={"1rem"}
+                            >
+                                <Stack direction="row" gap={8}>
+                                    <Box
+                                        className={`w-12 h-12 rounded-lg`}
+                                        sx={{
+                                            bgcolor: item.alliance === "red" ? "redAlliance.main" : "blueAlliance.main",
+                                        }}
+                                    />
+                                    <Stack direction="row" gap={4} className="w-max">
+                                        <Label size="sm">{item.name}</Label>
+                                        {item.pointsLabel ? <Label size="sm">{item.pointsLabel}</Label> : null}
                                     </Stack>
                                 </Stack>
-                            )
-                        })}
-                    </Stack>
-                </ScrollView>
+                                <Stack
+                                    direction={"row-reverse"}
+                                    gap={"0.25rem"}
+                                    justifyContent={"center"}
+                                    alignItems={"center"}
+                                >
+                                    {EditButton(() => {
+                                        selectZone(zonePrefs)
+                                        saveZonesGeneric(zones, selectedField, persistZones)
+                                    })}
+                                    {DeleteButton(() => {
+                                        const newZones = zones.filter((_, idx) => idx !== i)
+                                        setZones(newZones)
+                                        saveZonesGeneric(newZones, selectedField, persistZones)
+                                    })}
+                                </Stack>
+                            </Stack>
+                        )
+                    })}
+                </Stack>
             ) : (
                 <Label size="md">{emptyLabel}</Label>
             )}


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-164

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

When opening Protected Zones in the configure assets panel , there is a scrollbar covering the panel and one covering just the Manage Protected Zones Interface. 

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Removed the extra inner scroll container, so the protected zones screen no longer creates a nested scrolbar

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

 - [ ] Verify that there is only one scrollbar when opening the protected zones interface
- [ ] All other functionality remains the same

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
