### PR TITLE
Mirabuf mass override is a no-op `[SYNTH-281]`

### DIFF
--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -1063,9 +1063,9 @@ class PhysicsSystem extends WorldSystem {
                             appliedSphereCollider = true
                         }
 
-                        massOverride = totalMass == 0.0 ? 1 : Math.min(totalMass, MAX_GP_MASS)
+                        massOverride = totalMass == 0.0 ? undefined : Math.min(totalMass, MAX_GP_MASS)
                     } else {
-                        massOverride = totalMass == 0.0 ? 1 : totalMass * massMod
+                        massOverride = totalMass == 0.0 ? undefined : totalMass * massMod
                     }
                 }
 

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -1041,6 +1041,7 @@ class PhysicsSystem extends WorldSystem {
 
                 let shape = shapeResult.Get()
                 let appliedSphereCollider = false
+                let massOverride: number | undefined
 
                 if (rn.isDynamic) {
                     if (rn.isGamePiece) {
@@ -1062,10 +1063,9 @@ class PhysicsSystem extends WorldSystem {
                             appliedSphereCollider = true
                         }
 
-                        const mass = totalMass == 0.0 ? 1 : Math.min(totalMass, MAX_GP_MASS)
-                        shape.GetMassProperties().mMass = mass
+                        massOverride = totalMass == 0.0 ? 1 : Math.min(totalMass, MAX_GP_MASS)
                     } else {
-                        shape.GetMassProperties().mMass = totalMass == 0.0 ? 1 : totalMass * massMod
+                        massOverride = totalMass == 0.0 ? 1 : totalMass * massMod
                     }
                 }
 
@@ -1078,6 +1078,12 @@ class PhysicsSystem extends WorldSystem {
                     rn.isDynamic ? JOLT.EMotionType_Dynamic : JOLT.EMotionType_Static,
                     rnLayer
                 )
+
+                if (massOverride !== undefined) {
+                    bodySettings.mOverrideMassProperties = JOLT.EOverrideMassProperties_CalculateInertia
+                    bodySettings.mMassPropertiesOverride.mMass = massOverride
+                }
+
                 const body = this._joltBodyInterface.CreateBody(bodySettings)
                 this._joltBodyInterface.AddBody(body.GetID(), JOLT.EActivation_Activate)
                 body.SetAllowSleeping(false)

--- a/fission/src/systems/simulation/stimulus/ChassisStimulus.ts
+++ b/fission/src/systems/simulation/stimulus/ChassisStimulus.ts
@@ -25,7 +25,7 @@ class ChassisStimulus extends Stimulus {
         super(id, info)
 
         this._body = World.physicsSystem.getBody(bodyId)!
-        this._mass = this._body.GetShape().GetMassProperties().mMass
+        this._mass = 1 / this._body.GetMotionProperties().GetInverseMass()
     }
 
     public update(_: number): void {}


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-281

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Mass data from mirabuf was not being applied correctly.

```ts
shape.GetMassProperties().mMass = mass
```

mutates a throwaway copy, never saves the mass override data.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

The solution is a bit weird because jolt appears to store mass data as a inverse and the only way to really set the mass is to get the inverse and then invert it?

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

Robot and gamepiece mass now actually reflects mirabuf's declared mass instead of falling back to Jolt's density-based estimate. 

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
