### PR TITLE
Support Asan Jolt build for our current tests `[SYNTH-282]`

### DIFF
--- a/fission/package.json
+++ b/fission/package.json
@@ -12,6 +12,7 @@
     "dev": "vite --open",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:asan": "sh ./scripts/test-asan.sh",
     "build": "tsc && vite build",
     "build:prod": "tsc && vite build --base=/fission/ --outDir dist/prod",
     "build:dev": "tsc && vite build --base=/fission-closed/ --outDir dist/dev",

--- a/fission/scripts/test-asan.sh
+++ b/fission/scripts/test-asan.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Runs the fission test suite a second time against an ASan-instrumented Jolt
+# build (see jolt/CMakeLists.txt's ENABLE_ASAN option) to catch
+# use-after-free/double-free bugs in the paths the normal suite already
+# exercises. Builds the ASan Jolt binary if it isn't present yet (requires
+# Emscripten, see jolt/README.md for EMSCRIPTEN_ROOT/EMSDK setup).
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+JOLT_DIR="$SCRIPT_DIR/../../jolt"
+ASAN_DIST="$JOLT_DIR/dist/jolt-physics.asan.wasm-compat.js"
+
+if [ ! -f "$ASAN_DIST" ]; then
+    echo "ASan Jolt build not found at $ASAN_DIST, building it now..."
+    (cd "$JOLT_DIR" && bun run build:asan)
+fi
+
+export JOLT_ASAN_DIST="$ASAN_DIST"
+exec bunx vitest run --project fission-asan

--- a/fission/scripts/test-asan.sh
+++ b/fission/scripts/test-asan.sh
@@ -1,18 +1,24 @@
 #!/bin/sh
-# Runs the fission test suite a second time against an ASan-instrumented Jolt
-# build (see jolt/CMakeLists.txt's ENABLE_ASAN option) to catch
-# use-after-free/double-free bugs in the paths the normal suite already
-# exercises. Builds the ASan Jolt binary if it isn't present yet (requires
-# Emscripten, see jolt/README.md for EMSCRIPTEN_ROOT/EMSDK setup).
+
+# Run via `bun run test:asan`` from fission/
+# Run all of our tests with address sanitization, requires emscripten.
+
 set -e
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 JOLT_DIR="$SCRIPT_DIR/../../jolt"
 ASAN_DIST="$JOLT_DIR/dist/jolt-physics.asan.wasm-compat.js"
 
+if [ ! -f "$JOLT_DIR/build.sh" ]; then
+    echo "jolt submodule not checked out, run:\n\tgit submodule update --init jolt" >&2
+    exit 1
+fi
+
 if [ ! -f "$ASAN_DIST" ]; then
     echo "ASan Jolt build not found at $ASAN_DIST, building it now..."
-    (cd "$JOLT_DIR" && bun run build:asan)
+    (cd "$JOLT_DIR" && sh build.sh Debug -DENABLE_ASAN=ON -DBUILD_WASM_COMPAT_ONLY=ON)
+    cp "$JOLT_DIR/dist/jolt-physics.debug.wasm-compat.js" "$ASAN_DIST"
+    cp "$JOLT_DIR/dist/jolt-physics.debug.wasm-compat.d.ts" "$JOLT_DIR/dist/jolt-physics.asan.wasm-compat.d.ts"
 fi
 
 export JOLT_ASAN_DIST="$ASAN_DIST"

--- a/fission/src/mirabuf/ScoringZoneSceneObject.ts
+++ b/fission/src/mirabuf/ScoringZoneSceneObject.ts
@@ -1,4 +1,3 @@
-import JOLT from "@/util/loading/JoltSyncLoader"
 import type Jolt from "@synthesis.adsk/jolt-physics"
 import type * as THREE from "three"
 import * as Three from "three"
@@ -59,9 +58,8 @@ class ScoringZoneSceneObject extends ZoneSceneObject<ScoringZonePreferences> {
             const gp = World.physicsSystem.getBody(gpID)
             if (!gp) return false
 
-            const gpBounding = gp.GetWorldSpaceBounds()
+            const gpBounding = gp.GetWorldSpaceBounds() // STATIC_ALIAS
             const overlaps = this.bounding?.OverlapsAABox(gpBounding)
-            JOLT.destroy(gpBounding)
 
             return overlaps
         })

--- a/fission/src/test/physics/PhysicsSystem.test.ts
+++ b/fission/src/test/physics/PhysicsSystem.test.ts
@@ -25,7 +25,7 @@ describe("Physics Sanity Checks", () => {
 
         const shapeResult = system.createConvexHull(points)
 
-        assert(shapeResult.HasError() == false, shapeResult.GetError().c_str())
+        assert(shapeResult.HasError() == false, shapeResult.HasError() ? shapeResult.GetError().c_str() : undefined)
         expect(shapeResult.IsValid()).toBe(true)
 
         const shape = shapeResult.Get()
@@ -41,7 +41,7 @@ describe("Physics Sanity Checks", () => {
 
         const shapeResult = system.createConvexHull(points)
 
-        assert(shapeResult.HasError() == false, shapeResult.GetError().c_str())
+        assert(shapeResult.HasError() == false, shapeResult.HasError() ? shapeResult.GetError().c_str() : undefined)
         expect(shapeResult.IsValid()).toBe(true)
 
         const shape = shapeResult.Get()
@@ -66,7 +66,7 @@ describe("Physics Sanity Checks", () => {
         const density = 2.5
         const shapeResult = system.createConvexHull(points, density)
 
-        assert(shapeResult.HasError() == false, shapeResult.GetError().c_str())
+        assert(shapeResult.HasError() == false, shapeResult.HasError() ? shapeResult.GetError().c_str() : undefined)
         expect(shapeResult.IsValid()).toBe(true)
 
         const shape = shapeResult.Get()

--- a/fission/src/test/util/TypeConversions.test.ts
+++ b/fission/src/test/util/TypeConversions.test.ts
@@ -19,11 +19,10 @@ describe("Three to Jolt Conversions", async () => {
         const threeArr = tM.toArray()
 
         for (let c = 0; c < 4; c++) {
-            const column = jM.GetColumn4(c)
+            const column = jM.GetColumn4(c) // STATIC_ALIAS
             for (let r = 0; r < 4; r++) {
                 expect(threeArr[c * 4 + r]).toBeCloseTo(column.GetComponent(r), 4)
             }
-            JOLT.destroy(column)
         }
 
         const threeTranslation = new THREE.Vector3()
@@ -31,19 +30,17 @@ describe("Three to Jolt Conversions", async () => {
         const threeScale = new THREE.Vector3()
         tM.decompose(threeTranslation, threeRotation, threeScale)
 
-        const joltTranslation = jM.GetTranslation()
-        const joltRotation = jM.GetQuaternion()
+        const joltTranslation = jM.GetTranslation() // STATIC_ALIAS
+        const joltRotation = jM.GetQuaternion() // STATIC_ALIAS
         const joltScale = new JOLT.Vec3(1, 1, 1)
 
         expect(joltTranslation.GetX()).toBeCloseTo(threeTranslation.x, 4)
         expect(joltTranslation.GetY()).toBeCloseTo(threeTranslation.y, 4)
         expect(joltTranslation.GetZ()).toBeCloseTo(threeTranslation.z, 4)
-        // JOLT.destroy(joltTranslation); // Causes error for some reason?
         expect(joltRotation.GetX()).toBeCloseTo(threeRotation.x, 4)
         expect(joltRotation.GetY()).toBeCloseTo(threeRotation.y, 4)
         expect(joltRotation.GetZ()).toBeCloseTo(threeRotation.z, 4)
         expect(joltRotation.GetW()).toBeCloseTo(threeRotation.w, 4)
-        JOLT.destroy(joltRotation)
         expect(joltScale.GetX()).toBeCloseTo(threeScale.x, 4)
         expect(joltScale.GetY()).toBeCloseTo(threeScale.y, 4)
         expect(joltScale.GetZ()).toBeCloseTo(threeScale.z, 4)
@@ -220,11 +217,10 @@ describe("Jolt to Three Conversions", () => {
         const threeArr = tM.toArray()
 
         for (let c = 0; c < 4; c++) {
-            const column = jM.GetColumn4(c)
+            const column = jM.GetColumn4(c) // STATIC_ALIAS
             for (let r = 0; r < 4; r++) {
                 expect(threeArr[c * 4 + r]).toBeCloseTo(column.GetComponent(r), 4)
             }
-            JOLT.destroy(column)
         }
 
         const threeTranslation = new THREE.Vector3()
@@ -232,19 +228,17 @@ describe("Jolt to Three Conversions", () => {
         const threeScale = new THREE.Vector3()
         tM.decompose(threeTranslation, threeRotation, threeScale)
 
-        const joltTranslation = jM.GetTranslation()
-        const joltRotation = jM.GetQuaternion()
+        const joltTranslation = jM.GetTranslation() // STATIC_ALIAS
+        const joltRotation = jM.GetQuaternion() // STATIC_ALIAS
         const joltScale = new JOLT.Vec3(1, 1, 1)
 
         expect(threeTranslation.x).toBeCloseTo(joltTranslation.GetX(), 4)
         expect(threeTranslation.y).toBeCloseTo(joltTranslation.GetY(), 4)
         expect(threeTranslation.z).toBeCloseTo(joltTranslation.GetZ(), 4)
-        // JOLT.destroy(joltTranslation); // Causes error for some reason?
         expect(threeRotation.x).toBeCloseTo(joltRotation.GetX(), 4)
         expect(threeRotation.y).toBeCloseTo(joltRotation.GetY(), 4)
         expect(threeRotation.z).toBeCloseTo(joltRotation.GetZ(), 4)
         expect(threeRotation.w).toBeCloseTo(joltRotation.GetW(), 4)
-        JOLT.destroy(joltRotation)
         expect(threeScale.x).toBeCloseTo(joltScale.GetX(), 4)
         expect(threeScale.y).toBeCloseTo(joltScale.GetY(), 4)
         expect(threeScale.z).toBeCloseTo(joltScale.GetZ(), 4)
@@ -253,12 +247,12 @@ describe("Jolt to Three Conversions", () => {
 
     test("Jolt.Mat44 [Identity] -> THREE.Matrix4", () => {
         const tmp = new JOLT.RMat44()
-        const joltMat = tmp.sIdentity()
+        const joltMat = tmp.sIdentity() // STATIC_ALIAS
         const threeMat = convertJoltMat44ToThreeMatrix4(joltMat)
 
         compareMat(joltMat, threeMat)
 
-        JOLT.destroy(joltMat)
+        JOLT.destroy(tmp)
     })
 
     test("Jolt.Mat44 [+X Axis Rotation] -> THREE.Matrix4", () => {

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -81,21 +81,18 @@ export default defineConfig(async ({ mode }) => {
               changeOrigin: true,
               secure: true,
           }
-    return {
-        plugins: plugins,
-        publicDir: "./public",
-        resolve: {
-            alias: [
-                { find: "@/components", replacement: path.resolve(__dirname, "src", "ui", "components") },
-                { find: "@/modals", replacement: path.resolve(__dirname, "src", "ui", "modals") },
-                { find: "@/panels", replacement: path.resolve(__dirname, "src", "ui", "panels") },
-                { find: "@", replacement: path.resolve(__dirname, "src") },
-            ],
-        },
-        define: {
-            GIT_COMMIT: JSON.stringify(await getCommitHash()),
-        },
+
+    const baseAliases = [
+        { find: "@/components", replacement: path.resolve(__dirname, "src", "ui", "components") },
+        { find: "@/modals", replacement: path.resolve(__dirname, "src", "ui", "modals") },
+        { find: "@/panels", replacement: path.resolve(__dirname, "src", "ui", "panels") },
+        { find: "@", replacement: path.resolve(__dirname, "src") },
+    ]
+
+    const fissionProject = {
+        extends: true,
         test: {
+            name: "fission",
             setupFiles: ["src/test/TestSetup.browser.ts"],
             globalSetup: ["src/test/TestSetup.server.ts"],
             testTimeout: 10000,
@@ -140,6 +137,53 @@ export default defineConfig(async ({ mode }) => {
                 exclude: ["src/test/**", "src/proto/**"],
                 reportOnFailure: true,
             },
+        },
+    }
+
+    // `bun run test:asan`
+    const fissionAsanProject = {
+        extends: true,
+        resolve: {
+            alias: [
+                ...baseAliases,
+                {
+                    find: /^@synthesis\.adsk\/jolt-physics(\/wasm-compat)?$/,
+                    replacement: process.env.JOLT_ASAN_DIST,
+                },
+            ],
+        },
+        test: {
+            name: "fission-asan",
+            setupFiles: ["src/test/TestSetup.browser.ts"],
+            globalSetup: ["src/test/TestSetup.server.ts"],
+            testTimeout: 10000,
+            globals: true,
+            environment: "jsdom",
+            browser: {
+                enabled: true,
+                provider: "playwright",
+                instances: [
+                    {
+                        name: "chromium",
+                        browser: "chromium",
+                        headless: true,
+                    },
+                ],
+            },
+        },
+    }
+
+    return {
+        plugins: plugins,
+        publicDir: "./public",
+        resolve: {
+            alias: baseAliases,
+        },
+        define: {
+            GIT_COMMIT: JSON.stringify(await getCommitHash()),
+        },
+        test: {
+            projects: [fissionProject, ...(process.env.JOLT_ASAN_DIST ? [fissionAsanProject] : [])],
         },
         build: {
             target: "esnext",

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -98,21 +98,6 @@ export default defineConfig(async ({ mode }) => {
             testTimeout: 10000,
             globals: true,
             environment: "jsdom",
-            reporters: process.env.GITHUB_ACTIONS
-                ? [
-                      "github-actions",
-                      "default",
-                      {
-                          onTestRunEnd(_modules: unknown, unhandled: unknown[], reason: TestRunEndReason) {
-                              if (reason === "passed" && unhandled.length === 0) {
-                                  console.error("GH ACTIONS VITEST PASSED")
-                              } else {
-                                  console.error(unhandled)
-                              }
-                          },
-                      },
-                  ]
-                : ["default"],
             browser: {
                 enabled: true,
                 provider: "playwright",
@@ -183,6 +168,21 @@ export default defineConfig(async ({ mode }) => {
             GIT_COMMIT: JSON.stringify(await getCommitHash()),
         },
         test: {
+            reporters: process.env.GITHUB_ACTIONS
+                ? [
+                      "github-actions",
+                      "default",
+                      {
+                          onTestRunEnd(_modules: unknown, unhandled: unknown[], reason: TestRunEndReason) {
+                              if (reason === "passed" && unhandled.length === 0) {
+                                  console.error("GH ACTIONS VITEST PASSED")
+                              } else {
+                                  console.error(unhandled)
+                              }
+                          },
+                      },
+                  ]
+                : ["default"],
             projects: [fissionProject, ...(process.env.JOLT_ASAN_DIST ? [fissionAsanProject] : [])],
         },
         build: {

--- a/fission/vite.config.ts
+++ b/fission/vite.config.ts
@@ -114,14 +114,6 @@ export default defineConfig(async ({ mode }) => {
                     },
                 ],
             },
-            coverage: {
-                provider: "istanbul",
-                reporter: ["text", "html"] as const,
-                reportsDirectory: "./coverage",
-                include: ["src/**/*.{ts,tsx}"],
-                exclude: ["src/test/**", "src/proto/**"],
-                reportOnFailure: true,
-            },
         },
     }
 
@@ -183,6 +175,14 @@ export default defineConfig(async ({ mode }) => {
                       },
                   ]
                 : ["default"],
+            coverage: {
+                provider: "istanbul",
+                reporter: ["text", "html"] as const,
+                reportsDirectory: "./coverage",
+                include: ["src/**/*.{ts,tsx}"],
+                exclude: ["src/test/**", "src/proto/**"],
+                reportOnFailure: true,
+            },
             projects: [fissionProject, ...(process.env.JOLT_ASAN_DIST ? [fissionAsanProject] : [])],
         },
         build: {


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-282

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

We have no real way of testing memory related bugs.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Enabled ASan (AddressSanitizer) build in the jolt submodule. We can now run our current test suite with ASan optionally enabled. This will help us catch these types of errors:

- Use after free
- Double free
- Heap buffer overflow/underflow
- Invalid free

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

Please feel free to build and run this version of our tests locally. Just be sure to have emscripten installed. However the tests will not pass. This is expected as we have a lot of memory management related mistakes. Once we have fixed all of them in subsequent prs we can enable this test in CI.

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
