### PR TITLE
Remove `.npmrc`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-.vs/
-.vscode/
+.*
 build/
 dist/
 out/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.*
+.vs/
+.vscode/
 build/
 dist/
 out/
@@ -9,3 +10,4 @@ renderer/
 *.exe
 .idea
 **/.direnv
+.npmrc

--- a/fission/.gitignore
+++ b/fission/.gitignore
@@ -1,4 +1,3 @@
-.*
 public/Downloadables
 package-lock.json
 bun.lockb

--- a/fission/.gitignore
+++ b/fission/.gitignore
@@ -1,3 +1,4 @@
+.*
 public/Downloadables
 package-lock.json
 bun.lockb

--- a/fission/.npmrc
+++ b/fission/.npmrc
@@ -1,1 +1,0 @@
-registry=https://npm.autodesk.com/artifactory/api/npm/npm-remote/


### PR DESCRIPTION
`.npmrc` got added and it broke our GitHub actions. Since we don't need this right now we can just remove it.