### PR TITLE
Remove joint config options on Codesim

### DIFF
--- a/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
@@ -374,17 +374,20 @@ const ConfigurePanel: React.FC<PanelImplProps<void, ConfigurePanelCustomProps>> 
                         "Configure the robot’s ejector mechanism, which controls the release or expulsion of game pieces."
                     ),
 
-                    new ConfigModeSelectionOption(
-                        "Configure Joints",
-                        ConfigMode.SUBSYSTEMS,
-                        "Set the velocities, torques, and accelerations of your robot's motors."
-                    ),
-
-                    new ConfigModeSelectionOption(
-                        "Sequence Joints",
-                        ConfigMode.SEQUENTIAL,
-                        "Set which joints follow each other. For example, the second stage of an elevator could follow the first, moving in unison with it."
-                    ),
+                    ...(selectedAssembly?.brain?.brainType === "synthesis"
+                        ? [
+                              new ConfigModeSelectionOption(
+                                  "Configure Joints",
+                                  ConfigMode.SUBSYSTEMS,
+                                  "Set the velocities, torques, and accelerations of your robot's motors."
+                              ),
+                              new ConfigModeSelectionOption(
+                                  "Sequence Joints",
+                                  ConfigMode.SEQUENTIAL,
+                                  "Set which joints follow each other. For example, the second stage of an elevator could follow the first, moving in unison with it."
+                              ),
+                          ]
+                        : []),
 
                     new ConfigModeSelectionOption(
                         "Alliance / Station",


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-234

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

When the user is doing code simulation and the brain is set to WPILib, the joint configurationand sequence options are visible in the configure assets panel. This can be confusing, and hinder the user as these options are not used during code simulation.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Add a check to see if the brain is synthesis before adding the config selection option, in the configure panel.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

- [ ] Joint selection options are hidden on wpilib brain, but are still functional.

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
