### PR TITLE
fix(constraints): vector cleanup

### DIFF
--- a/fission/src/systems/physics/ConstraintSettingsUtilities.ts
+++ b/fission/src/systems/physics/ConstraintSettingsUtilities.ts
@@ -7,17 +7,16 @@ import { convertMirabufVector3ToJoltRVec3, convertMirabufVector3ToJoltVec3 } fro
 type LimitSpecs = Omit<DOFSpecs, "friction" | "axis">
 
 export function createAnchorPoint(jointInstance: mirabuf.joint.JointInstance, jointDefinition: mirabuf.joint.Joint) {
-    const jointOrigin = jointDefinition.origin
+    const anchorPoint = jointDefinition.origin
         ? convertMirabufVector3ToJoltRVec3(jointDefinition.origin)
         : new JOLT.RVec3(0, 0, 0)
     // TODO: Offset transformation for robot builder.
     const jointOriginOffset = jointInstance.offset
-        ? convertMirabufVector3ToJoltRVec3(jointInstance.offset)
-        : new JOLT.RVec3(0, 0, 0)
+        ? convertMirabufVector3ToJoltVec3(jointInstance.offset)
+        : new JOLT.Vec3(0, 0, 0)
 
-    const anchorPoint = jointOrigin.AddRVec3(jointOriginOffset)
+    anchorPoint.Add(jointOriginOffset)
 
-    JOLT.destroy(jointOrigin)
     JOLT.destroy(jointOriginOffset)
 
     return anchorPoint

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -555,6 +555,7 @@ class PhysicsSystem extends WorldSystem {
 
         const anchorPoint = createAnchorPoint(jointInstance, jointDefinition)
         hingeConstraintSettings.mPoint1 = hingeConstraintSettings.mPoint2 = anchorPoint
+        JOLT.destroy(anchorPoint)
 
         const rotationalFreedom = jointDefinition.rotational!.rotationalFreedom!
 
@@ -588,6 +589,7 @@ class PhysicsSystem extends WorldSystem {
 
         const anchorPoint = createAnchorPoint(jointInstance, jointDefinition)
         constraintSettings.mPoint1 = constraintSettings.mPoint2 = anchorPoint
+        JOLT.destroy(anchorPoint)
 
         const freedom = jointDefinition.prismatic!.prismaticFreedom!
 
@@ -760,6 +762,7 @@ class PhysicsSystem extends WorldSystem {
             wheelDimensions.radius = resolvedRadius
         }
 
+        // convertJoltRVec3ToJoltVec3 destroys `anchorPoint` here
         const wheelPos = urdfWheelBasis
             ? convertJoltRVec3ToJoltVec3(anchorPoint)
             : convertJoltRVec3ToJoltVec3(anchorPoint.Add(axis))
@@ -767,6 +770,7 @@ class PhysicsSystem extends WorldSystem {
         const wheelSettings = new JOLT.WheelSettingsWV()
 
         wheelSettings.mPosition = wheelPos
+
 
         wheelSettings.mMaxSteerAngle = 0.0
         wheelSettings.mMaxHandBrakeTorque = 0.0

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -555,7 +555,6 @@ class PhysicsSystem extends WorldSystem {
 
         const anchorPoint = createAnchorPoint(jointInstance, jointDefinition)
         hingeConstraintSettings.mPoint1 = hingeConstraintSettings.mPoint2 = anchorPoint
-        JOLT.destroy(anchorPoint)
 
         const rotationalFreedom = jointDefinition.rotational!.rotationalFreedom!
 
@@ -589,7 +588,6 @@ class PhysicsSystem extends WorldSystem {
 
         const anchorPoint = createAnchorPoint(jointInstance, jointDefinition)
         constraintSettings.mPoint1 = constraintSettings.mPoint2 = anchorPoint
-        JOLT.destroy(anchorPoint)
 
         const freedom = jointDefinition.prismatic!.prismaticFreedom!
 
@@ -762,7 +760,7 @@ class PhysicsSystem extends WorldSystem {
             wheelDimensions.radius = resolvedRadius
         }
 
-        // convertJoltRVec3ToJoltVec3 destroys `anchorPoint` here
+        // `convertJoltRVec3ToJoltVec3` destroys `anchorPoint` here
         const wheelPos = urdfWheelBasis
             ? convertJoltRVec3ToJoltVec3(anchorPoint)
             : convertJoltRVec3ToJoltVec3(anchorPoint.Add(axis))
@@ -770,7 +768,6 @@ class PhysicsSystem extends WorldSystem {
         const wheelSettings = new JOLT.WheelSettingsWV()
 
         wheelSettings.mPosition = wheelPos
-
 
         wheelSettings.mMaxSteerAngle = 0.0
         wheelSettings.mMaxHandBrakeTorque = 0.0


### PR DESCRIPTION
SYNTH-259

Replacing the `JoltRVec3` with a `JoltVec3` in the `createAnchorPoint()` function
Adding type annotations to `ConstraintSettingsUtililties`

> [!NOTE]
> This PR conflicts with #1418 