### PR TITLE
URDF Mesh Decimation `[SYNTH-264]`

### DIFF
--- a/fission/bun.lock
+++ b/fission/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "synthesis-fission",
@@ -21,6 +20,7 @@
         "fuse.js": "^7.1.0",
         "jszip": "^3.10.1",
         "lygia": "^1.3.3",
+        "meshoptimizer": "^1.2.0",
         "msw": "^2.10.5",
         "notistack": "^3.0.2",
         "peerjs": "^1.5.5",
@@ -1097,7 +1097,7 @@
 
     "meshline": ["meshline@3.3.1", "", { "peerDependencies": { "three": ">=0.137" } }, "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ=="],
 
-    "meshoptimizer": ["meshoptimizer@0.22.0", "", {}, "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg=="],
+    "meshoptimizer": ["meshoptimizer@1.2.0", "", {}, "sha512-davRZeIJbxJrE24cwQle7ZDsxjdk/OphNOV83oX+efQinyoHY9Jcyz3MHbaoG0qySZajldGztNZ1RN/T19PZsg=="],
 
     "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
 
@@ -1698,6 +1698,8 @@
     "@types/send/@types/node": ["@types/node@22.17.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ=="],
 
     "@types/serve-static/@types/node": ["@types/node@22.17.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ=="],
+
+    "@types/three/meshoptimizer": ["meshoptimizer@0.22.0", "", {}, "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg=="],
 
     "@types/ws/@types/node": ["@types/node@22.17.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ=="],
 

--- a/fission/package.json
+++ b/fission/package.json
@@ -47,6 +47,7 @@
     "fuse.js": "^7.1.0",
     "jszip": "^3.10.1",
     "lygia": "^1.3.3",
+    "meshoptimizer": "^1.2.0",
     "msw": "^2.10.5",
     "notistack": "^3.0.2",
     "peerjs": "^1.5.5",

--- a/fission/src/ui/modals/mirabuf/ImportLocalMirabufModal.tsx
+++ b/fission/src/ui/modals/mirabuf/ImportLocalMirabufModal.tsx
@@ -100,14 +100,14 @@ const ImportLocalMirabufModal: React.FC<ModalImplProps<void, ImportLocalMirabufP
                     assembly.info!.GUID = uuid
 
                     let hash: string = inputHash
-                    //// TODO: Caching currently requires too much memory due to the size of URDF meshes. Can be re-enabled after simplifying
 
-                    // const res = await MirabufCachingService.storeAssemblyInCache(assembly, { miraType })
+                    const res = await MirabufCachingService.storeAssemblyInCache(assembly, { miraType })
 
-                    // if (res == null) {
-                    //     console.warn("Caching URDF failed!")
-                    //     hash = inputHash
-                    // }
+                    if (res == null) {
+                        console.warn("Caching URDF failed!")
+                    } else {
+                        hash = res.hash
+                    }
 
                     mirabufSceneObject = await createMirabuf(hash, assembly, progressHandle)
                     progressHandle.done("Import complete!")

--- a/fission/src/urdf/MeshDecimation.ts
+++ b/fission/src/urdf/MeshDecimation.ts
@@ -1,7 +1,7 @@
 import { MeshoptSimplifier } from "meshoptimizer"
 import type { ParsedMesh } from "./STLParser"
 
-// STL Mesh Decimation for URDF STL mesh imports.
+// Mesh decimation for URDF STL/OBJ/glTF imports.
 // This decimation step takes the 2026 kitbot import size from 3.11GB to 117MB.
 
 // Every result is checked against the input (see validate()) and the original mesh is returned
@@ -44,6 +44,10 @@ export async function readyMeshDecimation(): Promise<void> {
 interface Welded {
     verts: Float32Array
     indices: Uint32Array
+    /** Per-vertex UV, 2 floats per entry in `verts`. Zero-length when the source mesh carries no UV
+     * (STL, or a glTF/OBJ mesh with no texture coordinates) - skipped rather than carried as zeros
+     * so the STL path does no extra work. */
+    uv: Float32Array
 }
 
 // Collapses bit-identical positions into a compacted vertex buffer and reindexes
@@ -57,18 +61,25 @@ function weldPositions(mesh: ParsedMesh): Welded {
     }
 
     const verts = new Float32Array(uniqueCount * 3)
+    const hasUV = mesh.uv.length > 0
+    const uv = new Float32Array(hasUV ? uniqueCount * 2 : 0)
     for (let i = 0; i < sourceVertCount; i++) {
         if (remap[i] !== i) continue
         const out = compacted[i] * 3
         verts[out] = mesh.verts[i * 3]
         verts[out + 1] = mesh.verts[i * 3 + 1]
         verts[out + 2] = mesh.verts[i * 3 + 2]
+        if (hasUV) {
+            const outUV = compacted[i] * 2
+            uv[outUV] = mesh.uv[i * 2]
+            uv[outUV + 1] = mesh.uv[i * 2 + 1]
+        }
     }
 
     const indices = new Uint32Array(mesh.indices.length)
     for (let i = 0; i < indices.length; i++) indices[i] = compacted[remap[mesh.indices[i]]]
 
-    return { verts, indices }
+    return { verts, indices, uv }
 }
 
 interface MeshStats {
@@ -417,18 +428,24 @@ function validate(original: MeshStats, simplified: MeshStats): boolean {
     return true
 }
 
-function compactVertices(source: Float32Array, indices: Uint32Array): Welded {
+function compactVertices(source: Float32Array, sourceUV: Float32Array, indices: Uint32Array): Welded {
     const [remap, uniqueCount] = MeshoptSimplifier.compactMesh(indices)
     const verts = new Float32Array(uniqueCount * 3)
+    const hasUV = sourceUV.length > 0
+    const uv = new Float32Array(hasUV ? uniqueCount * 2 : 0)
     for (let i = 0; i < remap.length; i++) {
         const out = remap[i]
         if (out === 0xffffffff) continue
         verts[out * 3] = source[i * 3]
         verts[out * 3 + 1] = source[i * 3 + 1]
         verts[out * 3 + 2] = source[i * 3 + 2]
+        if (hasUV) {
+            uv[out * 2] = sourceUV[i * 2]
+            uv[out * 2 + 1] = sourceUV[i * 2 + 1]
+        }
     }
 
-    return { verts, indices }
+    return { verts, indices, uv }
 }
 
 function computeFaceNormals(verts: Float32Array, indices: Uint32Array, triCount: number): Float32Array {
@@ -479,12 +496,14 @@ function buildIncidentFacesCSR(indices: Uint32Array, vertCount: number, triCount
 function clusterFacesAroundVertex(
     v: number,
     verts: Float32Array,
+    uv: Float32Array,
     indices: Uint32Array,
     faceNormals: Float32Array,
     { offsets, incident }: IncidentFaces,
     clusterOf: Int32Array,
     outVerts: number[],
     outNormals: number[],
+    outUV: number[],
     outIndices: Uint32Array
 ): void {
     const start = offsets[v]
@@ -524,6 +543,7 @@ function clusterFacesAroundVertex(
         const len = Math.hypot(nx, ny, nz) || 1
         outVerts.push(verts[v * 3], verts[v * 3 + 1], verts[v * 3 + 2])
         outNormals.push(nx / len, ny / len, nz / len)
+        if (uv.length > 0) outUV.push(uv[v * 2], uv[v * 2 + 1])
     }
 }
 
@@ -531,7 +551,7 @@ function clusterFacesAroundVertex(
 // simply averaging all faces at a vertex rounds off machined edges. Instead, the faces around each
 // vertex are grouped into clusters of similar orientation and each cluster gets its own vertex (see
 // clusterFacesAroundVertex above).
-function buildShadingData({ verts, indices }: Welded): ParsedMesh {
+function buildShadingData({ verts, indices, uv }: Welded): ParsedMesh {
     const triCount = indices.length / 3
     const vertCount = verts.length / 3
 
@@ -540,6 +560,7 @@ function buildShadingData({ verts, indices }: Welded): ParsedMesh {
 
     const outVerts: number[] = []
     const outNormals: number[] = []
+    const outUV: number[] = []
     const outIndices = new Uint32Array(indices.length)
     const clusterOf = new Int32Array(triCount).fill(-1)
 
@@ -547,12 +568,14 @@ function buildShadingData({ verts, indices }: Welded): ParsedMesh {
         clusterFacesAroundVertex(
             v,
             verts,
+            uv,
             indices,
             faceNormals,
             incidentFaces,
             clusterOf,
             outVerts,
             outNormals,
+            outUV,
             outIndices
         )
     }
@@ -560,15 +583,17 @@ function buildShadingData({ verts, indices }: Welded): ParsedMesh {
     return {
         verts: Float32Array.from(outVerts),
         normals: Float32Array.from(outNormals),
-        uv: new Float32Array(0), // STL carries no UV data
+        uv: Float32Array.from(outUV), // empty when the source mesh (STL, or UV-less glTF/OBJ) carried none
         indices: outIndices,
     }
 }
 
 /**
- * Reduces an over-tessellated STL mesh under a bounded geometric error budget. Returns the input
+ * Reduces an over-tessellated mesh under a bounded geometric error budget. Returns the input
  * mesh unchanged if it is already small, if decimation isn't available, if the source isn't a clean
- * closed manifold, or if no budget on the ladder produces a result that survives validation.
+ * closed manifold, or if no budget on the ladder produces a result that survives validation - the
+ * ladder is calibrated against STL tessellation density, so a denser glTF/OBJ export of the same
+ * part is more likely to fall through every rung and come back untouched (safe, just less reduction).
  */
 export function decimateMesh(mesh: ParsedMesh): ParsedMesh {
     const triangleCount = mesh.indices.length / 3
@@ -592,7 +617,7 @@ export function decimateMesh(mesh: ParsedMesh): ParsedMesh {
         if (simplified.length < 12) continue
         if (simplified.length / 3 > triangleCount * (1 - MIN_REDUCTION)) continue
 
-        const result = compactVertices(welded.verts, simplified)
+        const result = compactVertices(welded.verts, welded.uv, simplified)
         if (!validate(original, measure(result))) continue
 
         // This check is very expensive, run it last.

--- a/fission/src/urdf/MeshDecimation.ts
+++ b/fission/src/urdf/MeshDecimation.ts
@@ -1,63 +1,38 @@
 import { MeshoptSimplifier } from "meshoptimizer"
 import type { ParsedMesh } from "./STLParser"
 
-// Onshape's STL export tessellates every part far finer than a robot simulator needs - a plain
-// rectangular FRC tube stock STL carries 83k triangles for a shape that needs a few hundred. That
-// geometry is baked into the in-memory mirabuf.Assembly and duplicated per <link>, and it doubles
-// as the Jolt collision surface (convex hull for dynamic bodies, concave BVH mesh for static
-// ones), so it costs memory twice and shape-build time on top.
-//
-// Two things make this tricky, and both bit earlier attempts at this file:
-//
-// 1. STL is a triangle *soup* - every triangle owns its own 3 vertices, even where they coincide
-//    exactly with a neighbour's. meshoptimizer builds its own position remap internally and treats
-//    vertices that share a position as attribute "wedges"; a position with 3+ wedges is classified
-//    as locked and can never be collapsed. Every vertex of a soup mesh has one wedge per incident
-//    triangle, so *every* vertex ends up locked and simplify() returns the mesh untouched. Passing
-//    a remapped index buffer is not enough - the duplicate positions must be gone from the vertex
-//    buffer too, otherwise the internal remap still sees them. Hence weldPositions() below returns
-//    a compacted buffer, not just a remap.
-//
-// 2. Triangle count is the wrong thing to ask for. Asking for "2% of the original triangles" on the
-//    tube above collapses its 1.6mm walls: the result measured 47% of the original volume with 350
-//    non-manifold and 700 wrongly-wound edges. Instead we give the simplifier an *absolute*
-//    geometric error budget (ErrorAbsolute) and let it stop wherever that budget runs out, then
-//    verify the result independently. Thin features survive because collapsing them costs more
-//    error than the budget allows.
-//
+// STL Mesh Decimation for URDF STL mesh imports.
+// This decimation step takes the 2026 kitbot import size from 3.11GB to 117MB.
+
 // Every result is checked against the input (see validate()) and the original mesh is returned
 // unchanged if anything looks off. Correctness beats memory savings here.
 
 // Below this triangle count the mesh is already cheap; leave it alone.
 const TRIANGLE_THRESHOLD = 2000
-// Absolute error budgets, in metres (URDF geometry is metric; the metres->cm scale happens later in
-// URDFConverter). Tried loosest-first, stopping at the first result that passes validation.
+
+// Absolute error budgets in metres 
 //
-// These are calibrated, not guessed. meshopt's error metric is a quadric estimate, not a true
-// Hausdorff bound: measured against the original surface it undershoots by up to ~3.5x, so a 0.5mm
-// budget is what actually keeps worst-case surface deviation under ~2mm across both sample kits
-// (scripts/urdf-mem-debug/sweep-kits.mjs measures this directly - rerun it if these change).
+// These are calibrated values from the 2026 FRC kitbot. These values keep the measured surface
+// within 0.5mm of the original while still having a triangle reduction count of about 87.1%.
 //
-// The bottom rungs exist for hardware: an FRC kit's heaviest STLs by triangle count are often
-// screws (one file measured 111k triangles for a handful of button-head bolts), and a budget sized
-// for a chassis tube eats a screw's thread and head taper - measurably, 15-20% of its volume. Those
-// parts still give up 75-85% of their triangles once the budget is small enough to leave the threads
-// alone, so it's worth walking down to 0.03mm rather than skipping them.
+// Bottom rungs exist for hardware like screws. Some of these parts have measured over 100k triangles
+// regardless of how small they are so it's worth waking down to 0.03mm to avoid skipping those meshes.
 const ERROR_BUDGETS_M = [0.0005, 0.00025, 0.000125, 0.0000625, 0.00003125]
 // ...but never spend more error than this fraction of the part's own bounding-box diagonal, so a
 // 5mm spacer isn't handed a budget the size of itself.
 const RELATIVE_BUDGET_CAP = 0.01
+
 // Rejection thresholds for the simplified result, all measured against the welded input.
 const MAX_VOLUME_DEVIATION = 0.03
 const MAX_AREA_DEVIATION = 0.1
 const MAX_AXIS_DEVIATION = 0.01
-// Rays per axis for the solidity probe below, and the share of them allowed to come back
-// inconsistent. Measured separation is wide: meshes with a folded surface score 0.4-1.7% while clean
-// ones score 0-0.02% (the handful of non-zero rays on a clean mesh are ones that graze an edge).
-const SOLIDITY_RESOLUTION = 64
-const MAX_UNSOLID_RAY_RATIO = 0.001
+
+const SOLIDITY_RESOLUTION = 64 // grid density per axis
+const MAX_UNSOLID_RAY_RATIO = 0.001 // bad_rays / total_rays. fail any 0.1%
+
 // Rebuilding the vertex/normal/index buffers isn't free, so don't bother for a marginal win.
 const MIN_REDUCTION = 0.25
+
 // Faces meeting at a sharper angle than this get split normals, so a machined edge stays crisp
 // while a tessellated cylinder still shades smoothly at the reduced triangle count.
 const CREASE_COS = Math.cos((35 * Math.PI) / 180)
@@ -71,10 +46,7 @@ interface Welded {
     indices: Uint32Array
 }
 
-// Collapses bit-identical positions into a compacted vertex buffer and reindexes. Exact comparison
-// is enough in practice: on every Onshape STL checked, an exact weld already produces a closed,
-// consistently-wound manifold (a tolerance-based weld found no additional merges), because the
-// tessellator emits the same float bits for a shared corner in every facet that touches it.
+// Collapses bit-identical positions into a compacted vertex buffer and reindexes
 function weldPositions(mesh: ParsedMesh): Welded {
     const remap = MeshoptSimplifier.generatePositionRemap(mesh.verts, 3)
     const sourceVertCount = mesh.verts.length / 3
@@ -102,8 +74,7 @@ function weldPositions(mesh: ParsedMesh): Welded {
 interface MeshStats {
     /** Surface area. */
     area: number
-    /** Divergence-theorem volume - only meaningful on a closed surface, which is the point: a hole
-     * or a flipped patch shows up as a volume that no longer matches. */
+    /** Divergence-theorem volume. Only meaningful on a closed surface. */
     volume: number
     /** Per-axis bounding box extent. */
     size: [number, number, number]
@@ -117,9 +88,8 @@ interface MeshStats {
     reversedEdges: number
     /** Triangles with a repeated index or zero area. */
     degenerateTriangles: number
-    /** Connected shells. Onshape parts are routinely multi-body (a shaft plus its retaining ring);
-     * fusing two of them together is the "merges features that are spatially close but
-     * topologically disjoint" failure mode, and it shows up here as a drop. */
+    /** Connected shells. URDF parts are routinely multi-body (a shaft plus its retaining ring).
+     * Use this count to avoid accidentally merging two topologically disjoint components. */
     shells: number
 }
 
@@ -133,6 +103,7 @@ function countShells(indices: Uint32Array, vertCount: number): number {
         }
         return x
     }
+
     const used = new Uint8Array(vertCount)
     for (let i = 0; i < indices.length; i += 3) {
         for (let k = 0; k < 3; k++) used[indices[i + k]] = 1
@@ -142,21 +113,27 @@ function countShells(indices: Uint32Array, vertCount: number): number {
             if (a !== b) parent[a] = b
         }
     }
+
     const roots = new Set<number>()
     for (let i = 0; i < vertCount; i++) if (used[i]) roots.add(find(i))
     return roots.size
 }
 
-function measure({ verts, indices }: Welded): MeshStats {
-    const vertCount = verts.length / 3
-    const min = [Infinity, Infinity, Infinity]
-    const max = [-Infinity, -Infinity, -Infinity]
+interface EdgeStats {
+    area: number
+    volume: number
+    degenerateTriangles: number
+    boundaryEdges: number
+    nonManifoldEdges: number
+    reversedEdges: number
+}
+
+// Walks every triangle once, accumulating signed area/volume and edge-adjacency counts. Edge keys
+// are packed as `a * vertCount + b`
+function collectEdgeStats(verts: Float32Array, indices: Uint32Array, vertCount: number): EdgeStats {
     let area = 0
     let volume = 0
     let degenerateTriangles = 0
-
-    // Edge keys are packed as `a * vertCount + b`, which stays exact in a double for any vertex
-    // count a browser could hold.
     const undirected = new Map<number, number>()
     const directed = new Set<number>()
     let reversedEdges = 0
@@ -187,6 +164,7 @@ function measure({ verts, indices }: Welded): MeshStats {
             degenerateTriangles++
             continue
         }
+
         area += 0.5 * twiceArea
         volume +=
             (verts[a] * (verts[b + 1] * verts[c + 2] - verts[b + 2] * verts[c + 1]) -
@@ -207,6 +185,20 @@ function measure({ verts, indices }: Welded): MeshStats {
         }
     }
 
+    let boundaryEdges = 0
+    let nonManifoldEdges = 0
+    for (const count of undirected.values()) {
+        if (count === 1) boundaryEdges++
+        else if (count > 2) nonManifoldEdges++
+    }
+
+    return { area, volume, degenerateTriangles, boundaryEdges, nonManifoldEdges, reversedEdges }
+}
+
+function computeVertexBounds(verts: Float32Array): { size: [number, number, number]; diagonal: number } {
+    const min = [Infinity, Infinity, Infinity]
+    const max = [-Infinity, -Infinity, -Infinity]
+    const vertCount = verts.length / 3
     for (let i = 0; i < vertCount; i++) {
         for (let k = 0; k < 3; k++) {
             const value = verts[i * 3 + k]
@@ -215,37 +207,27 @@ function measure({ verts, indices }: Welded): MeshStats {
         }
     }
 
-    let boundaryEdges = 0
-    let nonManifoldEdges = 0
-    for (const count of undirected.values()) {
-        if (count === 1) boundaryEdges++
-        else if (count > 2) nonManifoldEdges++
-    }
-
     const size: [number, number, number] = [max[0] - min[0], max[1] - min[1], max[2] - min[2]]
+    return { size, diagonal: Math.hypot(size[0], size[1], size[2]) }
+}
+
+function measure({ verts, indices }: Welded): MeshStats {
+    const vertCount = verts.length / 3
     return {
-        area,
-        volume,
-        size,
-        diagonal: Math.hypot(size[0], size[1], size[2]),
-        boundaryEdges,
-        nonManifoldEdges,
-        reversedEdges,
-        degenerateTriangles,
+        ...collectEdgeStats(verts, indices, vertCount),
+        ...computeVertexBounds(verts),
         shells: countShells(indices, vertCount),
     }
 }
 
-// Sweeps a grid of parallel rays down each axis and checks that every ray's surface crossings
-// alternate enter/exit/enter/exit. That is the one property edge collapse can break while leaving
-// every cheap check happy: on small doubly-curved thin features (a nylock nut's nylon insert crown
-// was the case that found this) the simplified surface folds through itself, which keeps the mesh a
-// closed, consistently-wound manifold with the correct volume, area and bounding box - and renders
-// as a crumpled, partly see-through mess. Volume, area and dihedral angles all fail to distinguish
-// it; ray parity separates it by more than an order of magnitude.
-function unsolidRayRatio({ verts, indices }: Welded): number {
-    const min = [Infinity, Infinity, Infinity]
-    const max = [-Infinity, -Infinity, -Infinity]
+interface AxisBounds {
+    min: [number, number, number]
+    max: [number, number, number]
+}
+
+function computeIndexedBounds(verts: Float32Array, indices: Uint32Array): AxisBounds {
+    const min: [number, number, number] = [Infinity, Infinity, Infinity]
+    const max: [number, number, number] = [-Infinity, -Infinity, -Infinity]
     for (let i = 0; i < indices.length; i++) {
         for (let k = 0; k < 3; k++) {
             const value = verts[indices[i] * 3 + k]
@@ -254,92 +236,154 @@ function unsolidRayRatio({ verts, indices }: Welded): number {
         }
     }
 
+    return { min, max }
+}
+
+// Assigns each triangle to every grid cell its projected bounding box overlaps, so a ray cast from
+// a cell only has to test the triangles that could plausibly cover it.
+function bucketTrianglesByCell(
+    u: number,
+    v: number,
+    bounds: AxisBounds,
+    cellU: number,
+    cellV: number,
+    verts: Float32Array,
+    indices: Uint32Array
+): Map<number, number[]> {
+    const { min } = bounds
     const triCount = indices.length / 3
+    const buckets = new Map<number, number[]>()
+    for (let t = 0; t < triCount; t++) {
+        const a = indices[t * 3] * 3
+        const b = indices[t * 3 + 1] * 3
+        const c = indices[t * 3 + 2] * 3
+        const loU = Math.floor((Math.min(verts[a + u], verts[b + u], verts[c + u]) - min[u]) / cellU)
+        const hiU = Math.floor((Math.max(verts[a + u], verts[b + u], verts[c + u]) - min[u]) / cellU)
+        const loV = Math.floor((Math.min(verts[a + v], verts[b + v], verts[c + v]) - min[v]) / cellV)
+        const hiV = Math.floor((Math.max(verts[a + v], verts[b + v], verts[c + v]) - min[v]) / cellV)
+        for (let iu = Math.max(0, loU); iu <= Math.min(SOLIDITY_RESOLUTION - 1, hiU); iu++) {
+            for (let iv = Math.max(0, loV); iv <= Math.min(SOLIDITY_RESOLUTION - 1, hiV); iv++) {
+                const key = iu * SOLIDITY_RESOLUTION + iv
+                const bucket = buckets.get(key)
+                if (bucket) bucket.push(t)
+                else buckets.set(key, [t])
+            }
+        }
+    }
+
+    return buckets
+}
+
+// Casts one ray through its candidate triangles and returns each crossing as [position along the
+// ray axis, +1/-1 direction]. A triangle edge-on to the ray can't be classified as an entry or an
+// exit and is skipped.
+function castRay(
+    rayU: number,
+    rayV: number,
+    axis: number,
+    u: number,
+    v: number,
+    tris: number[],
+    verts: Float32Array,
+    indices: Uint32Array
+): Array<[number, number]> {
+    const hits: Array<[number, number]> = []
+    for (const t of tris) {
+        const a = indices[t * 3] * 3
+        const b = indices[t * 3 + 1] * 3
+        const c = indices[t * 3 + 2] * 3
+        const au = verts[a + u]
+        const av = verts[a + v]
+        const bu = verts[b + u]
+        const bv = verts[b + v]
+        const cu = verts[c + u]
+        const cv = verts[c + v]
+        const doubleArea = (bu - au) * (cv - av) - (cu - au) * (bv - av)
+        if (doubleArea === 0) continue
+        const wc = ((bu - au) * (rayV - av) - (rayU - au) * (bv - av)) / doubleArea
+        const wa = ((cu - bu) * (rayV - bv) - (rayU - bu) * (cv - bv)) / doubleArea
+        const wb = ((au - cu) * (rayV - cv) - (rayU - cu) * (av - cv)) / doubleArea
+        if (wa <= 0 || wb <= 0 || wc <= 0) continue
+
+        const ux = verts[b] - verts[a]
+        const uy = verts[b + 1] - verts[a + 1]
+        const uz = verts[b + 2] - verts[a + 2]
+        const vx = verts[c] - verts[a]
+        const vy = verts[c + 1] - verts[a + 1]
+        const vz = verts[c + 2] - verts[a + 2]
+        const normalAlongAxis = [uy * vz - uz * vy, uz * vx - ux * vz, ux * vy - uy * vx][axis]
+        if (normalAlongAxis === 0) continue
+        hits.push([
+            wa * verts[a + axis] + wb * verts[b + axis] + wc * verts[c + axis],
+            normalAlongAxis < 0 ? 1 : -1,
+        ])
+    }
+
+    return hits
+}
+
+// A ray through a solid should alternate outside/inside/outside as it crosses the surface, so the
+// running enter/exit tally should stay within {0, 1} and return to 0. Anything else means the
+// surface crosses itself along this ray
+function isRayInconsistent(hits: Array<[number, number]>): boolean {
+    hits.sort((x, y) => x[0] - y[0])
+    let inside = 0
+    for (const [, direction] of hits) {
+        inside += direction
+        if (inside < 0 || inside > 1) return true
+    }
+
+    return inside > 0
+}
+
+function countUnsolidRaysOnAxis(
+    axis: number,
+    verts: Float32Array,
+    indices: Uint32Array,
+    bounds: AxisBounds
+): { rays: number; bad: number } {
+    const u = (axis + 1) % 3
+    const v = (axis + 2) % 3
+    const cellU = (bounds.max[u] - bounds.min[u]) / SOLIDITY_RESOLUTION
+    const cellV = (bounds.max[v] - bounds.min[v]) / SOLIDITY_RESOLUTION
+    if (!(cellU > 0) || !(cellV > 0)) return { rays: 0, bad: 0 }
+
+    const buckets = bucketTrianglesByCell(u, v, bounds, cellU, cellV, verts, indices)
+
     let rays = 0
     let bad = 0
-    const hits: Array<[number, number]> = []
+    for (const [key, tris] of buckets) {
+        // Offset the ray from the cell corner by an irrational-looking fraction so it doesn't land
+        // exactly on a shared edge, where it would be counted twice or not at all.
+        const rayU = bounds.min[u] + (Math.floor(key / SOLIDITY_RESOLUTION) + 0.4531) * cellU
+        const rayV = bounds.min[v] + ((key % SOLIDITY_RESOLUTION) + 0.6237) * cellV
+        const hits = castRay(rayU, rayV, axis, u, v, tris, verts, indices)
+        if (hits.length === 0) continue
+        rays++
+        if (isRayInconsistent(hits)) bad++
+    }
 
+    return { rays, bad }
+}
+
+// Sweeps a grid of parallel rays down each axis and checks that every ray's surface crossings
+// alternate enter/exit/enter/exit. 
+//
+// This can be a very expensive check to run however its needed. Every other lightweight check
+// that fully covers a venn diagram of different failure modes simply can't replace this validation step.
+//
+// Every cheap check could be happy, on a small doubly-curved thin feature the simplified surface could fold
+// through itself, which keeps the mesh a closed, consistently-wound manifold with the correct volume, 
+// area and bounding box, and render compleatly wrong as a crumpled partly see-through mess. Volume, 
+// area and dihedral angles all will fail to distinguish it from the orignial geometry
+function unsolidRayRatio({ verts, indices }: Welded): number {
+    const bounds = computeIndexedBounds(verts, indices)
+    let rays = 0
+    let bad = 0
     for (let axis = 0; axis < 3; axis++) {
-        const u = (axis + 1) % 3
-        const v = (axis + 2) % 3
-        const cellU = (max[u] - min[u]) / SOLIDITY_RESOLUTION
-        const cellV = (max[v] - min[v]) / SOLIDITY_RESOLUTION
-        if (!(cellU > 0) || !(cellV > 0)) continue
-
-        const buckets = new Map<number, number[]>()
-        for (let t = 0; t < triCount; t++) {
-            const a = indices[t * 3] * 3
-            const b = indices[t * 3 + 1] * 3
-            const c = indices[t * 3 + 2] * 3
-            const loU = Math.floor((Math.min(verts[a + u], verts[b + u], verts[c + u]) - min[u]) / cellU)
-            const hiU = Math.floor((Math.max(verts[a + u], verts[b + u], verts[c + u]) - min[u]) / cellU)
-            const loV = Math.floor((Math.min(verts[a + v], verts[b + v], verts[c + v]) - min[v]) / cellV)
-            const hiV = Math.floor((Math.max(verts[a + v], verts[b + v], verts[c + v]) - min[v]) / cellV)
-            for (let iu = Math.max(0, loU); iu <= Math.min(SOLIDITY_RESOLUTION - 1, hiU); iu++) {
-                for (let iv = Math.max(0, loV); iv <= Math.min(SOLIDITY_RESOLUTION - 1, hiV); iv++) {
-                    const key = iu * SOLIDITY_RESOLUTION + iv
-                    const bucket = buckets.get(key)
-                    if (bucket) bucket.push(t)
-                    else buckets.set(key, [t])
-                }
-            }
-        }
-
-        for (const [key, tris] of buckets) {
-            // Offset the ray from the cell corner by an irrational-looking fraction so it doesn't
-            // land exactly on a shared edge, where it would be counted twice or not at all.
-            const rayU = min[u] + (Math.floor(key / SOLIDITY_RESOLUTION) + 0.4531) * cellU
-            const rayV = min[v] + ((key % SOLIDITY_RESOLUTION) + 0.6237) * cellV
-            hits.length = 0
-
-            for (const t of tris) {
-                const a = indices[t * 3] * 3
-                const b = indices[t * 3 + 1] * 3
-                const c = indices[t * 3 + 2] * 3
-                const au = verts[a + u]
-                const av = verts[a + v]
-                const bu = verts[b + u]
-                const bv = verts[b + v]
-                const cu = verts[c + u]
-                const cv = verts[c + v]
-                const doubleArea = (bu - au) * (cv - av) - (cu - au) * (bv - av)
-                if (doubleArea === 0) continue
-                const wc = ((bu - au) * (rayV - av) - (rayU - au) * (bv - av)) / doubleArea
-                const wa = ((cu - bu) * (rayV - bv) - (rayU - bu) * (cv - bv)) / doubleArea
-                const wb = ((au - cu) * (rayV - cv) - (rayU - cu) * (av - cv)) / doubleArea
-                if (wa <= 0 || wb <= 0 || wc <= 0) continue
-
-                const ux = verts[b] - verts[a]
-                const uy = verts[b + 1] - verts[a + 1]
-                const uz = verts[b + 2] - verts[a + 2]
-                const vx = verts[c] - verts[a]
-                const vy = verts[c + 1] - verts[a + 1]
-                const vz = verts[c + 2] - verts[a + 2]
-                const normalAlongAxis = [uy * vz - uz * vy, uz * vx - ux * vz, ux * vy - uy * vx][axis]
-                // A triangle edge-on to the ray can't be classified as an entry or an exit.
-                if (normalAlongAxis === 0) continue
-                hits.push([
-                    wa * verts[a + axis] + wb * verts[b + axis] + wc * verts[c + axis],
-                    normalAlongAxis < 0 ? 1 : -1,
-                ])
-            }
-
-            if (hits.length === 0) continue
-            rays++
-            hits.sort((x, y) => x[0] - y[0])
-            let inside = 0
-            for (const [, direction] of hits) {
-                inside += direction
-                // Depth outside {0, 1} means the ray left the solid before entering it, or entered
-                // twice without leaving: the surface crosses itself.
-                if (inside < 0 || inside > 1) {
-                    bad++
-                    inside = -1
-                    break
-                }
-            }
-            if (inside > 0) bad++
-        }
+        const result = countUnsolidRaysOnAxis(axis, verts, indices, bounds)
+        rays += result.rays
+        bad += result.bad
     }
 
     return rays > 0 ? bad / rays : 1
@@ -355,9 +399,7 @@ function isClosedManifold(stats: MeshStats): boolean {
 }
 
 // A simplified mesh is only accepted if it is still a closed, consistently-wound manifold and still
-// occupies the same space as the input. Volume is the sharpest of these: it catches both holes and
-// collapsed thin walls, which surface area on its own does not (a tube whose walls have been merged
-// keeps roughly the right area while losing half its volume).
+// occupies the same space as the input.
 function validate(original: MeshStats, simplified: MeshStats): boolean {
     if (!isClosedManifold(simplified)) return false
     if (simplified.shells !== original.shells) return false
@@ -366,16 +408,15 @@ function validate(original: MeshStats, simplified: MeshStats): boolean {
     if (original.area > 0 && Math.abs(simplified.area - original.area) / original.area > MAX_AREA_DEVIATION) {
         return false
     }
+
     for (let k = 0; k < 3; k++) {
         const extent = original.size[k]
         if (extent > 0 && Math.abs(simplified.size[k] - extent) / extent > MAX_AXIS_DEVIATION) return false
     }
+
     return true
 }
 
-// meshopt's compactMesh() rewrites the index buffer it is handed *in place* and returns the remap it
-// applied, so the remap must not be applied to those indices a second time. Doing so leaves every
-// triangle with three identical indices - a silently invisible mesh.
 function compactVertices(source: Float32Array, indices: Uint32Array): Welded {
     const [remap, uniqueCount] = MeshoptSimplifier.compactMesh(indices)
     const verts = new Float32Array(uniqueCount * 3)
@@ -386,17 +427,11 @@ function compactVertices(source: Float32Array, indices: Uint32Array): Welded {
         verts[out * 3 + 1] = source[i * 3 + 1]
         verts[out * 3 + 2] = source[i * 3 + 2]
     }
+
     return { verts, indices }
 }
 
-// Rebuilds shading data for the decimated mesh. Decimation invalidates STL's per-facet normals, and
-// simply averaging all faces at a vertex rounds off machined edges. Instead, the faces around each
-// vertex are grouped into clusters of similar orientation and each cluster gets its own vertex: a
-// box keeps three crisp normals per corner, a tessellated cylinder keeps one smooth one.
-function buildShadingData({ verts, indices }: Welded): ParsedMesh {
-    const triCount = indices.length / 3
-    const vertCount = verts.length / 3
-
+function computeFaceNormals(verts: Float32Array, indices: Uint32Array, triCount: number): Float32Array {
     const faceNormals = new Float32Array(triCount * 3)
     for (let t = 0; t < triCount; t++) {
         const a = indices[t * 3] * 3
@@ -408,6 +443,7 @@ function buildShadingData({ verts, indices }: Welded): ParsedMesh {
         const vx = verts[c] - verts[a]
         const vy = verts[c + 1] - verts[a + 1]
         const vz = verts[c + 2] - verts[a + 2]
+
         // Left unnormalized: the magnitude is twice the triangle area, which is exactly the weight
         // we want when averaging a cluster.
         faceNormals[t * 3] = uy * vz - uz * vy
@@ -415,7 +451,16 @@ function buildShadingData({ verts, indices }: Welded): ParsedMesh {
         faceNormals[t * 3 + 2] = ux * vy - uy * vx
     }
 
-    // Incident faces per vertex, CSR-style.
+    return faceNormals
+}
+
+interface IncidentFaces {
+    offsets: Uint32Array
+    incident: Uint32Array
+}
+
+// Incident faces per vertex, CSR-style.
+function buildIncidentFacesCSR(indices: Uint32Array, vertCount: number, triCount: number): IncidentFaces {
     const offsets = new Uint32Array(vertCount + 1)
     for (let i = 0; i < indices.length; i++) offsets[indices[i] + 1]++
     for (let i = 0; i < vertCount; i++) offsets[i + 1] += offsets[i]
@@ -425,58 +470,97 @@ function buildShadingData({ verts, indices }: Welded): ParsedMesh {
         for (let k = 0; k < 3; k++) incident[cursor[indices[t * 3 + k]]++] = t
     }
 
+    return { offsets, incident }
+}
+
+// Groups the faces around one vertex into clusters of similar orientation (within CREASE_COS) and
+// appends one output vertex/normal per cluster, then repoints each face's corner index at that
+// cluster
+function clusterFacesAroundVertex(
+    v: number,
+    verts: Float32Array,
+    indices: Uint32Array,
+    faceNormals: Float32Array,
+    { offsets, incident }: IncidentFaces,
+    clusterOf: Int32Array,
+    outVerts: number[],
+    outNormals: number[],
+    outIndices: Uint32Array
+): void {
+    const start = offsets[v]
+    const end = offsets[v + 1]
+    for (let i = start; i < end; i++) clusterOf[incident[i]] = -1
+
+    for (let i = start; i < end; i++) {
+        const seed = incident[i]
+        if (clusterOf[seed] !== -1) continue
+        const sx = faceNormals[seed * 3]
+        const sy = faceNormals[seed * 3 + 1]
+        const sz = faceNormals[seed * 3 + 2]
+        const seedLen = Math.hypot(sx, sy, sz) || 1
+
+        const newIndex = outVerts.length / 3
+        let nx = 0
+        let ny = 0
+        let nz = 0
+        for (let j = i; j < end; j++) {
+            const face = incident[j]
+            if (clusterOf[face] !== -1) continue
+            const fx = faceNormals[face * 3]
+            const fy = faceNormals[face * 3 + 1]
+            const fz = faceNormals[face * 3 + 2]
+            const faceLen = Math.hypot(fx, fy, fz) || 1
+            const alignment = (sx * fx + sy * fy + sz * fz) / (seedLen * faceLen)
+            if (alignment < CREASE_COS) continue
+            clusterOf[face] = newIndex
+            nx += fx
+            ny += fy
+            nz += fz
+            for (let k = 0; k < 3; k++) {
+                if (indices[face * 3 + k] === v) outIndices[face * 3 + k] = newIndex
+            }
+        }
+
+        const len = Math.hypot(nx, ny, nz) || 1
+        outVerts.push(verts[v * 3], verts[v * 3 + 1], verts[v * 3 + 2])
+        outNormals.push(nx / len, ny / len, nz / len)
+    }
+}
+
+// Rebuilds shading data for the decimated mesh. Decimation invalidates STL's per-facet normals, and
+// simply averaging all faces at a vertex rounds off machined edges. Instead, the faces around each
+// vertex are grouped into clusters of similar orientation and each cluster gets its own vertex (see
+// clusterFacesAroundVertex above).
+function buildShadingData({ verts, indices }: Welded): ParsedMesh {
+    const triCount = indices.length / 3
+    const vertCount = verts.length / 3
+
+    const faceNormals = computeFaceNormals(verts, indices, triCount)
+    const incidentFaces = buildIncidentFacesCSR(indices, vertCount, triCount)
+
     const outVerts: number[] = []
     const outNormals: number[] = []
     const outIndices = new Uint32Array(indices.length)
     const clusterOf = new Int32Array(triCount).fill(-1)
 
     for (let v = 0; v < vertCount; v++) {
-        const start = offsets[v]
-        const end = offsets[v + 1]
-        for (let i = start; i < end; i++) clusterOf[incident[i]] = -1
-
-        for (let i = start; i < end; i++) {
-            const seed = incident[i]
-            if (clusterOf[seed] !== -1) continue
-            const sx = faceNormals[seed * 3]
-            const sy = faceNormals[seed * 3 + 1]
-            const sz = faceNormals[seed * 3 + 2]
-            const seedLen = Math.hypot(sx, sy, sz) || 1
-
-            const newIndex = outVerts.length / 3
-            let nx = 0
-            let ny = 0
-            let nz = 0
-            for (let j = i; j < end; j++) {
-                const face = incident[j]
-                if (clusterOf[face] !== -1) continue
-                const fx = faceNormals[face * 3]
-                const fy = faceNormals[face * 3 + 1]
-                const fz = faceNormals[face * 3 + 2]
-                const faceLen = Math.hypot(fx, fy, fz) || 1
-                const alignment = (sx * fx + sy * fy + sz * fz) / (seedLen * faceLen)
-                if (alignment < CREASE_COS) continue
-                clusterOf[face] = newIndex
-                nx += fx
-                ny += fy
-                nz += fz
-                for (let k = 0; k < 3; k++) {
-                    if (indices[face * 3 + k] === v) outIndices[face * 3 + k] = newIndex
-                }
-            }
-
-            const len = Math.hypot(nx, ny, nz) || 1
-            outVerts.push(verts[v * 3], verts[v * 3 + 1], verts[v * 3 + 2])
-            outNormals.push(nx / len, ny / len, nz / len)
-        }
+        clusterFacesAroundVertex(
+            v,
+            verts,
+            indices,
+            faceNormals,
+            incidentFaces,
+            clusterOf,
+            outVerts,
+            outNormals,
+            outIndices
+        )
     }
 
     return {
         verts: Float32Array.from(outVerts),
         normals: Float32Array.from(outNormals),
-        // STL carries no UV data; URDFConverter substitutes a shared zero-UV buffer sized to the
-        // final vertex count, so leaving this empty is what it expects.
-        uv: new Float32Array(0),
+        uv: new Float32Array(0), // STL carries no UV data
         indices: outIndices,
     }
 }

--- a/fission/src/urdf/MeshDecimation.ts
+++ b/fission/src/urdf/MeshDecimation.ts
@@ -17,7 +17,12 @@ const TRIANGLE_THRESHOLD = 2000
 //
 // Bottom rungs exist for hardware like screws. Some of these parts have measured over 100k triangles
 // regardless of how small they are so it's worth waking down to 0.03mm to avoid skipping those meshes.
-const ERROR_BUDGETS_M = [0.0005, 0.00025, 0.000125, 0.0000625, 0.00003125]
+//
+// The bottommost rung (0.0156mm) is glTF-specific headroom: Onshape's glTF exporter tessellates
+// denser than its STL exporter, so precision-detail parts (small ball bearings, PCB-like boards) can
+// still be well outside MAX_VOLUME_DEVIATION at 0.03mm. Confirmed via why-rejected.mjs that these
+// parts converge exactly one rung down instead of needing a different budgeting model.
+const ERROR_BUDGETS_M = [0.0005, 0.00025, 0.000125, 0.0000625, 0.00003125, 0.000015625]
 // ...but never spend more error than this fraction of the part's own bounding-box diagonal, so a
 // 5mm spacer isn't handed a budget the size of itself.
 const RELATIVE_BUDGET_CAP = 0.01

--- a/fission/src/urdf/MeshDecimation.ts
+++ b/fission/src/urdf/MeshDecimation.ts
@@ -2,26 +2,19 @@ import { MeshoptSimplifier } from "meshoptimizer"
 import type { ParsedMesh } from "./STLParser"
 
 // Mesh decimation for URDF STL/OBJ/glTF imports.
-// This decimation step takes the 2026 kitbot import size from 3.11GB to 117MB.
-
 // Every result is checked against the input (see validate()) and the original mesh is returned
-// unchanged if anything looks off. Correctness beats memory savings here.
+// unchanged if anything looks off, this is a reasonably conservative decimation step.
 
 // Below this triangle count the mesh is already cheap; leave it alone.
 const TRIANGLE_THRESHOLD = 2000
 
-// Absolute error budgets in metres 
+// Absolute error budgets in metres
 //
 // These are calibrated values from the 2026 FRC kitbot. These values keep the measured surface
 // within 0.5mm of the original while still having a triangle reduction count of about 87.1%.
 //
 // Bottom rungs exist for hardware like screws. Some of these parts have measured over 100k triangles
 // regardless of how small they are so it's worth waking down to 0.03mm to avoid skipping those meshes.
-//
-// The bottommost rung (0.0156mm) is glTF-specific headroom: Onshape's glTF exporter tessellates
-// denser than its STL exporter, so precision-detail parts (small ball bearings, PCB-like boards) can
-// still be well outside MAX_VOLUME_DEVIATION at 0.03mm. Confirmed via why-rejected.mjs that these
-// parts converge exactly one rung down instead of needing a different budgeting model.
 const ERROR_BUDGETS_M = [0.0005, 0.00025, 0.000125, 0.0000625, 0.00003125, 0.000015625]
 // ...but never spend more error than this fraction of the part's own bounding-box diagonal, so a
 // 5mm spacer isn't handed a budget the size of itself.
@@ -57,10 +50,7 @@ export async function readyMeshDecimation(): Promise<void> {
 interface Welded {
     verts: Float32Array
     indices: Uint32Array
-    /** Per-vertex UV, 2 floats per entry in `verts`. Zero-length when the source mesh carries no UV
-     * (STL, or a glTF/OBJ mesh with no texture coordinates) - skipped rather than carried as zeros
-     * so the STL path does no extra work. */
-    uv: Float32Array
+    uv: Float32Array // Zero length with the source mesh caries no UV
 }
 
 // Collapses bit-identical positions into a compacted vertex buffer and reindexes
@@ -95,6 +85,14 @@ function weldPositions(mesh: ParsedMesh): Welded {
     return { verts, indices, uv }
 }
 
+function cross(ax: number, ay: number, az: number, bx: number, by: number, bz: number): [number, number, number] {
+    return [ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx]
+}
+
+function dot(ax: number, ay: number, az: number, bx: number, by: number, bz: number): number {
+    return ax * bx + ay * by + az * bz
+}
+
 // Drops triangles with a repeated index or zero cross-product area from the triangle list.
 function stripDegenerateTriangles(mesh: Welded): Welded {
     const { verts, indices } = mesh
@@ -114,9 +112,7 @@ function stripDegenerateTriangles(mesh: Welded): Welded {
         const vx = verts[c] - verts[a]
         const vy = verts[c + 1] - verts[a + 1]
         const vz = verts[c + 2] - verts[a + 2]
-        const nx = uy * vz - uz * vy
-        const ny = uz * vx - ux * vz
-        const nz = ux * vy - uy * vx
+        const [nx, ny, nz] = cross(ux, uy, uz, vx, vy, vz)
         if (Math.hypot(nx, ny, nz) === 0) continue
 
         kept.push(i0, i1, i2)
@@ -155,6 +151,7 @@ function countShells(indices: Uint32Array, vertCount: number): number {
             parent[x] = parent[parent[x]]
             x = parent[x]
         }
+
         return x
     }
 
@@ -183,7 +180,7 @@ interface EdgeStats {
 }
 
 // Walks every triangle once, accumulating signed area/volume and edge-adjacency counts. Edge keys
-// are packed as `a * vertCount + b`
+// are packed as `u * vertCount + v`
 function collectEdgeStats(verts: Float32Array, indices: Uint32Array, vertCount: number): EdgeStats {
     let area = 0
     let volume = 0
@@ -210,9 +207,7 @@ function collectEdgeStats(verts: Float32Array, indices: Uint32Array, vertCount: 
         const vx = verts[c] - verts[a]
         const vy = verts[c + 1] - verts[a + 1]
         const vz = verts[c + 2] - verts[a + 2]
-        const nx = uy * vz - uz * vy
-        const ny = uz * vx - ux * vz
-        const nz = ux * vy - uy * vx
+        const [nx, ny, nz] = cross(ux, uy, uz, vx, vy, vz)
         const twiceArea = Math.hypot(nx, ny, nz)
         if (twiceArea === 0) {
             degenerateTriangles++
@@ -220,11 +215,9 @@ function collectEdgeStats(verts: Float32Array, indices: Uint32Array, vertCount: 
         }
 
         area += 0.5 * twiceArea
-        volume +=
-            (verts[a] * (verts[b + 1] * verts[c + 2] - verts[b + 2] * verts[c + 1]) -
-                verts[a + 1] * (verts[b] * verts[c + 2] - verts[b + 2] * verts[c]) +
-                verts[a + 2] * (verts[b] * verts[c + 1] - verts[b + 1] * verts[c])) /
-            6
+        // Signed tetrahedron volume of (origin, a, b, c) = dot(a, cross(b, c)) / 6.
+        const [cbx, cby, cbz] = cross(verts[b], verts[b + 1], verts[b + 2], verts[c], verts[c + 1], verts[c + 2])
+        volume += dot(verts[a], verts[a + 1], verts[a + 2], cbx, cby, cbz) / 6
 
         for (const [u, v] of [
             [i0, i1],
@@ -367,10 +360,7 @@ function castRay(
         const vz = verts[c + 2] - verts[a + 2]
         const normalAlongAxis = [uy * vz - uz * vy, uz * vx - ux * vz, ux * vy - uy * vx][axis]
         if (normalAlongAxis === 0) continue
-        hits.push([
-            wa * verts[a + axis] + wb * verts[b + axis] + wc * verts[c + axis],
-            normalAlongAxis < 0 ? 1 : -1,
-        ])
+        hits.push([wa * verts[a + axis] + wb * verts[b + axis] + wc * verts[c + axis], normalAlongAxis < 0 ? 1 : -1])
     }
 
     return hits
@@ -421,14 +411,14 @@ function countUnsolidRaysOnAxis(
 }
 
 // Sweeps a grid of parallel rays down each axis and checks that every ray's surface crossings
-// alternate enter/exit/enter/exit. 
+// alternate enter/exit/enter/exit.
 //
 // This can be a very expensive check to run however its needed. Every other lightweight check
 // that fully covers a venn diagram of different failure modes simply can't replace this validation step.
 //
 // Every cheap check could be happy, on a small doubly-curved thin feature the simplified surface could fold
-// through itself, which keeps the mesh a closed, consistently-wound manifold with the correct volume, 
-// area and bounding box, and render compleatly wrong as a crumpled partly see-through mess. Volume, 
+// through itself, which keeps the mesh a closed, consistently-wound manifold with the correct volume,
+// area and bounding box, and render compleatly wrong as a crumpled partly see-through mess. Volume,
 // area and dihedral angles all will fail to distinguish it from the orignial geometry
 function unsolidRayRatio({ verts, indices }: Welded): number {
     const bounds = computeIndexedBounds(verts, indices)
@@ -506,9 +496,10 @@ function computeFaceNormals(verts: Float32Array, indices: Uint32Array, triCount:
 
         // Left unnormalized: the magnitude is twice the triangle area, which is exactly the weight
         // we want when averaging a cluster.
-        faceNormals[t * 3] = uy * vz - uz * vy
-        faceNormals[t * 3 + 1] = uz * vx - ux * vz
-        faceNormals[t * 3 + 2] = ux * vy - uy * vx
+        const [nx, ny, nz] = cross(ux, uy, uz, vx, vy, vz)
+        faceNormals[t * 3] = nx
+        faceNormals[t * 3 + 1] = ny
+        faceNormals[t * 3 + 2] = nz
     }
 
     return faceNormals
@@ -658,7 +649,7 @@ export function decimateMesh(mesh: ParsedMesh): ParsedMesh {
     for (const budget of ERROR_BUDGETS_M) {
         const error = Math.min(budget, original.diagonal * RELATIVE_BUDGET_CAP)
         // Target index count is deliberately floored rather than budgeted: the error bound is what
-        // decides how far this goes.
+        // decides how far this goes in terms of simplification depth.
         const [simplified] = MeshoptSimplifier.simplify(welded.indices, welded.verts, 3, 12, error, [
             "ErrorAbsolute",
             "LockBorder",

--- a/fission/src/urdf/MeshDecimation.ts
+++ b/fission/src/urdf/MeshDecimation.ts
@@ -1,0 +1,521 @@
+import { MeshoptSimplifier } from "meshoptimizer"
+import type { ParsedMesh } from "./STLParser"
+
+// Onshape's STL export tessellates every part far finer than a robot simulator needs - a plain
+// rectangular FRC tube stock STL carries 83k triangles for a shape that needs a few hundred. That
+// geometry is baked into the in-memory mirabuf.Assembly and duplicated per <link>, and it doubles
+// as the Jolt collision surface (convex hull for dynamic bodies, concave BVH mesh for static
+// ones), so it costs memory twice and shape-build time on top.
+//
+// Two things make this tricky, and both bit earlier attempts at this file:
+//
+// 1. STL is a triangle *soup* - every triangle owns its own 3 vertices, even where they coincide
+//    exactly with a neighbour's. meshoptimizer builds its own position remap internally and treats
+//    vertices that share a position as attribute "wedges"; a position with 3+ wedges is classified
+//    as locked and can never be collapsed. Every vertex of a soup mesh has one wedge per incident
+//    triangle, so *every* vertex ends up locked and simplify() returns the mesh untouched. Passing
+//    a remapped index buffer is not enough - the duplicate positions must be gone from the vertex
+//    buffer too, otherwise the internal remap still sees them. Hence weldPositions() below returns
+//    a compacted buffer, not just a remap.
+//
+// 2. Triangle count is the wrong thing to ask for. Asking for "2% of the original triangles" on the
+//    tube above collapses its 1.6mm walls: the result measured 47% of the original volume with 350
+//    non-manifold and 700 wrongly-wound edges. Instead we give the simplifier an *absolute*
+//    geometric error budget (ErrorAbsolute) and let it stop wherever that budget runs out, then
+//    verify the result independently. Thin features survive because collapsing them costs more
+//    error than the budget allows.
+//
+// Every result is checked against the input (see validate()) and the original mesh is returned
+// unchanged if anything looks off. Correctness beats memory savings here.
+
+// Below this triangle count the mesh is already cheap; leave it alone.
+const TRIANGLE_THRESHOLD = 2000
+// Absolute error budgets, in metres (URDF geometry is metric; the metres->cm scale happens later in
+// URDFConverter). Tried loosest-first, stopping at the first result that passes validation.
+//
+// These are calibrated, not guessed. meshopt's error metric is a quadric estimate, not a true
+// Hausdorff bound: measured against the original surface it undershoots by up to ~3.5x, so a 0.5mm
+// budget is what actually keeps worst-case surface deviation under ~2mm across both sample kits
+// (scripts/urdf-mem-debug/sweep-kits.mjs measures this directly - rerun it if these change).
+//
+// The bottom rungs exist for hardware: an FRC kit's heaviest STLs by triangle count are often
+// screws (one file measured 111k triangles for a handful of button-head bolts), and a budget sized
+// for a chassis tube eats a screw's thread and head taper - measurably, 15-20% of its volume. Those
+// parts still give up 75-85% of their triangles once the budget is small enough to leave the threads
+// alone, so it's worth walking down to 0.03mm rather than skipping them.
+const ERROR_BUDGETS_M = [0.0005, 0.00025, 0.000125, 0.0000625, 0.00003125]
+// ...but never spend more error than this fraction of the part's own bounding-box diagonal, so a
+// 5mm spacer isn't handed a budget the size of itself.
+const RELATIVE_BUDGET_CAP = 0.01
+// Rejection thresholds for the simplified result, all measured against the welded input.
+const MAX_VOLUME_DEVIATION = 0.03
+const MAX_AREA_DEVIATION = 0.1
+const MAX_AXIS_DEVIATION = 0.01
+// Rays per axis for the solidity probe below, and the share of them allowed to come back
+// inconsistent. Measured separation is wide: meshes with a folded surface score 0.4-1.7% while clean
+// ones score 0-0.02% (the handful of non-zero rays on a clean mesh are ones that graze an edge).
+const SOLIDITY_RESOLUTION = 64
+const MAX_UNSOLID_RAY_RATIO = 0.001
+// Rebuilding the vertex/normal/index buffers isn't free, so don't bother for a marginal win.
+const MIN_REDUCTION = 0.25
+// Faces meeting at a sharper angle than this get split normals, so a machined edge stays crisp
+// while a tessellated cylinder still shades smoothly at the reduced triangle count.
+const CREASE_COS = Math.cos((35 * Math.PI) / 180)
+
+export async function readyMeshDecimation(): Promise<void> {
+    await MeshoptSimplifier.ready
+}
+
+interface Welded {
+    verts: Float32Array
+    indices: Uint32Array
+}
+
+// Collapses bit-identical positions into a compacted vertex buffer and reindexes. Exact comparison
+// is enough in practice: on every Onshape STL checked, an exact weld already produces a closed,
+// consistently-wound manifold (a tolerance-based weld found no additional merges), because the
+// tessellator emits the same float bits for a shared corner in every facet that touches it.
+function weldPositions(mesh: ParsedMesh): Welded {
+    const remap = MeshoptSimplifier.generatePositionRemap(mesh.verts, 3)
+    const sourceVertCount = mesh.verts.length / 3
+    const compacted = new Uint32Array(sourceVertCount)
+    let uniqueCount = 0
+    for (let i = 0; i < sourceVertCount; i++) {
+        if (remap[i] === i) compacted[i] = uniqueCount++
+    }
+
+    const verts = new Float32Array(uniqueCount * 3)
+    for (let i = 0; i < sourceVertCount; i++) {
+        if (remap[i] !== i) continue
+        const out = compacted[i] * 3
+        verts[out] = mesh.verts[i * 3]
+        verts[out + 1] = mesh.verts[i * 3 + 1]
+        verts[out + 2] = mesh.verts[i * 3 + 2]
+    }
+
+    const indices = new Uint32Array(mesh.indices.length)
+    for (let i = 0; i < indices.length; i++) indices[i] = compacted[remap[mesh.indices[i]]]
+
+    return { verts, indices }
+}
+
+interface MeshStats {
+    /** Surface area. */
+    area: number
+    /** Divergence-theorem volume - only meaningful on a closed surface, which is the point: a hole
+     * or a flipped patch shows up as a volume that no longer matches. */
+    volume: number
+    /** Per-axis bounding box extent. */
+    size: [number, number, number]
+    /** Bounding box diagonal. */
+    diagonal: number
+    /** Edges used by exactly one triangle: holes. */
+    boundaryEdges: number
+    /** Edges used by three or more triangles: pinched/self-touching surface. */
+    nonManifoldEdges: number
+    /** Directed edges traversed twice: neighbouring triangles wound opposite ways. */
+    reversedEdges: number
+    /** Triangles with a repeated index or zero area. */
+    degenerateTriangles: number
+    /** Connected shells. Onshape parts are routinely multi-body (a shaft plus its retaining ring);
+     * fusing two of them together is the "merges features that are spatially close but
+     * topologically disjoint" failure mode, and it shows up here as a drop. */
+    shells: number
+}
+
+function countShells(indices: Uint32Array, vertCount: number): number {
+    const parent = new Uint32Array(vertCount)
+    for (let i = 0; i < vertCount; i++) parent[i] = i
+    const find = (x: number): number => {
+        while (parent[x] !== x) {
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        }
+        return x
+    }
+    const used = new Uint8Array(vertCount)
+    for (let i = 0; i < indices.length; i += 3) {
+        for (let k = 0; k < 3; k++) used[indices[i + k]] = 1
+        for (let k = 1; k < 3; k++) {
+            const a = find(indices[i])
+            const b = find(indices[i + k])
+            if (a !== b) parent[a] = b
+        }
+    }
+    const roots = new Set<number>()
+    for (let i = 0; i < vertCount; i++) if (used[i]) roots.add(find(i))
+    return roots.size
+}
+
+function measure({ verts, indices }: Welded): MeshStats {
+    const vertCount = verts.length / 3
+    const min = [Infinity, Infinity, Infinity]
+    const max = [-Infinity, -Infinity, -Infinity]
+    let area = 0
+    let volume = 0
+    let degenerateTriangles = 0
+
+    // Edge keys are packed as `a * vertCount + b`, which stays exact in a double for any vertex
+    // count a browser could hold.
+    const undirected = new Map<number, number>()
+    const directed = new Set<number>()
+    let reversedEdges = 0
+
+    for (let t = 0; t < indices.length; t += 3) {
+        const i0 = indices[t]
+        const i1 = indices[t + 1]
+        const i2 = indices[t + 2]
+        if (i0 === i1 || i1 === i2 || i0 === i2) {
+            degenerateTriangles++
+            continue
+        }
+
+        const a = i0 * 3
+        const b = i1 * 3
+        const c = i2 * 3
+        const ux = verts[b] - verts[a]
+        const uy = verts[b + 1] - verts[a + 1]
+        const uz = verts[b + 2] - verts[a + 2]
+        const vx = verts[c] - verts[a]
+        const vy = verts[c + 1] - verts[a + 1]
+        const vz = verts[c + 2] - verts[a + 2]
+        const nx = uy * vz - uz * vy
+        const ny = uz * vx - ux * vz
+        const nz = ux * vy - uy * vx
+        const twiceArea = Math.hypot(nx, ny, nz)
+        if (twiceArea === 0) {
+            degenerateTriangles++
+            continue
+        }
+        area += 0.5 * twiceArea
+        volume +=
+            (verts[a] * (verts[b + 1] * verts[c + 2] - verts[b + 2] * verts[c + 1]) -
+                verts[a + 1] * (verts[b] * verts[c + 2] - verts[b + 2] * verts[c]) +
+                verts[a + 2] * (verts[b] * verts[c + 1] - verts[b + 1] * verts[c])) /
+            6
+
+        for (const [u, v] of [
+            [i0, i1],
+            [i1, i2],
+            [i2, i0],
+        ]) {
+            const forward = u * vertCount + v
+            if (directed.has(forward)) reversedEdges++
+            else directed.add(forward)
+            const key = u < v ? forward : v * vertCount + u
+            undirected.set(key, (undirected.get(key) ?? 0) + 1)
+        }
+    }
+
+    for (let i = 0; i < vertCount; i++) {
+        for (let k = 0; k < 3; k++) {
+            const value = verts[i * 3 + k]
+            if (value < min[k]) min[k] = value
+            if (value > max[k]) max[k] = value
+        }
+    }
+
+    let boundaryEdges = 0
+    let nonManifoldEdges = 0
+    for (const count of undirected.values()) {
+        if (count === 1) boundaryEdges++
+        else if (count > 2) nonManifoldEdges++
+    }
+
+    const size: [number, number, number] = [max[0] - min[0], max[1] - min[1], max[2] - min[2]]
+    return {
+        area,
+        volume,
+        size,
+        diagonal: Math.hypot(size[0], size[1], size[2]),
+        boundaryEdges,
+        nonManifoldEdges,
+        reversedEdges,
+        degenerateTriangles,
+        shells: countShells(indices, vertCount),
+    }
+}
+
+// Sweeps a grid of parallel rays down each axis and checks that every ray's surface crossings
+// alternate enter/exit/enter/exit. That is the one property edge collapse can break while leaving
+// every cheap check happy: on small doubly-curved thin features (a nylock nut's nylon insert crown
+// was the case that found this) the simplified surface folds through itself, which keeps the mesh a
+// closed, consistently-wound manifold with the correct volume, area and bounding box - and renders
+// as a crumpled, partly see-through mess. Volume, area and dihedral angles all fail to distinguish
+// it; ray parity separates it by more than an order of magnitude.
+function unsolidRayRatio({ verts, indices }: Welded): number {
+    const min = [Infinity, Infinity, Infinity]
+    const max = [-Infinity, -Infinity, -Infinity]
+    for (let i = 0; i < indices.length; i++) {
+        for (let k = 0; k < 3; k++) {
+            const value = verts[indices[i] * 3 + k]
+            if (value < min[k]) min[k] = value
+            if (value > max[k]) max[k] = value
+        }
+    }
+
+    const triCount = indices.length / 3
+    let rays = 0
+    let bad = 0
+    const hits: Array<[number, number]> = []
+
+    for (let axis = 0; axis < 3; axis++) {
+        const u = (axis + 1) % 3
+        const v = (axis + 2) % 3
+        const cellU = (max[u] - min[u]) / SOLIDITY_RESOLUTION
+        const cellV = (max[v] - min[v]) / SOLIDITY_RESOLUTION
+        if (!(cellU > 0) || !(cellV > 0)) continue
+
+        const buckets = new Map<number, number[]>()
+        for (let t = 0; t < triCount; t++) {
+            const a = indices[t * 3] * 3
+            const b = indices[t * 3 + 1] * 3
+            const c = indices[t * 3 + 2] * 3
+            const loU = Math.floor((Math.min(verts[a + u], verts[b + u], verts[c + u]) - min[u]) / cellU)
+            const hiU = Math.floor((Math.max(verts[a + u], verts[b + u], verts[c + u]) - min[u]) / cellU)
+            const loV = Math.floor((Math.min(verts[a + v], verts[b + v], verts[c + v]) - min[v]) / cellV)
+            const hiV = Math.floor((Math.max(verts[a + v], verts[b + v], verts[c + v]) - min[v]) / cellV)
+            for (let iu = Math.max(0, loU); iu <= Math.min(SOLIDITY_RESOLUTION - 1, hiU); iu++) {
+                for (let iv = Math.max(0, loV); iv <= Math.min(SOLIDITY_RESOLUTION - 1, hiV); iv++) {
+                    const key = iu * SOLIDITY_RESOLUTION + iv
+                    const bucket = buckets.get(key)
+                    if (bucket) bucket.push(t)
+                    else buckets.set(key, [t])
+                }
+            }
+        }
+
+        for (const [key, tris] of buckets) {
+            // Offset the ray from the cell corner by an irrational-looking fraction so it doesn't
+            // land exactly on a shared edge, where it would be counted twice or not at all.
+            const rayU = min[u] + (Math.floor(key / SOLIDITY_RESOLUTION) + 0.4531) * cellU
+            const rayV = min[v] + ((key % SOLIDITY_RESOLUTION) + 0.6237) * cellV
+            hits.length = 0
+
+            for (const t of tris) {
+                const a = indices[t * 3] * 3
+                const b = indices[t * 3 + 1] * 3
+                const c = indices[t * 3 + 2] * 3
+                const au = verts[a + u]
+                const av = verts[a + v]
+                const bu = verts[b + u]
+                const bv = verts[b + v]
+                const cu = verts[c + u]
+                const cv = verts[c + v]
+                const doubleArea = (bu - au) * (cv - av) - (cu - au) * (bv - av)
+                if (doubleArea === 0) continue
+                const wc = ((bu - au) * (rayV - av) - (rayU - au) * (bv - av)) / doubleArea
+                const wa = ((cu - bu) * (rayV - bv) - (rayU - bu) * (cv - bv)) / doubleArea
+                const wb = ((au - cu) * (rayV - cv) - (rayU - cu) * (av - cv)) / doubleArea
+                if (wa <= 0 || wb <= 0 || wc <= 0) continue
+
+                const ux = verts[b] - verts[a]
+                const uy = verts[b + 1] - verts[a + 1]
+                const uz = verts[b + 2] - verts[a + 2]
+                const vx = verts[c] - verts[a]
+                const vy = verts[c + 1] - verts[a + 1]
+                const vz = verts[c + 2] - verts[a + 2]
+                const normalAlongAxis = [uy * vz - uz * vy, uz * vx - ux * vz, ux * vy - uy * vx][axis]
+                // A triangle edge-on to the ray can't be classified as an entry or an exit.
+                if (normalAlongAxis === 0) continue
+                hits.push([
+                    wa * verts[a + axis] + wb * verts[b + axis] + wc * verts[c + axis],
+                    normalAlongAxis < 0 ? 1 : -1,
+                ])
+            }
+
+            if (hits.length === 0) continue
+            rays++
+            hits.sort((x, y) => x[0] - y[0])
+            let inside = 0
+            for (const [, direction] of hits) {
+                inside += direction
+                // Depth outside {0, 1} means the ray left the solid before entering it, or entered
+                // twice without leaving: the surface crosses itself.
+                if (inside < 0 || inside > 1) {
+                    bad++
+                    inside = -1
+                    break
+                }
+            }
+            if (inside > 0) bad++
+        }
+    }
+
+    return rays > 0 ? bad / rays : 1
+}
+
+function isClosedManifold(stats: MeshStats): boolean {
+    return (
+        stats.boundaryEdges === 0 &&
+        stats.nonManifoldEdges === 0 &&
+        stats.reversedEdges === 0 &&
+        stats.degenerateTriangles === 0
+    )
+}
+
+// A simplified mesh is only accepted if it is still a closed, consistently-wound manifold and still
+// occupies the same space as the input. Volume is the sharpest of these: it catches both holes and
+// collapsed thin walls, which surface area on its own does not (a tube whose walls have been merged
+// keeps roughly the right area while losing half its volume).
+function validate(original: MeshStats, simplified: MeshStats): boolean {
+    if (!isClosedManifold(simplified)) return false
+    if (simplified.shells !== original.shells) return false
+    if (original.volume <= 0) return false
+    if (Math.abs(simplified.volume - original.volume) / original.volume > MAX_VOLUME_DEVIATION) return false
+    if (original.area > 0 && Math.abs(simplified.area - original.area) / original.area > MAX_AREA_DEVIATION) {
+        return false
+    }
+    for (let k = 0; k < 3; k++) {
+        const extent = original.size[k]
+        if (extent > 0 && Math.abs(simplified.size[k] - extent) / extent > MAX_AXIS_DEVIATION) return false
+    }
+    return true
+}
+
+// meshopt's compactMesh() rewrites the index buffer it is handed *in place* and returns the remap it
+// applied, so the remap must not be applied to those indices a second time. Doing so leaves every
+// triangle with three identical indices - a silently invisible mesh.
+function compactVertices(source: Float32Array, indices: Uint32Array): Welded {
+    const [remap, uniqueCount] = MeshoptSimplifier.compactMesh(indices)
+    const verts = new Float32Array(uniqueCount * 3)
+    for (let i = 0; i < remap.length; i++) {
+        const out = remap[i]
+        if (out === 0xffffffff) continue
+        verts[out * 3] = source[i * 3]
+        verts[out * 3 + 1] = source[i * 3 + 1]
+        verts[out * 3 + 2] = source[i * 3 + 2]
+    }
+    return { verts, indices }
+}
+
+// Rebuilds shading data for the decimated mesh. Decimation invalidates STL's per-facet normals, and
+// simply averaging all faces at a vertex rounds off machined edges. Instead, the faces around each
+// vertex are grouped into clusters of similar orientation and each cluster gets its own vertex: a
+// box keeps three crisp normals per corner, a tessellated cylinder keeps one smooth one.
+function buildShadingData({ verts, indices }: Welded): ParsedMesh {
+    const triCount = indices.length / 3
+    const vertCount = verts.length / 3
+
+    const faceNormals = new Float32Array(triCount * 3)
+    for (let t = 0; t < triCount; t++) {
+        const a = indices[t * 3] * 3
+        const b = indices[t * 3 + 1] * 3
+        const c = indices[t * 3 + 2] * 3
+        const ux = verts[b] - verts[a]
+        const uy = verts[b + 1] - verts[a + 1]
+        const uz = verts[b + 2] - verts[a + 2]
+        const vx = verts[c] - verts[a]
+        const vy = verts[c + 1] - verts[a + 1]
+        const vz = verts[c + 2] - verts[a + 2]
+        // Left unnormalized: the magnitude is twice the triangle area, which is exactly the weight
+        // we want when averaging a cluster.
+        faceNormals[t * 3] = uy * vz - uz * vy
+        faceNormals[t * 3 + 1] = uz * vx - ux * vz
+        faceNormals[t * 3 + 2] = ux * vy - uy * vx
+    }
+
+    // Incident faces per vertex, CSR-style.
+    const offsets = new Uint32Array(vertCount + 1)
+    for (let i = 0; i < indices.length; i++) offsets[indices[i] + 1]++
+    for (let i = 0; i < vertCount; i++) offsets[i + 1] += offsets[i]
+    const incident = new Uint32Array(indices.length)
+    const cursor = Uint32Array.from(offsets.subarray(0, vertCount))
+    for (let t = 0; t < triCount; t++) {
+        for (let k = 0; k < 3; k++) incident[cursor[indices[t * 3 + k]]++] = t
+    }
+
+    const outVerts: number[] = []
+    const outNormals: number[] = []
+    const outIndices = new Uint32Array(indices.length)
+    const clusterOf = new Int32Array(triCount).fill(-1)
+
+    for (let v = 0; v < vertCount; v++) {
+        const start = offsets[v]
+        const end = offsets[v + 1]
+        for (let i = start; i < end; i++) clusterOf[incident[i]] = -1
+
+        for (let i = start; i < end; i++) {
+            const seed = incident[i]
+            if (clusterOf[seed] !== -1) continue
+            const sx = faceNormals[seed * 3]
+            const sy = faceNormals[seed * 3 + 1]
+            const sz = faceNormals[seed * 3 + 2]
+            const seedLen = Math.hypot(sx, sy, sz) || 1
+
+            const newIndex = outVerts.length / 3
+            let nx = 0
+            let ny = 0
+            let nz = 0
+            for (let j = i; j < end; j++) {
+                const face = incident[j]
+                if (clusterOf[face] !== -1) continue
+                const fx = faceNormals[face * 3]
+                const fy = faceNormals[face * 3 + 1]
+                const fz = faceNormals[face * 3 + 2]
+                const faceLen = Math.hypot(fx, fy, fz) || 1
+                const alignment = (sx * fx + sy * fy + sz * fz) / (seedLen * faceLen)
+                if (alignment < CREASE_COS) continue
+                clusterOf[face] = newIndex
+                nx += fx
+                ny += fy
+                nz += fz
+                for (let k = 0; k < 3; k++) {
+                    if (indices[face * 3 + k] === v) outIndices[face * 3 + k] = newIndex
+                }
+            }
+
+            const len = Math.hypot(nx, ny, nz) || 1
+            outVerts.push(verts[v * 3], verts[v * 3 + 1], verts[v * 3 + 2])
+            outNormals.push(nx / len, ny / len, nz / len)
+        }
+    }
+
+    return {
+        verts: Float32Array.from(outVerts),
+        normals: Float32Array.from(outNormals),
+        // STL carries no UV data; URDFConverter substitutes a shared zero-UV buffer sized to the
+        // final vertex count, so leaving this empty is what it expects.
+        uv: new Float32Array(0),
+        indices: outIndices,
+    }
+}
+
+/**
+ * Reduces an over-tessellated STL mesh under a bounded geometric error budget. Returns the input
+ * mesh unchanged if it is already small, if decimation isn't available, if the source isn't a clean
+ * closed manifold, or if no budget on the ladder produces a result that survives validation.
+ */
+export function decimateMesh(mesh: ParsedMesh): ParsedMesh {
+    const triangleCount = mesh.indices.length / 3
+    if (triangleCount <= TRIANGLE_THRESHOLD || !MeshoptSimplifier.supported) return mesh
+
+    const welded = weldPositions(mesh)
+    const original = measure(welded)
+
+    // Simplifying an already-broken mesh (open shell, self-touching surface) means validation can't
+    // tell what the simplifier did from what was wrong to begin with. Leave those alone.
+    if (!isClosedManifold(original) || original.volume <= 0) return mesh
+
+    for (const budget of ERROR_BUDGETS_M) {
+        const error = Math.min(budget, original.diagonal * RELATIVE_BUDGET_CAP)
+        // Target index count is deliberately floored rather than budgeted: the error bound is what
+        // decides how far this goes.
+        const [simplified] = MeshoptSimplifier.simplify(welded.indices, welded.verts, 3, 12, error, [
+            "ErrorAbsolute",
+            "LockBorder",
+        ])
+        if (simplified.length < 12) continue
+        if (simplified.length / 3 > triangleCount * (1 - MIN_REDUCTION)) continue
+
+        const result = compactVertices(welded.verts, simplified)
+        if (!validate(original, measure(result))) continue
+
+        // This check is very expensive, run it last.
+        if (unsolidRayRatio(result) > MAX_UNSOLID_RAY_RATIO) continue
+
+        return buildShadingData(result)
+    }
+
+    return mesh
+}

--- a/fission/src/urdf/MeshDecimation.ts
+++ b/fission/src/urdf/MeshDecimation.ts
@@ -634,9 +634,7 @@ function buildShadingData({ verts, indices, uv }: Welded): ParsedMesh {
 /**
  * Reduces an over-tessellated mesh under a bounded geometric error budget. Returns the input
  * mesh unchanged if it is already small, if decimation isn't available, if the source isn't a clean
- * closed manifold, or if no budget on the ladder produces a result that survives validation - the
- * ladder is calibrated against STL tessellation density, so a denser glTF/OBJ export of the same
- * part is more likely to fall through every rung and come back untouched (safe, just less reduction).
+ * closed manifold, or if no budget on the ladder produces a result that survives validation.
  */
 export function decimateMesh(mesh: ParsedMesh): ParsedMesh {
     const triangleCount = mesh.indices.length / 3

--- a/fission/src/urdf/MeshDecimation.ts
+++ b/fission/src/urdf/MeshDecimation.ts
@@ -35,6 +35,14 @@ const MAX_AXIS_DEVIATION = 0.01
 const SOLIDITY_RESOLUTION = 64 // grid density per axis
 const MAX_UNSOLID_RAY_RATIO = 0.001 // bad_rays / total_rays. fail any 0.1%
 
+// OBJ writes vertex positions as truncated ASCII decimal text (unlike STL/glTF's full float32
+// precision), so a handful of already-near-degenerate CAD tessellation slivers (chamfers, curve
+// intersections) get two corners rounded to the exact same float and collapse to zero area. These are
+// safe to drop outright. They contribute ~0 area/volume, but only below this fraction of the mesh's
+// triangles, so a real defect (an actual hole, a badly exported part) still bails instead of getting
+// silently patched over.
+const MAX_HEALABLE_DEGENERATE_FRACTION = 0.01
+
 // Rebuilding the vertex/normal/index buffers isn't free, so don't bother for a marginal win.
 const MIN_REDUCTION = 0.25
 
@@ -85,6 +93,36 @@ function weldPositions(mesh: ParsedMesh): Welded {
     for (let i = 0; i < indices.length; i++) indices[i] = compacted[remap[mesh.indices[i]]]
 
     return { verts, indices, uv }
+}
+
+// Drops triangles with a repeated index or zero cross-product area from the triangle list.
+function stripDegenerateTriangles(mesh: Welded): Welded {
+    const { verts, indices } = mesh
+    const kept: number[] = []
+    for (let t = 0; t < indices.length; t += 3) {
+        const i0 = indices[t]
+        const i1 = indices[t + 1]
+        const i2 = indices[t + 2]
+        if (i0 === i1 || i1 === i2 || i0 === i2) continue
+
+        const a = i0 * 3
+        const b = i1 * 3
+        const c = i2 * 3
+        const ux = verts[b] - verts[a]
+        const uy = verts[b + 1] - verts[a + 1]
+        const uz = verts[b + 2] - verts[a + 2]
+        const vx = verts[c] - verts[a]
+        const vy = verts[c + 1] - verts[a + 1]
+        const vz = verts[c + 2] - verts[a + 2]
+        const nx = uy * vz - uz * vy
+        const ny = uz * vx - ux * vz
+        const nz = ux * vy - uy * vx
+        if (Math.hypot(nx, ny, nz) === 0) continue
+
+        kept.push(i0, i1, i2)
+    }
+
+    return { verts, indices: Uint32Array.from(kept), uv: mesh.uv }
 }
 
 interface MeshStats {
@@ -604,8 +642,16 @@ export function decimateMesh(mesh: ParsedMesh): ParsedMesh {
     const triangleCount = mesh.indices.length / 3
     if (triangleCount <= TRIANGLE_THRESHOLD || !MeshoptSimplifier.supported) return mesh
 
-    const welded = weldPositions(mesh)
-    const original = measure(welded)
+    let welded = weldPositions(mesh)
+    let original = measure(welded)
+
+    if (
+        original.degenerateTriangles > 0 &&
+        original.degenerateTriangles / triangleCount <= MAX_HEALABLE_DEGENERATE_FRACTION
+    ) {
+        welded = stripDegenerateTriangles(welded)
+        original = measure(welded)
+    }
 
     // Simplifying an already-broken mesh (open shell, self-touching surface) means validation can't
     // tell what the simplifier did from what was wrong to begin with. Leave those alone.

--- a/fission/src/urdf/URDFConverter.ts
+++ b/fission/src/urdf/URDFConverter.ts
@@ -504,9 +504,6 @@ function parseMesh(meshPath: string, meshFiles: Map<string, Uint8Array>): Parsed
     }
 
     const ext = meshPath.split(".").pop()?.toLowerCase()
-    // Decimation is scoped to STL for now: STL's per-triangle (non-shared) vertices are what was
-    // validated against, and STL's UV is always an all-zero placeholder so there's no real UV data
-    // to lose. OBJ/glTF sources may carry real shared indices/UV and aren't touched here.
     if (ext === "stl") return decimateMesh(parseSTL(data))
     if (ext === "obj") return parseOBJ(data)
     if (ext === "gltf") return parseGLTF(data, meshPath, meshFiles)
@@ -643,9 +640,9 @@ function isCylindricalPhantom(link: URDFLink, parentJoint: URDFJoint): boolean {
     )
 }
 
-// FNV-1a over the raw bytes backing a typed array. Used only to bucket candidates for interning -
-// every hash hit is still verified with a byte-exact comparison before two arrays are treated as
-// the same object, so a hash collision can only cost a cache miss, never an incorrect merge.
+// FNV-1a over raw bytes. Buckets candidates for interning.
+// 0x811c9dc5 / 0x01000193: standard FNV-1a 32-bit offset basis / prime.
+// https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
 function hashTypedArrayBytes(view: ArrayBufferView): number {
     const bytes = new Uint8Array(view.buffer, view.byteOffset, view.byteLength)
     let h = 0x811c9dc5

--- a/fission/src/urdf/URDFConverter.ts
+++ b/fission/src/urdf/URDFConverter.ts
@@ -677,6 +677,7 @@ class GeometryInterner {
                 if (typedArraysEqual(candidate.source, indices)) return candidate.interned
             }
         }
+
         const interned = Array.from(indices)
         const list = bucket ?? []
         list.push({ source: indices, interned })
@@ -702,6 +703,7 @@ class GeometryInterner {
                 }
             }
         }
+
         const entry = { verts, normals }
         const list = bucket ?? []
         list.push(entry)
@@ -770,6 +772,71 @@ function linkGeometrySignature(link: URDFLink): string {
     return `${link.mass}|${link.comXYZ.join(",")}|${visualSig}`
 }
 
+function resolvePartDefinition(
+    link: URDFLink,
+    globalTransform: URDFTransform | undefined,
+    meshFiles: Map<string, Uint8Array>,
+    meshCache: Map<string, ParsedMesh | null>,
+    geometryInterner: GeometryInterner,
+    definitionBySignature: Map<string, string>,
+    partDefinitions: Record<string, mirabuf.IPartDefinition>
+): string {
+    const robotSpaceVisuals = shouldTreatVisualOriginsAsRobotSpace(link, globalTransform, meshFiles, meshCache)
+    const signature = robotSpaceVisuals ? null : linkGeometrySignature(link)
+    const reusedDefinitionName = signature ? definitionBySignature.get(signature) : undefined
+    if (reusedDefinitionName) return reusedDefinitionName
+
+    const bodies = link.visuals
+        .map((visual, index) =>
+            buildLinkBody(
+                link,
+                visual,
+                index,
+                meshFiles,
+                robotSpaceVisuals,
+                meshCache,
+                geometryInterner,
+                globalTransform
+            )
+        )
+        .filter((body): body is mirabuf.IBody => body !== null)
+
+    partDefinitions[link.name] = {
+        info: { GUID: link.name, name: link.name, version: 1 },
+        physicalData: {
+            mass: link.mass,
+            com: positionToYup(link.comXYZ[0], link.comXYZ[1], link.comXYZ[2]),
+        },
+        baseTransform: { spatialMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1] },
+        bodies,
+    }
+
+    if (signature) definitionBySignature.set(signature, link.name)
+    return link.name
+}
+
+function buildPartInstance(
+    link: URDFLink,
+    rootLink: URDFLink,
+    parentJoint: Map<string, URDFJoint>,
+    partDefinitionReference: string
+): mirabuf.IPartInstance {
+    const pj = parentJoint.get(link.name)
+    const spatialMatrix =
+        link === rootLink
+            ? ROOT_SPATIAL_MATRIX
+            : pj
+              ? originToSpatialMatrix(pj.originXYZ, pj.originRPY)
+              : ROOT_SPATIAL_MATRIX
+
+    return {
+        info: { GUID: link.name, name: link.name, version: 1 },
+        partDefinitionReference,
+        transform: { spatialMatrix },
+        appearance: link.visuals[0]?.materialName ?? undefined,
+    }
+}
+
 async function buildParts(
     links: URDFLink[],
     rootLink: URDFLink,
@@ -785,6 +852,7 @@ async function buildParts(
     const parentJoint = new Map<string, URDFJoint>(joints.map(j => [j.child, j]))
     const globalTransforms = buildGlobalLinkTransforms(joints, rootLink.name)
     const meshCache = new Map<string, ParsedMesh | null>()
+
     // Maps a link's geometry signature to the link name whose PartDefinition already covers it.
     const definitionBySignature = new Map<string, string>()
     const geometryInterner = new GeometryInterner()
@@ -801,58 +869,18 @@ async function buildParts(
             progressHandle.update(`Building Parts (${i}/${links.length})`, progress)
             await yieldToMain()
         }
+
         const globalTransform = globalTransforms.get(link.name)
-        const robotSpaceVisuals = shouldTreatVisualOriginsAsRobotSpace(link, globalTransform, meshFiles, meshCache)
-
-        const signature = robotSpaceVisuals ? null : linkGeometrySignature(link)
-        const reusedDefinitionName = signature ? definitionBySignature.get(signature) : undefined
-
-        let partDefinitionReference: string
-        if (reusedDefinitionName) {
-            partDefinitionReference = reusedDefinitionName
-        } else {
-            const bodies = link.visuals
-                .map((visual, index) =>
-                    buildLinkBody(
-                        link,
-                        visual,
-                        index,
-                        meshFiles,
-                        robotSpaceVisuals,
-                        meshCache,
-                        geometryInterner,
-                        globalTransform
-                    )
-                )
-                .filter((body): body is mirabuf.IBody => body !== null)
-
-            partDefinitions[link.name] = {
-                info: { GUID: link.name, name: link.name, version: 1 },
-                physicalData: {
-                    mass: link.mass,
-                    com: positionToYup(link.comXYZ[0], link.comXYZ[1], link.comXYZ[2]),
-                },
-                baseTransform: { spatialMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1] },
-                bodies,
-            }
-            partDefinitionReference = link.name
-            if (signature) definitionBySignature.set(signature, link.name)
-        }
-
-        const pj = parentJoint.get(link.name)
-        const spatialMatrix =
-            link === rootLink
-                ? ROOT_SPATIAL_MATRIX
-                : pj
-                  ? originToSpatialMatrix(pj.originXYZ, pj.originRPY)
-                  : ROOT_SPATIAL_MATRIX
-
-        partInstances[link.name] = {
-            info: { GUID: link.name, name: link.name, version: 1 },
-            partDefinitionReference,
-            transform: { spatialMatrix },
-            appearance: link.visuals[0]?.materialName ?? undefined,
-        }
+        const partDefinitionReference = resolvePartDefinition(
+            link,
+            globalTransform,
+            meshFiles,
+            meshCache,
+            geometryInterner,
+            definitionBySignature,
+            partDefinitions
+        )
+        partInstances[link.name] = buildPartInstance(link, rootLink, parentJoint, partDefinitionReference)
     }
 
     return { partDefinitions, partInstances }

--- a/fission/src/urdf/URDFConverter.ts
+++ b/fission/src/urdf/URDFConverter.ts
@@ -669,19 +669,40 @@ function buildLinkBody(
     const yupNormals = toYup(inLinkFrame.normals)
     const uv = inLinkFrame.uv.length > 0 ? inLinkFrame.uv : new Float32Array((scaled.length / 3) * 2)
 
-    // mirabuf.IMesh (protobuf-generated) requires plain number[]
+    // mirabuf.IMesh types these fields as `number[]`, but every consumer (encode, MirabufInstance,
+    // PhysicsSystem) only ever reads .length/indexed access, so keeping verts/normals/uv as Float32Array
+    // avoids doubling them to 8-byte JS doubles via Array.from. `indices` stays a real array: THREE.js's
+    // BufferGeometry.setIndex does `Array.isArray(index)` and silently mishandles a typed array there.
     return {
         info: { GUID: `${link.name}_body_${index}`, name: `${link.name}_body_${index}` },
         triangleMesh: {
             mesh: {
-                verts: Array.from(scaled),
-                normals: Array.from(yupNormals),
-                uv: Array.from(uv),
+                verts: scaled as unknown as number[],
+                normals: yupNormals as unknown as number[],
+                uv: uv as unknown as number[],
                 indices: Array.from(inLinkFrame.indices),
             },
         },
         appearanceOverride: visual.materialName ?? undefined,
     }
+}
+
+// Onshape kits routinely reuse the same fastener/hardware mesh dozens of times (nuts, screws,
+// bearings...). buildParts used to bake a fresh PartDefinition per <link>, so every repeat baked
+// its own full copy of the mesh. Two links produce byte-identical body geometry whenever their
+// mass/COM and every visual's (mesh, scale, local origin, material) match — the joint-tree
+// placement is applied separately via the PartInstance transform, so it doesn't need to be part
+// of the signature. Robot-space links are excluded: their baked geometry folds in the link's
+// global position (see shouldTreatVisualOriginsAsRobotSpace), so two such links are never
+// byte-identical even when they look alike.
+function linkGeometrySignature(link: URDFLink): string {
+    const visualSig = link.visuals
+        .map(
+            v =>
+                `${v.visualMeshPath ?? ""}|${v.visualMeshScale.join(",")}|${v.visualOriginXYZ.join(",")}|${v.visualOriginRPY.join(",")}|${v.materialName ?? ""}`
+        )
+        .join(";")
+    return `${link.mass}|${link.comXYZ.join(",")}|${visualSig}`
 }
 
 async function buildParts(
@@ -699,6 +720,8 @@ async function buildParts(
     const parentJoint = new Map<string, URDFJoint>(joints.map(j => [j.child, j]))
     const globalTransforms = buildGlobalLinkTransforms(joints, rootLink.name)
     const meshCache = new Map<string, ParsedMesh | null>()
+    // Maps a link's geometry signature to the link name whose PartDefinition already covers it.
+    const definitionBySignature = new Map<string, string>()
 
     const linksPerProgressBarStep = Math.ceil(links.length / 10)
     const progressBarIncrement = (URDFImportProgressBar.BUILD_PARTS - URDFImportProgressBar.LOAD_MESHES) / 10
@@ -715,20 +738,30 @@ async function buildParts(
         const globalTransform = globalTransforms.get(link.name)
         const robotSpaceVisuals = shouldTreatVisualOriginsAsRobotSpace(link, globalTransform, meshFiles, meshCache)
 
-        const bodies = link.visuals
-            .map((visual, index) =>
-                buildLinkBody(link, visual, index, meshFiles, robotSpaceVisuals, meshCache, globalTransform)
-            )
-            .filter((body): body is mirabuf.IBody => body !== null)
+        const signature = robotSpaceVisuals ? null : linkGeometrySignature(link)
+        const reusedDefinitionName = signature ? definitionBySignature.get(signature) : undefined
 
-        partDefinitions[link.name] = {
-            info: { GUID: link.name, name: link.name, version: 1 },
-            physicalData: {
-                mass: link.mass,
-                com: positionToYup(link.comXYZ[0], link.comXYZ[1], link.comXYZ[2]),
-            },
-            baseTransform: { spatialMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1] },
-            bodies,
+        let partDefinitionReference: string
+        if (reusedDefinitionName) {
+            partDefinitionReference = reusedDefinitionName
+        } else {
+            const bodies = link.visuals
+                .map((visual, index) =>
+                    buildLinkBody(link, visual, index, meshFiles, robotSpaceVisuals, meshCache, globalTransform)
+                )
+                .filter((body): body is mirabuf.IBody => body !== null)
+
+            partDefinitions[link.name] = {
+                info: { GUID: link.name, name: link.name, version: 1 },
+                physicalData: {
+                    mass: link.mass,
+                    com: positionToYup(link.comXYZ[0], link.comXYZ[1], link.comXYZ[2]),
+                },
+                baseTransform: { spatialMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1] },
+                bodies,
+            }
+            partDefinitionReference = link.name
+            if (signature) definitionBySignature.set(signature, link.name)
         }
 
         const pj = parentJoint.get(link.name)
@@ -741,7 +774,7 @@ async function buildParts(
 
         partInstances[link.name] = {
             info: { GUID: link.name, name: link.name, version: 1 },
-            partDefinitionReference: link.name,
+            partDefinitionReference,
             transform: { spatialMatrix },
             appearance: link.visuals[0]?.materialName ?? undefined,
         }

--- a/fission/src/urdf/URDFConverter.ts
+++ b/fission/src/urdf/URDFConverter.ts
@@ -505,8 +505,8 @@ function parseMesh(meshPath: string, meshFiles: Map<string, Uint8Array>): Parsed
 
     const ext = meshPath.split(".").pop()?.toLowerCase()
     if (ext === "stl") return decimateMesh(parseSTL(data))
-    if (ext === "obj") return parseOBJ(data)
-    if (ext === "gltf") return parseGLTF(data, meshPath, meshFiles)
+    if (ext === "obj") return decimateMesh(parseOBJ(data))
+    if (ext === "gltf") return decimateMesh(parseGLTF(data, meshPath, meshFiles))
     console.warn(`[URDF] Unsupported mesh format: .${ext} (${meshPath}) — link will have no geometry`)
     return null
 }

--- a/fission/src/urdf/URDFConverter.ts
+++ b/fission/src/urdf/URDFConverter.ts
@@ -664,25 +664,9 @@ function typedArraysEqual(a: ArrayBufferView, b: ArrayBufferView): boolean {
     return true
 }
 
-// Baked body geometry can't be shared across links via a PartDefinition reference the way whole
-// duplicate links can be (see linkGeometrySignature): a collapsed Onshape sub-assembly link bakes
-// each of its parts' true world/robot-space position directly into that part's vertices, so two
-// occurrences of "the same bearing" mounted at two different points on the robot produce genuinely
-// different vertex arrays. But some pieces of a baked body ARE guaranteed identical regardless of
-// position, and every consumer (protobuf encode, MirabufInstance, PhysicsSystem) only ever reads
-// these arrays - none of them mutate or hold onto a reference beyond copying out of it - so it's
-// safe for many Body objects to point at the exact same backing array instead of each allocating
-// their own copy:
-//   - indices: STL has no shared-vertex concept, so `indices` is always the trivial [0..N-1]
-//     sequence for a given triangle count, completely independent of the mesh's identity/position.
-//   - uv: STLParser always returns an all-zero placeholder (no real STL UV data), so for a given
-//     vertex count the "uv" content is always identical - always N zeros - regardless of source.
-//   - verts/normals: not position-independent in general, but two bodies anywhere in the assembly
-//     occasionally do end up byte-identical (e.g. identical sub-parts at the same relative offset
-//     within otherwise-unmergeable collapsed links). Interned as a bonus, not the primary win.
-// Content is still verified byte-exact before sharing (see hashTypedArrayBytes/typedArraysEqual) -
-// this only shares an existing allocation for content already proven identical, it never changes
-// what data ends up in the assembly.
+// Baked geometry bakes world-space position into vertices, so identical parts at different
+// positions produce different arrays; can't dedupe by reference alone. But some fields are
+// position-independent and safe to share across Body objects.
 class GeometryInterner {
     private _indicesByHash = new Map<string, { source: Uint32Array; interned: number[] }[]>()
     private _zeroUvByLength = new Map<number, Float32Array>()
@@ -762,10 +746,6 @@ function buildLinkBody(
     const uv = inLinkFrame.uv.length > 0 ? inLinkFrame.uv : geometryInterner.internZeroUv(vertexCount)
     const interned = geometryInterner.internVertsNormals(scaled, yupNormals)
 
-    // mirabuf.IMesh types these fields as `number[]`, but every consumer (encode, MirabufInstance,
-    // PhysicsSystem) only ever reads .length/indexed access, so keeping verts/normals/uv as Float32Array
-    // avoids doubling them to 8-byte JS doubles via Array.from. `indices` stays a real array: THREE.js's
-    // BufferGeometry.setIndex does `Array.isArray(index)` and silently mishandles a typed array there.
     return {
         info: { GUID: `${link.name}_body_${index}`, name: `${link.name}_body_${index}` },
         triangleMesh: {
@@ -780,14 +760,9 @@ function buildLinkBody(
     }
 }
 
-// Onshape kits routinely reuse the same fastener/hardware mesh dozens of times (nuts, screws,
-// bearings...). buildParts used to bake a fresh PartDefinition per <link>, so every repeat baked
-// its own full copy of the mesh. Two links produce byte-identical body geometry whenever their
-// mass/COM and every visual's (mesh, scale, local origin, material) match — the joint-tree
-// placement is applied separately via the PartInstance transform, so it doesn't need to be part
-// of the signature. Robot-space links are excluded: their baked geometry folds in the link's
-// global position (see shouldTreatVisualOriginsAsRobotSpace), so two such links are never
-// byte-identical even when they look alike.
+// Vendored parts routinely reuse the same fastener/hardware mesh dozens of times.
+// Avoid a full baked copy of each identical mesh. Reuse bype-identical body geometry
+// whereever possible.
 function linkGeometrySignature(link: URDFLink): string {
     const visualSig = link.visuals
         .map(
@@ -1065,10 +1040,7 @@ export async function convertURDF(
         designHierarchy: hierarchy,
         data: {
             parts: { partDefinitions, partInstances, userData: { data: { [URDF_IMPORT_TAG]: "true" } } },
-            // motorDefinitions must be an object: PhysicsSystem.ts:375 indexes it before any null-check
             joints: { jointDefinitions, jointInstances, rigidGroups, motorDefinitions: {} },
-            // appearances must be an object (not undefined/null): loadMaterials calls Object.entries on it
-            // physicalMaterials must be an object (not undefined), an empty map is fine here
             materials: { appearances, physicalMaterials: {} },
         },
     })

--- a/fission/src/urdf/URDFConverter.ts
+++ b/fission/src/urdf/URDFConverter.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid"
 import { mirabuf } from "@/proto/mirabuf"
 import { parseGLTF } from "./GLTFParser"
+import { decimateMesh, readyMeshDecimation } from "./MeshDecimation"
 import { parseOBJ } from "./OBJParser"
 import { parseSTL, type ParsedMesh } from "./STLParser"
 import { URDF_IMPORT_TAG } from "./URDFUserData"
@@ -503,7 +504,10 @@ function parseMesh(meshPath: string, meshFiles: Map<string, Uint8Array>): Parsed
     }
 
     const ext = meshPath.split(".").pop()?.toLowerCase()
-    if (ext === "stl") return parseSTL(data)
+    // Decimation is scoped to STL for now: STL's per-triangle (non-shared) vertices are what was
+    // validated against, and STL's UV is always an all-zero placeholder so there's no real UV data
+    // to lose. OBJ/glTF sources may carry real shared indices/UV and aren't touched here.
+    if (ext === "stl") return decimateMesh(parseSTL(data))
     if (ext === "obj") return parseOBJ(data)
     if (ext === "gltf") return parseGLTF(data, meshPath, meshFiles)
     console.warn(`[URDF] Unsupported mesh format: .${ext} (${meshPath}) — link will have no geometry`)
@@ -639,6 +643,92 @@ function isCylindricalPhantom(link: URDFLink, parentJoint: URDFJoint): boolean {
     )
 }
 
+// FNV-1a over the raw bytes backing a typed array. Used only to bucket candidates for interning -
+// every hash hit is still verified with a byte-exact comparison before two arrays are treated as
+// the same object, so a hash collision can only cost a cache miss, never an incorrect merge.
+function hashTypedArrayBytes(view: ArrayBufferView): number {
+    const bytes = new Uint8Array(view.buffer, view.byteOffset, view.byteLength)
+    let h = 0x811c9dc5
+    for (let i = 0; i < bytes.length; i++) {
+        h ^= bytes[i]
+        h = Math.imul(h, 0x01000193)
+    }
+    return h >>> 0
+}
+
+function typedArraysEqual(a: ArrayBufferView, b: ArrayBufferView): boolean {
+    if (a.byteLength !== b.byteLength) return false
+    const ab = new Uint8Array(a.buffer, a.byteOffset, a.byteLength)
+    const bb = new Uint8Array(b.buffer, b.byteOffset, b.byteLength)
+    for (let i = 0; i < ab.length; i++) if (ab[i] !== bb[i]) return false
+    return true
+}
+
+// Baked body geometry can't be shared across links via a PartDefinition reference the way whole
+// duplicate links can be (see linkGeometrySignature): a collapsed Onshape sub-assembly link bakes
+// each of its parts' true world/robot-space position directly into that part's vertices, so two
+// occurrences of "the same bearing" mounted at two different points on the robot produce genuinely
+// different vertex arrays. But some pieces of a baked body ARE guaranteed identical regardless of
+// position, and every consumer (protobuf encode, MirabufInstance, PhysicsSystem) only ever reads
+// these arrays - none of them mutate or hold onto a reference beyond copying out of it - so it's
+// safe for many Body objects to point at the exact same backing array instead of each allocating
+// their own copy:
+//   - indices: STL has no shared-vertex concept, so `indices` is always the trivial [0..N-1]
+//     sequence for a given triangle count, completely independent of the mesh's identity/position.
+//   - uv: STLParser always returns an all-zero placeholder (no real STL UV data), so for a given
+//     vertex count the "uv" content is always identical - always N zeros - regardless of source.
+//   - verts/normals: not position-independent in general, but two bodies anywhere in the assembly
+//     occasionally do end up byte-identical (e.g. identical sub-parts at the same relative offset
+//     within otherwise-unmergeable collapsed links). Interned as a bonus, not the primary win.
+// Content is still verified byte-exact before sharing (see hashTypedArrayBytes/typedArraysEqual) -
+// this only shares an existing allocation for content already proven identical, it never changes
+// what data ends up in the assembly.
+class GeometryInterner {
+    private _indicesByHash = new Map<string, { source: Uint32Array; interned: number[] }[]>()
+    private _zeroUvByLength = new Map<number, Float32Array>()
+    private _vertNormByHash = new Map<string, { verts: Float32Array; normals: Float32Array }[]>()
+
+    internIndices(indices: Uint32Array): number[] {
+        const key = `${indices.length}_${hashTypedArrayBytes(indices)}`
+        const bucket = this._indicesByHash.get(key)
+        if (bucket) {
+            for (const candidate of bucket) {
+                if (typedArraysEqual(candidate.source, indices)) return candidate.interned
+            }
+        }
+        const interned = Array.from(indices)
+        const list = bucket ?? []
+        list.push({ source: indices, interned })
+        this._indicesByHash.set(key, list)
+        return interned
+    }
+
+    internZeroUv(vertexCount: number): Float32Array {
+        const cached = this._zeroUvByLength.get(vertexCount)
+        if (cached) return cached
+        const fresh = new Float32Array(vertexCount * 2)
+        this._zeroUvByLength.set(vertexCount, fresh)
+        return fresh
+    }
+
+    internVertsNormals(verts: Float32Array, normals: Float32Array): { verts: Float32Array; normals: Float32Array } {
+        const key = `${verts.length}_${hashTypedArrayBytes(verts)}_${hashTypedArrayBytes(normals)}`
+        const bucket = this._vertNormByHash.get(key)
+        if (bucket) {
+            for (const candidate of bucket) {
+                if (typedArraysEqual(candidate.verts, verts) && typedArraysEqual(candidate.normals, normals)) {
+                    return candidate
+                }
+            }
+        }
+        const entry = { verts, normals }
+        const list = bucket ?? []
+        list.push(entry)
+        this._vertNormByHash.set(key, list)
+        return entry
+    }
+}
+
 function buildLinkBody(
     link: URDFLink,
     visual: URDFVisual,
@@ -646,6 +736,7 @@ function buildLinkBody(
     meshFiles: Map<string, Uint8Array>,
     robotSpaceVisuals: boolean,
     meshCache: Map<string, ParsedMesh | null>,
+    geometryInterner: GeometryInterner,
     linkGlobalTransform?: URDFTransform
 ): mirabuf.IBody | null {
     if (!visual.visualMeshPath) return null
@@ -667,7 +758,9 @@ function buildLinkBody(
         scaled[i + 2] = -rv[i + 1] * sz
     }
     const yupNormals = toYup(inLinkFrame.normals)
-    const uv = inLinkFrame.uv.length > 0 ? inLinkFrame.uv : new Float32Array((scaled.length / 3) * 2)
+    const vertexCount = scaled.length / 3
+    const uv = inLinkFrame.uv.length > 0 ? inLinkFrame.uv : geometryInterner.internZeroUv(vertexCount)
+    const interned = geometryInterner.internVertsNormals(scaled, yupNormals)
 
     // mirabuf.IMesh types these fields as `number[]`, but every consumer (encode, MirabufInstance,
     // PhysicsSystem) only ever reads .length/indexed access, so keeping verts/normals/uv as Float32Array
@@ -677,10 +770,10 @@ function buildLinkBody(
         info: { GUID: `${link.name}_body_${index}`, name: `${link.name}_body_${index}` },
         triangleMesh: {
             mesh: {
-                verts: scaled as unknown as number[],
-                normals: yupNormals as unknown as number[],
+                verts: interned.verts as unknown as number[],
+                normals: interned.normals as unknown as number[],
                 uv: uv as unknown as number[],
-                indices: Array.from(inLinkFrame.indices),
+                indices: geometryInterner.internIndices(inLinkFrame.indices),
             },
         },
         appearanceOverride: visual.materialName ?? undefined,
@@ -722,6 +815,7 @@ async function buildParts(
     const meshCache = new Map<string, ParsedMesh | null>()
     // Maps a link's geometry signature to the link name whose PartDefinition already covers it.
     const definitionBySignature = new Map<string, string>()
+    const geometryInterner = new GeometryInterner()
 
     const linksPerProgressBarStep = Math.ceil(links.length / 10)
     const progressBarIncrement = (URDFImportProgressBar.BUILD_PARTS - URDFImportProgressBar.LOAD_MESHES) / 10
@@ -747,7 +841,16 @@ async function buildParts(
         } else {
             const bodies = link.visuals
                 .map((visual, index) =>
-                    buildLinkBody(link, visual, index, meshFiles, robotSpaceVisuals, meshCache, globalTransform)
+                    buildLinkBody(
+                        link,
+                        visual,
+                        index,
+                        meshFiles,
+                        robotSpaceVisuals,
+                        meshCache,
+                        geometryInterner,
+                        globalTransform
+                    )
                 )
                 .filter((body): body is mirabuf.IBody => body !== null)
 
@@ -899,6 +1002,8 @@ export async function convertURDF(
     meshFiles: Map<string, Uint8Array>,
     progressHandle: ProgressHandle
 ): Promise<mirabuf.Assembly> {
+    await readyMeshDecimation()
+
     const doc = new DOMParser().parseFromString(urdfText, "text/xml")
     const parseError = doc.querySelector("parsererror")
     if (parseError) throw new Error(`URDF XML parse error: ${parseError.textContent}`)


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-264

Reduce URDF assembly size and enable caching. 

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

URDF exports contain extremely detailed meshes. Far higher resolution than we would ever need. Certain vendor provided screws that I identified were over 100k triangles when they should have been just a few hundred. 

This caused robots that we really want to support like [2026 Kitbot (download here)](https://github.com/user-attachments/files/30494860/Kitbot.2026.zip) being quite literally Gigabytes post import. 

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Two part solution:

1. Reuse byte-identical meshes such that we avoid carrying redundant copies of meshes (as much as reasonably possible). 
2. Fully implement mesh decimation for all 3 mesh data formats for URDF (STL/Obj/glTF).

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

Import a URDF kitbot. It will preform much much better now, both in terms of import time and in terms of memory usage.

These changes for me took the imported triangle count of 2026 Kitbot from 1.2 million to 150 thousand (91.6% reduction) and took the memory usage from 3.11GB to 117MB.

Confirm URDF OPFS caching works as expected.

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
