### PR TITLE
feat(physics): allow gamepieces to sleep & adding simulation debt into timestep

### DIFF
--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -69,6 +69,7 @@ const MAX_COLLISIONS_STEPS = 20
 // step count will scale depending on how many active bodies
 // there currently are
 const ACTIVE_BODY_STEP_BUDGET = 600
+export const MAX_SUBSTEP_PERIOD = 1.0 / 300.0
 // maximum amount of simulation time that can be consumed per render
 // for catching up to slow frame
 const MAX_SIMULATION_TIME_PER_FRAME = 4 * STANDARD_SIMULATION_PERIOD
@@ -1442,7 +1443,11 @@ class PhysicsSystem extends WorldSystem {
             const desiredSteps = Math.ceil(simTime / MAX_COLLISIONS_STEP_PERIOD)
             const activeBodies = this._joltPhysSystem.GetNumActiveBodies(JOLT.EBodyType_RigidBody)
             const affordableSteps = Math.floor(ACTIVE_BODY_STEP_BUDGET / Math.max(activeBodies, 1))
-            const collisionSteps = Math.max(1, Math.min(MAX_COLLISIONS_STEPS, desiredSteps, affordableSteps))
+            const minStableSteps = Math.ceil(simTime / MAX_SUBSTEP_PERIOD)
+            const collisionSteps = Math.max(
+                1,
+                Math.min(MAX_COLLISIONS_STEPS, desiredSteps, Math.max(affordableSteps, minStableSteps))
+            )
             this._joltInterface.Step(simTime, collisionSteps)
         }
 

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -61,6 +61,14 @@ const LAYER_GHOST = 10
 const COUNT_OBJECT_LAYERS = 11
 
 export const STANDARD_SIMULATION_PERIOD = 1.0 / 60.0
+const MAX_COLLISIONS_STEP_PERIOD = 1.0 / 1200.0
+// cap on collision steps per rendered frame
+// when a frame is so slow that the cap is hit, each collision
+// step covers more simulation time
+const MAX_COLLISIONS_STEPS = 20
+// step count will scale depending on how many active bodies
+// there currently are
+const ACTIVE_BODY_STEP_BUDGET = 600
 // maximum amount of simulation time that can be consumed per render
 // for catching up to slow frame
 const MAX_SIMULATION_TIME_PER_FRAME = 4 * STANDARD_SIMULATION_PERIOD
@@ -96,7 +104,9 @@ function computeSphericity(volume: number, area: number): number {
     return volumeEquivalentSphereArea / area
 }
 
-// fixing simulation system in STANDARD_SIMULATION_PERIOD increments
+// simulation period. actual step length tracks the rendered
+// frame time (PhysicsSystem.update), so stable constant keeps
+// driver stiffness independent of construction-time frame rate.
 export function getLastDeltaT(): number {
     return STANDARD_SIMULATION_PERIOD
 }
@@ -152,8 +162,6 @@ class PhysicsSystem extends WorldSystem {
 
     private _pauseSet = new Set<string>()
 
-    private _simulationTimeDebt = 0
-
     private _bodyAssociations: Map<JoltBodyIndexAndSequence, BodyAssociate>
 
     public get isPaused(): boolean {
@@ -190,6 +198,7 @@ class PhysicsSystem extends WorldSystem {
         this._joltPhysSystem.GetPhysicsSettings().mDeterministicSimulation = false
         this._joltPhysSystem.GetPhysicsSettings().mSpeculativeContactDistance = 0.06
         this._joltPhysSystem.GetPhysicsSettings().mPenetrationSlop = 0.005
+        this._joltPhysSystem.GetPhysicsSettings().mTimeBeforeSleep = 0.2
 
         const ground = this.createBox(
             new THREE.Vector3(7.5, 0.1, 7.5),
@@ -1082,9 +1091,14 @@ class PhysicsSystem extends WorldSystem {
                 }
 
                 const body = this._joltBodyInterface.CreateBody(bodySettings)
-                this._joltBodyInterface.AddBody(body.GetID(), JOLT.EActivation_Activate)
 
-                // allowing gamepieces to sleep
+                // Game pieces are allowed to sleep and spawn inactive
+                // they are placed at their resting position by MirabufSceneObject
+                // which activates them.
+                this._joltBodyInterface.AddBody(
+                    body.GetID(),
+                    rn.isGamePiece ? JOLT.EActivation_DontActivate : JOLT.EActivation_Activate
+                )
                 if (!rn.isGamePiece) body.SetAllowSleeping(false)
                 rnToBodies.set(rn.id, body.GetID())
 
@@ -1422,12 +1436,14 @@ class PhysicsSystem extends WorldSystem {
             return
         }
 
-        // timestepping with a catchup for skipped frames
-        this._simulationTimeDebt = Math.min(this._simulationTimeDebt + deltaT, MAX_SIMULATION_TIME_PER_FRAME)
-
-        while (this._simulationTimeDebt >= STANDARD_SIMULATION_PERIOD) {
-            this._joltInterface.Step(STANDARD_SIMULATION_PERIOD, 1)
-            this._simulationTimeDebt -= STANDARD_SIMULATION_PERIOD
+        // step the simulation by rendered frame's duration so motion is smooth
+        const simTime = Math.min(deltaT, MAX_SIMULATION_TIME_PER_FRAME)
+        if (simTime > 0) {
+            const desiredSteps = Math.ceil(simTime / MAX_COLLISIONS_STEP_PERIOD)
+            const activeBodies = this._joltPhysSystem.GetNumActiveBodies(JOLT.EBodyType_RigidBody)
+            const affordableSteps = Math.floor(ACTIVE_BODY_STEP_BUDGET / Math.max(activeBodies, 1))
+            const collisionSteps = Math.max(1, Math.min(MAX_COLLISIONS_STEPS, desiredSteps, affordableSteps))
+            this._joltInterface.Step(simTime, collisionSteps)
         }
 
         this.applySphereGamePieceStiction()

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -290,6 +290,17 @@ class PhysicsSystem extends WorldSystem {
         this.getBody(bodyId)!.SetIsSensor(false)
     }
 
+    /**
+     * Wakes a sleeping body.
+     *
+     * @param bodyId
+     */
+    public activateBody(bodyId: Jolt.BodyID) {
+        if (!this.isBodyAdded(bodyId)) return
+
+        this._joltBodyInterface.ActivateBody(bodyId)
+    }
+
     public isBodyAdded(bodyId: Jolt.BodyID) {
         return this._joltBodyInterface.IsAdded(bodyId)
     }

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -61,12 +61,9 @@ const LAYER_GHOST = 10
 const COUNT_OBJECT_LAYERS = 11
 
 export const STANDARD_SIMULATION_PERIOD = 1.0 / 60.0
-const MIN_SIMULATION_PERIOD = 1.0 / 120.0
-const MAX_SIMULATION_PERIOD = 1.0 / 10.0
-const MIN_SUBSTEPS = 12
-const MAX_SUBSTEPS = 20
-const STANDARD_SUB_STEPS = 20
-const TIMESTEP_ADJUSTMENT = 0.0001
+// maximum amount of simulation time that can be consumed per render
+// for catching up to slow frame
+const MAX_SIMULATION_TIME_PER_FRAME = 4 * STANDARD_SIMULATION_PERIOD
 
 const SIGNIFICANT_FRICTION_THRESHOLD = 0.05
 
@@ -99,9 +96,9 @@ function computeSphericity(volume: number, area: number): number {
     return volumeEquivalentSphereArea / area
 }
 
-let lastDeltaT = STANDARD_SIMULATION_PERIOD
+// fixing simulation system in STANDARD_SIMULATION_PERIOD increments
 export function getLastDeltaT(): number {
-    return lastDeltaT
+    return STANDARD_SIMULATION_PERIOD
 }
 
 // Friction constants
@@ -154,6 +151,8 @@ class PhysicsSystem extends WorldSystem {
     >[] = []
 
     private _pauseSet = new Set<string>()
+
+    private _simulationTimeDebt = 0
 
     private _bodyAssociations: Map<JoltBodyIndexAndSequence, BodyAssociate>
 
@@ -1077,9 +1076,16 @@ class PhysicsSystem extends WorldSystem {
                     rn.isDynamic ? JOLT.EMotionType_Dynamic : JOLT.EMotionType_Static,
                     rnLayer
                 )
+                if (rn.isDynamic) {
+                    // prevents fast bodies from phasing through thin static geometry (like ramps on fields)
+                    bodySettings.mMotionQuality = JOLT.EMotionQuality_LinearCast
+                }
+
                 const body = this._joltBodyInterface.CreateBody(bodySettings)
                 this._joltBodyInterface.AddBody(body.GetID(), JOLT.EActivation_Activate)
-                body.SetAllowSleeping(false)
+
+                // allowing gamepieces to sleep
+                if (!rn.isGamePiece) body.SetAllowSleeping(false)
                 rnToBodies.set(rn.id, body.GetID())
 
                 // Set Friction Here
@@ -1396,7 +1402,8 @@ class PhysicsSystem extends WorldSystem {
         const zero = new JOLT.Vec3(0, 0, 0)
         this._sphereGamePieceBodies.forEach(bodyId => {
             const body = this.getBody(bodyId)
-            if (!body) return
+            // Sleeping bodies are already at rest and shouldn't be touched
+            if (!body || !body.IsActive()) return
 
             const atRest =
                 body.GetLinearVelocity().Length() < SPHERE_GP_STICTION_LINEAR_SPEED &&
@@ -1415,15 +1422,13 @@ class PhysicsSystem extends WorldSystem {
             return
         }
 
-        const diffDeltaT = deltaT - lastDeltaT
+        // timestepping with a catchup for skipped frames
+        this._simulationTimeDebt = Math.min(this._simulationTimeDebt + deltaT, MAX_SIMULATION_TIME_PER_FRAME)
 
-        lastDeltaT += Math.min(TIMESTEP_ADJUSTMENT, Math.max(-TIMESTEP_ADJUSTMENT, diffDeltaT))
-        lastDeltaT = Math.min(MAX_SIMULATION_PERIOD, Math.max(MIN_SIMULATION_PERIOD, lastDeltaT))
-
-        let substeps = Math.max(1, Math.floor((lastDeltaT / STANDARD_SIMULATION_PERIOD) * STANDARD_SUB_STEPS))
-        substeps = Math.min(MAX_SUBSTEPS, Math.max(MIN_SUBSTEPS, substeps))
-
-        this._joltInterface.Step(lastDeltaT, substeps)
+        while (this._simulationTimeDebt >= STANDARD_SIMULATION_PERIOD) {
+            this._joltInterface.Step(STANDARD_SIMULATION_PERIOD, 1)
+            this._simulationTimeDebt -= STANDARD_SIMULATION_PERIOD
+        }
 
         this.applySphereGamePieceStiction()
 

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -1096,10 +1096,6 @@ class PhysicsSystem extends WorldSystem {
                     rn.isDynamic ? JOLT.EMotionType_Dynamic : JOLT.EMotionType_Static,
                     rnLayer
                 )
-                if (rn.isDynamic) {
-                    // prevents fast bodies from phasing through thin static geometry (like ramps on fields)
-                    bodySettings.mMotionQuality = JOLT.EMotionQuality_LinearCast
-                }
 
                 const body = this._joltBodyInterface.CreateBody(bodySettings)
 

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -104,13 +104,6 @@ function computeSphericity(volume: number, area: number): number {
     return volumeEquivalentSphereArea / area
 }
 
-// simulation period. actual step length tracks the rendered
-// frame time (PhysicsSystem.update), so stable constant keeps
-// driver stiffness independent of construction-time frame rate.
-export function getLastDeltaT(): number {
-    return STANDARD_SIMULATION_PERIOD
-}
-
 // Friction constants
 const FLOOR_FRICTION = 0.7
 const DEFAULT_FRICTION = 0.7

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -1092,8 +1092,8 @@ class PhysicsSystem extends WorldSystem {
 
                 const body = this._joltBodyInterface.CreateBody(bodySettings)
 
-                // Game pieces are allowed to sleep and spawn inactive
-                // they are placed at their resting position by MirabufSceneObject
+                // Game pieces are allowed to sleep, but are inactive by default
+                // they are placed at their initial position by their `MirabufSceneObject`
                 // which activates them.
                 this._joltBodyInterface.AddBody(
                     body.GetID(),

--- a/fission/src/systems/scene/DragModeSystem.ts
+++ b/fission/src/systems/scene/DragModeSystem.ts
@@ -377,6 +377,11 @@ class DragModeSystem extends WorldSystem {
             return
         }
 
+        // keeping the dragged body awake so drag forces take effect even if body is sleeping
+        if (!this._dragTarget.physicsDisabled && !body.IsActive()) {
+            World.physicsSystem.activateBody(this._dragTarget.bodyId)
+        }
+
         const currentPos = body.GetPosition()
         const currentPosition = new THREE.Vector3(currentPos.GetX(), currentPos.GetY(), currentPos.GetZ())
         const currentRotation = body.GetRotation()

--- a/fission/src/systems/simulation/driver/HingeDriver.ts
+++ b/fission/src/systems/simulation/driver/HingeDriver.ts
@@ -1,6 +1,6 @@
 import type Jolt from "@synthesis.adsk/jolt-physics"
 import type { mirabuf } from "@/proto/mirabuf"
-import { getLastDeltaT } from "@/systems/physics/PhysicsSystem"
+import { STANDARD_SIMULATION_PERIOD } from "@/systems/physics/PhysicsSystem"
 import PreferencesSystem from "@/systems/preferences/PreferencesSystem"
 import JOLT from "@/util/loading/JoltSyncLoader"
 import { type NoraNumber, NoraTypes } from "../Nora"
@@ -125,7 +125,7 @@ class HingeDriver extends Driver {
         const springSettings = motorSettings.mSpringSettings
 
         // These values were selected based on the suggestions of the documentation for stiff control.
-        springSettings.mFrequency = 20 * (1.0 / getLastDeltaT())
+        springSettings.mFrequency = 20 * (1.0 / STANDARD_SIMULATION_PERIOD)
         springSettings.mDamping = 0.995
         motorSettings.mSpringSettings = springSettings
 

--- a/fission/src/systems/simulation/driver/SliderDriver.ts
+++ b/fission/src/systems/simulation/driver/SliderDriver.ts
@@ -1,6 +1,6 @@
 import type Jolt from "@synthesis.adsk/jolt-physics"
 import type { mirabuf } from "@/proto/mirabuf"
-import { getLastDeltaT } from "@/systems/physics/PhysicsSystem"
+import { STANDARD_SIMULATION_PERIOD } from "@/systems/physics/PhysicsSystem"
 import PreferencesSystem from "@/systems/preferences/PreferencesSystem"
 import JOLT from "@/util/loading/JoltSyncLoader"
 import { type NoraNumber, NoraTypes } from "../Nora"
@@ -69,7 +69,7 @@ class SliderDriver extends Driver {
 
         const motorSettings = this._constraint.GetMotorSettings()
         const springSettings = motorSettings.mSpringSettings
-        springSettings.mFrequency = 20 * (1.0 / getLastDeltaT())
+        springSettings.mFrequency = 20 * (1.0 / STANDARD_SIMULATION_PERIOD)
         springSettings.mDamping = 0.999
         motorSettings.mSpringSettings = springSettings
 

--- a/fission/src/test/World.test.ts
+++ b/fission/src/test/World.test.ts
@@ -6,7 +6,7 @@ vi.mock("@/systems/physics/PhysicsSystem", () => ({
         update: vi.fn(),
         destroy: vi.fn(),
     })),
-    getLastDeltaT: vi.fn(() => 0.016),
+    STANDARD_SIMULATION_PERIOD: 1.0 / 60.0,
     BodyAssociate: vi.fn(),
 }))
 

--- a/fission/src/test/physics/PhysicsSystem.test.ts
+++ b/fission/src/test/physics/PhysicsSystem.test.ts
@@ -1,6 +1,7 @@
 import type Jolt from "@synthesis.adsk/jolt-physics"
 import * as THREE from "three"
 import { afterEach, assert, beforeEach, describe, expect, test } from "vitest"
+import { GAMEPIECE_SUFFIX } from "@/mirabuf/MirabufParser"
 import { BodyAssociate } from "@/systems/physics/BodyAssociate"
 import JOLT from "@/util/loading/JoltSyncLoader"
 import PhysicsSystem, { LayerReserve } from "../../systems/physics/PhysicsSystem"
@@ -678,6 +679,9 @@ describe("Update Loop", () => {
 function makeMockParser(physicalData: { volume: number; area: number }, isGamePiece: boolean): MirabufParser {
     const tetraVerts = [0, 0, 0, 100, 0, 0, 0, 100, 0, 0, 0, 100]
 
+    // PhysicsSystem picks the collision layer off the node id suffix, not isGamePiece
+    const nodeId = isGamePiece ? `node-0${GAMEPIECE_SUFFIX}` : "node-0"
+
     return {
         assembly: {
             dynamic: false,
@@ -709,9 +713,9 @@ function makeMockParser(physicalData: { volume: number; area: number }, isGamePi
         },
         rigidNodes: new Map([
             [
-                "node-0",
+                nodeId,
                 {
-                    id: "node-0",
+                    id: nodeId,
                     parts: new Set(["part-0"]),
                     isDynamic: true,
                     isGamePiece,
@@ -762,5 +766,48 @@ describe("Sphere Game Piece Body Registration", () => {
         system.createBodiesFromParser(makeMockParser(SPHERE_DATA, true))
         system.createBodiesFromParser(makeMockParser(SPHERE_DATA, true))
         expect(system.sphereGamePieceBodies.length).toBe(2)
+    })
+})
+
+describe("Game Piece Sleeping", () => {
+    let system: PhysicsSystem
+
+    const SPHERE_DATA = { volume: 1767.15, area: 706.86 } // 2026 game piece approximate values
+
+    function spawnFromParser(isGamePiece: boolean): Jolt.Body {
+        const bodyIds = system.createBodiesFromParser(makeMockParser(SPHERE_DATA, isGamePiece))
+        const bodyId = [...bodyIds.values()][0]
+        return system.getBody(bodyId)!
+    }
+
+    beforeEach(() => {
+        system = new PhysicsSystem()
+    })
+
+    afterEach(() => {
+        system.destroy()
+    })
+
+    test("Game piece is allowed to sleep", () => {
+        expect(spawnFromParser(true).GetAllowSleeping()).toBe(true)
+    })
+
+    test("Non game piece is not allowed to sleep", () => {
+        expect(spawnFromParser(false).GetAllowSleeping()).toBe(false)
+    })
+
+    test("Game piece resting on the floor falls asleep", () => {
+        const floor = system.createBox(new THREE.Vector3(5, 0.5, 5), undefined, new THREE.Vector3(0, -1, 0), undefined)
+        system.addBodyToSystem(floor.GetID(), false)
+
+        const body = spawnFromParser(true)
+        expect(body.IsActive()).toBe(true)
+
+        // 4 seconds of fixed timestep: enough to drop, settle, and exceed Jolt's 0.5s sleep timer
+        for (let i = 0; i < 240; i++) {
+            system.update(1 / 60)
+        }
+
+        expect(body.IsActive()).toBe(false)
     })
 })

--- a/fission/src/test/physics/PhysicsSystem.test.ts
+++ b/fission/src/test/physics/PhysicsSystem.test.ts
@@ -788,6 +788,15 @@ describe("Game Piece Sleeping", () => {
         system.destroy()
     })
 
+    /** Steps the system until `body` sleeps, returning the step it slept on, or -1 if it never did. */
+    function stepUntilAsleep(body: Jolt.Body, maxSteps: number): number {
+        for (let i = 0; i < maxSteps; i++) {
+            system.update(1 / 60)
+            if (!body.IsActive()) return i
+        }
+        return -1
+    }
+
     test("Game piece is allowed to sleep", () => {
         expect(spawnFromParser(true).GetAllowSleeping()).toBe(true)
     })
@@ -796,18 +805,30 @@ describe("Game Piece Sleeping", () => {
         expect(spawnFromParser(false).GetAllowSleeping()).toBe(false)
     })
 
-    test("Game piece resting on the floor falls asleep", () => {
-        const floor = system.createBox(new THREE.Vector3(5, 0.5, 5), undefined, new THREE.Vector3(0, -1, 0), undefined)
-        system.addBodyToSystem(floor.GetID(), false)
+    test("Game piece spawns inactive", () => {
+        expect(spawnFromParser(true).IsActive()).toBe(false)
+    })
 
+    test("Non game piece spawns active", () => {
+        expect(spawnFromParser(false).IsActive()).toBe(true)
+    })
+
+    test("Game piece falls asleep once it settles", () => {
         const body = spawnFromParser(true)
+
+        // Game pieces originally spawn inactive at origin and MirabufSceneobject is what moves
+        // them to their rightful place.
+        system.setBodyPosition(body.GetID(), new JOLT.RVec3(0, 1, 0))
         expect(body.IsActive()).toBe(true)
 
-        // 4 seconds of fixed timestep: enough to drop, settle, and exceed Jolt's 0.5s sleep timer
-        for (let i = 0; i < 240; i++) {
-            system.update(1 / 60)
-        }
+        // settling is pretty slow (sphere takes 300 steps to sleep; 5 seconds)
+        expect(stepUntilAsleep(body, 900)).toBeGreaterThanOrEqual(0)
+    })
 
-        expect(body.IsActive()).toBe(false)
+    test("Non game piece never sleeps even at rest", () => {
+        const body = spawnFromParser(false)
+        system.setBodyPosition(body.GetID(), new JOLT.RVec3(0, 1, 0))
+
+        expect(stepUntilAsleep(body, 900)).toBe(-1)
     })
 })

--- a/fission/src/test/physics/PhysicsSystem.test.ts
+++ b/fission/src/test/physics/PhysicsSystem.test.ts
@@ -1,10 +1,10 @@
 import type Jolt from "@synthesis.adsk/jolt-physics"
 import * as THREE from "three"
-import { afterEach, assert, beforeEach, describe, expect, test } from "vitest"
+import { afterEach, assert, beforeEach, describe, expect, test, vi } from "vitest"
 import { GAMEPIECE_SUFFIX } from "@/mirabuf/MirabufParser"
 import { BodyAssociate } from "@/systems/physics/BodyAssociate"
 import JOLT from "@/util/loading/JoltSyncLoader"
-import PhysicsSystem, { LayerReserve } from "../../systems/physics/PhysicsSystem"
+import PhysicsSystem, { LayerReserve, MAX_SUBSTEP_PERIOD } from "../../systems/physics/PhysicsSystem"
 import type MirabufParser from "../../mirabuf/MirabufParser"
 
 describe("Physics Sanity Checks", () => {
@@ -672,6 +672,92 @@ describe("Update Loop", () => {
         system.update(0.001) // Very small delta time
 
         expect(body.GetPosition().GetY()).toBeLessThanOrEqual(10)
+    })
+})
+
+describe("Real-Time Stepping", () => {
+    let system: PhysicsSystem
+
+    beforeEach(() => {
+        system = new PhysicsSystem()
+    })
+
+    afterEach(() => {
+        system.destroy()
+    })
+
+    function spyOnStep() {
+        return vi.spyOn(system["_joltInterface"], "Step")
+    }
+
+    function spawnActiveBoxes(count: number) {
+        for (let i = 0; i < count; i++) {
+            const body = system.createBox(
+                new THREE.Vector3(0.5, 0.5, 0.5),
+                1.0,
+                new THREE.Vector3((i % 10) * 2, 10 + Math.floor(i / 10) * 2, 0),
+                undefined
+            )
+            system.addBodyToSystem(body.GetID(), true)
+        }
+    }
+
+    test("simulates the full frame time at the intended resolution when unloaded", () => {
+        spawnActiveBoxes(1)
+        const step = spyOnStep()
+
+        system.update(1 / 60)
+
+        expect(step).toHaveBeenCalledWith(1 / 60, 20)
+    })
+
+    test("simulates the full frame time even when many bodies are active", () => {
+        spawnActiveBoxes(100)
+        const step = spyOnStep()
+
+        system.update(1 / 60)
+
+        expect(step).toHaveBeenCalledTimes(1)
+        const [simTime, collisionSteps] = step.mock.calls[0]
+        expect(simTime).toBe(1 / 60)
+        expect(collisionSteps).toBeLessThan(20)
+    })
+
+    test("the step budget never coarsens the substep past the stability ceiling", () => {
+        spawnActiveBoxes(300)
+        const step = spyOnStep()
+
+        system.update(1 / 60)
+
+        expect(step).toHaveBeenCalledTimes(1)
+        const [simTime, collisionSteps] = step.mock.calls[0]
+        expect(simTime).toBe(1 / 60)
+        expect(simTime / collisionSteps).toBeLessThanOrEqual(MAX_SUBSTEP_PERIOD)
+    })
+
+    test("caps a huge hitch at the catch-up ceiling instead of spiraling", () => {
+        spawnActiveBoxes(1)
+        const step = spyOnStep()
+
+        system.update(10)
+
+        expect(step).toHaveBeenCalledWith(4 / 60, 20)
+    })
+
+    test("always simulates min(frame time, cap) across frame times and loads", () => {
+        spawnActiveBoxes(40)
+        const step = spyOnStep()
+
+        const frameTimes = [1 / 240, 1 / 120, 1 / 60, 1 / 30, 1 / 15, 0.5]
+        for (const deltaT of frameTimes) {
+            system.update(deltaT)
+        }
+
+        expect(step.mock.calls.length).toBe(frameTimes.length)
+        for (let i = 0; i < frameTimes.length; i++) {
+            const [simTime] = step.mock.calls[i]
+            expect(simTime).toBe(Math.min(frameTimes[i], 4 / 60))
+        }
     })
 })
 

--- a/fission/src/test/scene/DragModeSystem.test.ts
+++ b/fission/src/test/scene/DragModeSystem.test.ts
@@ -124,7 +124,7 @@ describe("DragModeSystem Integration Tests", () => {
     })
 
     describe("Physics Integration", () => {
-        function setupDraggableCube() {
+        function setupDraggableCube(spawnActive: boolean = true) {
             // Create a physics cube which will then be a draggable game piece
             const vertices = new Float32Array([
                 -0.5, -0.5, -0.5, 0.5, -0.5, -0.5, 0.5, 0.5, -0.5, -0.5, 0.5, -0.5, -0.5, -0.5, 0.5, 0.5, -0.5, 0.5,
@@ -137,7 +137,7 @@ describe("DragModeSystem Integration Tests", () => {
             const shape = shapeResult.Get()
             const body = physicsSystem.createBody(shape, 1.0, new THREE.Vector3(0, 0, 0), new THREE.Quaternion())
             const bodyId = body.GetID()
-            physicsSystem.addBodyToSystem(bodyId, true)
+            physicsSystem.addBodyToSystem(bodyId, spawnActive)
 
             // Create a mock MirabufSceneObject that properly passes `instanceof` checks
             const mockSceneObject = Object.create(MirabufSceneObject.prototype)
@@ -218,6 +218,44 @@ describe("DragModeSystem Integration Tests", () => {
             }
 
             screenHandler.interactionEnd?.(endInteraction)
+
+            cleanup()
+        })
+
+        test("should wake and drag a sleeping game piece", () => {
+            const { physicsBody, cleanup } = setupDraggableCube(false)
+            expect(physicsBody.IsActive()).toBe(false)
+
+            const initialPos = physicsBody.GetPosition()
+            const initialPosition = { x: initialPos.GetX(), y: initialPos.GetY(), z: initialPos.GetZ() }
+
+            const screenHandler = World.sceneRenderer.screenInteractionHandler
+            screenHandler?.interactionStart?.({
+                interactionType: PRIMARY_MOUSE_INTERACTION as InteractionType,
+                position: [400, 300] as [number, number],
+            })
+            screenHandler?.interactionMove?.({
+                interactionType: PRIMARY_MOUSE_INTERACTION as InteractionType,
+                movement: [100, 0] as [number, number],
+            })
+
+            for (let i = 0; i < 10; i++) {
+                dragModeSystem.update(0.016)
+                physicsSystem.update(0.016)
+            }
+
+            expect(physicsBody.IsActive()).toBe(true)
+            const afterDragPos = physicsBody.GetPosition()
+            const moved =
+                Math.abs(afterDragPos.GetX() - initialPosition.x) > 0.2 ||
+                Math.abs(afterDragPos.GetY() - initialPosition.y) > 0.2 ||
+                Math.abs(afterDragPos.GetZ() - initialPosition.z) > 0.2
+            expect(moved).toBe(true)
+
+            screenHandler.interactionEnd?.({
+                interactionType: PRIMARY_MOUSE_INTERACTION as InteractionType,
+                position: [400, 300] as [number, number],
+            })
 
             cleanup()
         })


### PR DESCRIPTION
> [!IMPORTANT]
> The way that gamepieces go to sleep when the field first spawns is something we should look into:
> Currently, they are set to sleep (in this PR) however the MirabufSceneObject instantly wakes them up to move them to their desired location. This will tank performance for the first ~5 seconds while the gamepieces wait to go back to sleep.

SYNTH-257

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
