### PR TITLE
Fix jolt memory issues in `ZoneSceneObject.ts` `[SYNTH-277]`

### DIFF
--- a/fission/src/mirabuf/ZoneSceneObject.ts
+++ b/fission/src/mirabuf/ZoneSceneObject.ts
@@ -31,7 +31,7 @@ export default abstract class ZoneSceneObject<P extends object> extends SceneObj
     // Visual Properties Cache
     private _deltaTransformation?: THREE.Matrix4
     private _deltaTransHasUpdated: boolean = false
-    private _cachedFieldTransformation?: Jolt.RMat44
+    private _cachedFieldTransformation?: THREE.Matrix4
 
     public prefs: ZonePreferencesShared & P
     private _preferenceKey: keyof UserPreferences
@@ -69,9 +69,11 @@ export default abstract class ZoneSceneObject<P extends object> extends SceneObj
         if (!this.parentBodyId) return
 
         this._deltaTransformation = convertArrayToThreeMatrix4(this.prefs.deltaTransformation)
-        this._cachedFieldTransformation = World.physicsSystem.getBody(this.parentBodyId)!.GetWorldTransform()
 
-        const fieldTransformation = convertJoltMat44ToThreeMatrix4(this._cachedFieldTransformation)
+        const worldTransform = World.physicsSystem.getBody(this.parentBodyId)!.GetWorldTransform() // STATIC_ALIAS
+        const fieldTransformation = convertJoltMat44ToThreeMatrix4(worldTransform)
+        this._cachedFieldTransformation = fieldTransformation
+
         const props: VisualProperties = deltaAndFieldTransformsToVisualProp(
             this._deltaTransformation,
             fieldTransformation
@@ -91,14 +93,15 @@ export default abstract class ZoneSceneObject<P extends object> extends SceneObj
         if (this.bounding) JOLT.destroy(this.bounding)
 
         const halfExtent = convertThreeVector3ToJoltVec3(props.scale).Div(2)
-        const transform = new JOLT.Mat44().sRotationTranslation(
-            convertThreeQuaternionToJoltQuat(props.rotation),
-            convertThreeVector3ToJoltVec3(props.translation)
-        )
+        const rotation = convertThreeQuaternionToJoltQuat(props.rotation)
+        const translation = convertThreeVector3ToJoltVec3(props.translation)
+        const transform = new JOLT.Mat44().sRotationTranslation(rotation, translation)
 
         this.bounding = new JOLT.OrientedBox(transform, halfExtent)
 
         JOLT.destroy(transform)
+        JOLT.destroy(rotation)
+        JOLT.destroy(translation)
         JOLT.destroy(halfExtent)
     }
 
@@ -139,21 +142,17 @@ export default abstract class ZoneSceneObject<P extends object> extends SceneObj
      * @returns `undefined` when the visual properties for this zone have not changed
      */
     private generateVisualProperties(): VisualProperties | undefined {
-        // NOTE I believe that `GetWorldTransform` returns a copy
-        // Source: https://github.com/jrouwe/JoltPhysics/blob/master/Jolt/Physics/Body/Body.inl
-        const newTransform = World.physicsSystem.getBody(this.parentBodyId!)!.GetWorldTransform()
+        const worldTransform = World.physicsSystem.getBody(this.parentBodyId!)!.GetWorldTransform() // STATIC_ALIAS
+        const fieldTransformation = convertJoltMat44ToThreeMatrix4(worldTransform)
         const transformHasNotUpdated =
-            this._cachedFieldTransformation && newTransform.Equals(this._cachedFieldTransformation)
+            this._cachedFieldTransformation && fieldTransformation.equals(this._cachedFieldTransformation)
 
         // Update translation, rotation, and scale only if the field has moved
         if (transformHasNotUpdated && !this._deltaTransHasUpdated) return undefined
 
-        if (this._cachedFieldTransformation) JOLT.destroy(this._cachedFieldTransformation)
-        this._cachedFieldTransformation = newTransform
-
+        this._cachedFieldTransformation = fieldTransformation
         this._deltaTransHasUpdated = false
 
-        const fieldTransformation = convertJoltMat44ToThreeMatrix4(this._cachedFieldTransformation)
         return deltaAndFieldTransformsToVisualProp(this._deltaTransformation!, fieldTransformation)
     }
 
@@ -187,10 +186,5 @@ export default abstract class ZoneSceneObject<P extends object> extends SceneObj
             World.sceneRenderer.removeObject(this.mesh)
             this.mesh.geometry.dispose()
         }
-
-        // TODO
-        // I think we need to free `this._cachedFieldTransformation`, but there's some bug with doing so
-        // I think this is related to the fact that we're destroying and re-creating zones every time we update their preferences.
-        // For reviewers: This PR should still be merged, and this question should be resolved in another PR
     }
 }


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-277

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Asan was crashing on this file and emitting errors.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Fix jolt memory handling primarily around the `STATIC_ALIAS` return type. Remove or confirm comments referencing these issues.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

Asan now no longer crashes on this particular file.

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
