### PR TITLE
Destroy Game Piece When Falling of Map `[SYNTH-216]`

### DIFF
--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -107,6 +107,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
     private _robotPreferences: RobotPreferences | undefined
 
     private _ejectables: EjectableSceneObject[] = []
+    private _gamePieces: Array<{ bodyId: Jolt.BodyID; rigidNode: RigidNodeReadOnly }> = []
     private _intakeSensor?: IntakeSensorSceneObject
     private _scoringZones: ScoringZoneSceneObject[] = []
     private _protectedZones: ProtectedZoneSceneObject[] = []
@@ -173,6 +174,37 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
 
     public get activeEjectables(): Jolt.BodyID[] {
         return this._ejectables.map(e => e.gamePieceBodyId!).filter(x => x !== undefined)
+    }
+
+    /** Game piece rigid nodes, cached once at {@link setup} to avoid scanning all rigid nodes every frame. */
+    public get gamePieces(): ReadonlyArray<{ bodyId: Jolt.BodyID; rigidNode: RigidNodeReadOnly }> {
+        return this._gamePieces
+    }
+
+    /**
+     * Fully destroys a game piece: removes its physics body, pulls it out of any
+     * scoring zones, and hides its meshes so it disappears from view.
+     */
+    public destroyGamePiece(bodyId: Jolt.BodyID): void {
+        const key = bodyId.GetIndexAndSequenceNumber()
+        const entry = this._gamePieces.find(g => g.bodyId.GetIndexAndSequenceNumber() === key)
+        if (!entry) return
+
+        // Unlikely that the game piece is in a scoring zone, but if it is, remove it from the zone's contact list
+        const zones = World.sceneRenderer.filterSceneObjects(
+            (x): x is ScoringZoneSceneObject => x instanceof ScoringZoneSceneObject
+        )
+        zones.forEach(zone => ScoringZoneSceneObject.removeGamepiece(zone, bodyId))
+
+        World.physicsSystem.removeBodyAssociation(bodyId)
+        World.physicsSystem.destroyBodyIds(bodyId)
+
+        entry.rigidNode.parts.forEach(part => {
+            const meshes = this.mirabufInstance.meshes.get(part) ?? []
+            meshes.forEach(([batch, id]) => batch.setVisibleAt(id, false))
+        })
+
+        this._gamePieces = this._gamePieces.filter(g => g.bodyId.GetIndexAndSequenceNumber() !== key)
     }
 
     public get miraType(): MiraType {
@@ -291,6 +323,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
                 return
             }
             World.physicsSystem.setBodyAssociation(new RigidNodeAssociate(this, rigidNode, bodyId))
+            if (rigidNode.isGamePiece) this._gamePieces.push({ bodyId, rigidNode })
         })
 
         // Simulation

--- a/fission/src/systems/World.ts
+++ b/fission/src/systems/World.ts
@@ -8,6 +8,7 @@ import type MultiplayerSystem from "./multiplayer/MultiplayerSystem"
 import PhysicsSystem from "./physics/PhysicsSystem"
 import DragModeSystem from "./scene/DragModeSystem"
 import SceneRenderer from "./scene/SceneRenderer"
+import GamePiecePositionTracker from "./simulation/GamePiecePositionTracker"
 import RobotPositionTracker from "./simulation/RobotPositionTracker"
 import SimulationSystem from "./simulation/SimulationSystem"
 
@@ -149,6 +150,7 @@ class World {
 
         RobotDimensionTracker.update()
         RobotPositionTracker.update()
+        GamePiecePositionTracker.update()
     }
 
     public static get currentDeltaT(): number {

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -101,6 +101,9 @@ export function getLastDeltaT(): number {
 const FLOOR_FRICTION = 0.7
 const DEFAULT_FRICTION = 0.7
 
+// Y level below which anything on the field is considered to have fallen off the map.
+export const MAP_BOUNDARY_Y = -4
+
 // Transition GH-1152, AARD-1885:
 // Temporary workaround to reduce visible levitation of robots by minimizing suspension.
 // Setting these values to 0 causes physics issues (e.g., ground collisionn problems).

--- a/fission/src/systems/simulation/GamePiecePositionTracker.ts
+++ b/fission/src/systems/simulation/GamePiecePositionTracker.ts
@@ -1,0 +1,18 @@
+import { MAP_BOUNDARY_Y } from "@/systems/physics/PhysicsSystem"
+import World from "../World"
+
+class GamePiecePositionTracker {
+    public static update(): void {
+        const field = World.sceneRenderer.mirabufSceneObjects.getField()
+        if (!field || field.gamePieces.length === 0) return
+
+        field.gamePieces.forEach(({ bodyId }) => {
+            const body = World.physicsSystem.getBody(bodyId)
+            if (body && body.GetPosition().GetY() <= MAP_BOUNDARY_Y) {
+                field.destroyGamePiece(bodyId)
+            }
+        })
+    }
+}
+
+export default GamePiecePositionTracker

--- a/fission/src/systems/simulation/RobotPositionTracker.ts
+++ b/fission/src/systems/simulation/RobotPositionTracker.ts
@@ -1,11 +1,10 @@
 import * as THREE from "three"
 import { globalAddToast } from "@/components/GlobalUIControls.ts"
+import { MAP_BOUNDARY_Y } from "@/systems/physics/PhysicsSystem"
 import { convertJoltMat44ToThreeMatrix4 } from "@/util/TypeConversions"
 import World from "../World"
 
 class RobotPositionTracker {
-    private static _mapBoundaryY: number = -4
-
     public static update(): void {
         World.getOwnRobots().forEach(robot => {
             const rootNodeId = robot.getRootNodeId()
@@ -21,7 +20,7 @@ class RobotPositionTracker {
             const rootScale = new THREE.Vector3()
             rootTransform.decompose(rootPosition, rootRotation, rootScale)
 
-            if (robot.hasPhysics() && rootPosition.y < this._mapBoundaryY) {
+            if (robot.hasPhysics() && rootPosition.y < MAP_BOUNDARY_Y) {
                 globalAddToast("warning", "Robot fell off the map", `${robot.nameTag?.text()} - ${robot.assemblyName}`)
 
                 robot.mirabufInstance.parser.rigidNodes.forEach(rigidNode => {


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-216

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Currently game pieces can be thrown out of the field and they will fall forever (which also breaks the camera if you are focused on a field).

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Destroy game pieces when their y level is below a certain amount.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

- [x] Dropping a game piece of the map (ex, using drag mode or ejecting it) results in it despawning
- [x] Robots still spawn back at their starting point (if they are holding a game piece it will respawn with them)

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
