### PR TITLE
Use UUID-based scene object IDs `[SYNTH-309]`

### DIFF
--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -8,7 +8,7 @@ import InitialConfigPanel from "@/panels/configuring/initial-config/InitialConfi
 import { PAUSE_REF_ASSEMBLY_SPAWNING } from "@/systems/physics/PhysicsTypes.ts"
 import { createMirabuf } from "@/mirabuf/MirabufSceneObject.ts"
 import { getTargetControls } from "@/systems/scene/CameraControls.ts"
-import type { EncodedAssembly, LocalSceneObjectId, Message, RemoteSceneObjectId } from "@/systems/multiplayer/types.ts"
+import type { EncodedAssembly, Message } from "@/systems/multiplayer/types.ts"
 import { ProgressHandle } from "@/components/ProgressNotificationData.ts"
 
 const MIRABUF_LOCALSTORAGE_GENERATION_KEY = "Synthesis Nonce Key"
@@ -496,7 +496,7 @@ export async function spawnCachedMira(
                         type: "newObject",
                         timestamp: Date.now(),
                         data: {
-                            sceneObjectKey: mirabufSceneObject.id as RemoteSceneObjectId,
+                            sceneObjectKey: mirabufSceneObject.id,
                             assembly: encodedAssembly,
                             assemblyHash: info.hash,
                             miraType: info.miraType,
@@ -505,7 +505,7 @@ export async function spawnCachedMira(
                         },
                     }
                     await World.multiplayerSystem?.broadcast(message)
-                    World.multiplayerSystem?.registerOwnSceneObject(mirabufSceneObject.id as LocalSceneObjectId)
+                    World.multiplayerSystem?.registerOwnSceneObject(mirabufSceneObject.id)
                 }
 
                 if (targetControls && (info.miraType === MiraType.ROBOT || !targetControls.focusProvider)) {

--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -1,13 +1,7 @@
 import type Jolt from "@synthesis.adsk/jolt-physics"
 import * as THREE from "three"
 import type { mirabuf } from "@/proto/mirabuf"
-import type {
-    FieldConfiguration,
-    LocalSceneObjectId,
-    RemoteSceneObjectId,
-    RobotConfiguration,
-    UpdateObjectData,
-} from "@/systems/multiplayer/types"
+import type { FieldConfiguration, RobotConfiguration, UpdateObjectData } from "@/systems/multiplayer/types"
 import { BodyAssociate } from "@/systems/physics/BodyAssociate.ts"
 import EventSystem from "@/systems/EventSystem.ts"
 import type Mechanism from "@/systems/physics/Mechanism"
@@ -65,6 +59,7 @@ import ProtectedZoneSceneObject from "./ProtectedZoneSceneObject"
 import ScoringZoneSceneObject from "./ScoringZoneSceneObject"
 import { v4 as uuidV4 } from "uuid"
 import { copyVec3, hexStringToUint8Array, yieldToMain } from "@/util/Utility.ts"
+import type { SceneObjectId } from "@/systems/scene/SceneRenderer.ts"
 
 const DEBUG_BODIES = false
 
@@ -79,7 +74,7 @@ interface RnDebugMeshes {
  * last spawned in, however, systems (such as the configuration UI) can elect
  * assemblies to be in the spotlight when moving from interface to interface.
  */
-let spotlightAssembly: number | undefined
+let spotlightAssembly: SceneObjectId | undefined
 
 export function setSpotlightAssembly(assembly: MirabufSceneObject) {
     spotlightAssembly = assembly.id
@@ -87,7 +82,9 @@ export function setSpotlightAssembly(assembly: MirabufSceneObject) {
 
 // TODO: If nothing is in the spotlight, select last entry before defaulting to undefined
 export function getSpotlightAssembly(): MirabufSceneObject | undefined {
-    return World.sceneRenderer.sceneObjects.get(spotlightAssembly ?? 0) as MirabufSceneObject
+    return spotlightAssembly != null
+        ? (World.sceneRenderer.sceneObjects.get(spotlightAssembly) as MirabufSceneObject)
+        : undefined
 }
 
 type MinMax = { min: number; max: number }
@@ -708,7 +705,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
     }
 
     private removeSceneObjects(objs: SceneObject[]) {
-        objs.filter(obj => obj.id != -1).forEach(obj => World.sceneRenderer.removeSceneObject(obj.id))
+        objs.forEach(obj => World.sceneRenderer.removeSceneObject(obj.id))
         objs.length = 0
     }
 
@@ -720,7 +717,6 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
         if (zoneObject == null) return
 
         World.sceneRenderer.removeSceneObject(zoneObject.id)
-        zoneObject.id = -1
     }
 
     public removeProtectedZoneObject(zone: ProtectedZonePreferences) {
@@ -731,7 +727,6 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
         if (zoneObject == null) return
 
         World.sceneRenderer.removeSceneObject(zoneObject.id)
-        zoneObject.id = -1
     }
 
     /**
@@ -1023,7 +1018,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
         await World.multiplayerSystem.broadcast({
             type: "configureObject",
             data: {
-                sceneObjectKey: this.id as RemoteSceneObjectId,
+                sceneObjectKey: this.id,
                 objectConfigurationData: data,
             },
         })
@@ -1135,8 +1130,8 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
     }
 
     public enablePhysics() {
-        if (World.multiplayerSystem?.getOwnSceneObjectIDs().includes(this.id as LocalSceneObjectId)) {
-            World.multiplayerSystem.broadcast({ type: "enableObjectPhysics", data: this.id as RemoteSceneObjectId })
+        if (World.multiplayerSystem?.getOwnSceneObjectIDs().includes(this.id)) {
+            World.multiplayerSystem.broadcast({ type: "enableObjectPhysics", data: this.id })
         }
 
         this.mirabufInstance.parser.rigidNodes.forEach(rn => {
@@ -1146,8 +1141,8 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
     }
 
     public disablePhysics() {
-        if (World.multiplayerSystem?.getOwnSceneObjectIDs().includes(this.id as LocalSceneObjectId)) {
-            World.multiplayerSystem.broadcast({ type: "disableObjectPhysics", data: this.id as RemoteSceneObjectId })
+        if (World.multiplayerSystem?.getOwnSceneObjectIDs().includes(this.id)) {
+            World.multiplayerSystem.broadcast({ type: "disableObjectPhysics", data: this.id })
         }
 
         this.mirabufInstance.parser.rigidNodes.forEach(rn => {
@@ -1333,7 +1328,7 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
             .filter(n => n != null)
 
         return {
-            sceneObjectKey: this.id as RemoteSceneObjectId,
+            sceneObjectKey: this.id,
             gamePiecesControlled,
             bodies,
         }

--- a/fission/src/systems/EventSystem.ts
+++ b/fission/src/systems/EventSystem.ts
@@ -8,6 +8,7 @@ import type { CurrentContactData, OnContactValidateData } from "@/systems/physic
 import type TaskStatus from "@/util/TaskStatus.ts"
 import type MirabufSceneObject from "@/mirabuf/MirabufSceneObject.ts"
 import type { CameraPoint } from "@/systems/preferences/PreferenceTypes.ts"
+import type { SceneObjectId } from "@/systems/scene/SceneRenderer.ts"
 
 interface EventDataMap {
     // Mirabuf
@@ -53,7 +54,7 @@ interface EventDataMap {
     CameraModeChangedEvent: { mode: string }
     CameraFocusChangedEvent: { focusProvider: MirabufSceneObject | undefined }
     // Field View: the active camera point changed (the selected point, or undefined when none).
-    CameraViewChangedEvent: { point: CameraPoint | undefined; focusedRobotId?: number }
+    CameraViewChangedEvent: { point: CameraPoint | undefined; focusedRobotId?: SceneObjectId }
     // The active camera control scheme changed (e.g. "Target" or "FieldView").
     CameraControlsTypeChangedEvent: { controlsType: string }
 

--- a/fission/src/systems/match_mode/RobotDimensionTracker.ts
+++ b/fission/src/systems/match_mode/RobotDimensionTracker.ts
@@ -1,16 +1,17 @@
 import World from "@/systems/World"
 import MatchMode from "./MatchMode"
+import type { SceneObjectId } from "@/systems/scene/SceneRenderer.ts"
 
 const BUFFER_HEIGHT = 0.1
 const SIDE_BUFFER = 0.1
 
 class RobotDimensionTracker {
-    private static _robotLastFramePenalty: Map<number, boolean> = new Map()
+    private static _robotLastFramePenalty: Map<SceneObjectId, boolean> = new Map()
     private static _ignoreRotation: boolean = true
     private static _maxHeight: number = Infinity
     private static _heightLimitPenalty: number = 0
     private static _sideExtensionPenalty: number = 0
-    private static _robotSize: Map<number, { width: number; depth: number }> = new Map()
+    private static _robotSize: Map<SceneObjectId, { width: number; depth: number }> = new Map()
     private static _sideMaxExtension: number = 0
 
     public static setConfigValues(

--- a/fission/src/systems/multiplayer/MessageHandlers.ts
+++ b/fission/src/systems/multiplayer/MessageHandlers.ts
@@ -11,15 +11,14 @@ import type {
     ClientInfo,
     EncodedAssembly,
     InitObjectData,
-    LocalSceneObjectId,
     MatchModePenalty,
     MatchModeStateData,
     MessageType,
     ObjectPreferences,
-    RemoteSceneObjectId,
     UpdateObjectData,
 } from "./types"
 import EventSystem from "@/systems/EventSystem.ts"
+import type { SceneObjectId } from "@/systems/scene/SceneRenderer.ts"
 
 export const peerMessageHandlers = {
     info: handlePeerInfo,
@@ -44,7 +43,7 @@ export const peerMessageHandlers = {
 }
 
 const pendingOperations: (() => void)[] = []
-const progressHandles: Map<number, ProgressHandle> = new Map()
+const progressHandles: Map<SceneObjectId, ProgressHandle> = new Map()
 
 async function handleMatchModeState(data: MatchModeStateData) {
     console.log(data)
@@ -78,9 +77,7 @@ function handlePeerUpdate(data: UpdateObjectData[], peerId: string, timestamp: n
     clientToUpdateMap.set(peerId, timestamp)
 
     data.forEach(({ sceneObjectKey, gamePiecesControlled, bodies }) => {
-        const sceneObject = World.sceneRenderer.sceneObjects.get(
-            World.multiplayerSystem!.convertSceneObjectId(peerId, sceneObjectKey)
-        )
+        const sceneObject = World.sceneRenderer.sceneObjects.get(sceneObjectKey)
         if (sceneObject == null) {
             console.warn(
                 `Multiplayer SceneObject: ${sceneObjectKey} not found in sceneObjects map. Multiplayer SceneObjects must be initialized before being updated.`
@@ -201,13 +198,9 @@ async function handleNewObject(data: InitObjectData, peerId: string) {
     object.nameOverride = clientToInfoMap.get(peerId)?.displayName ?? peerId
 
     console.log("Registering object", object, data)
-    const localSceneObjectKey = World.sceneRenderer.registerSceneObject(object)
-    console.log("linking object", data.sceneObjectKey, "->", localSceneObjectKey)
+    World.sceneRenderer.registerSceneObject(object)
 
-    World.multiplayerSystem?.setSceneObjectIdMapping(peerId, data.sceneObjectKey, localSceneObjectKey)
-
-    clientToObjectMap.get(peerId)?.push(object.id as LocalSceneObjectId) ||
-        clientToObjectMap.set(peerId, [object.id as LocalSceneObjectId])
+    clientToObjectMap.get(peerId)?.push(object.id) || clientToObjectMap.set(peerId, [object.id])
 
     // Sets bodyMap
     const clientBodyIds = object.getAllBodyIds()
@@ -250,31 +243,28 @@ async function handleAssemblyRequest(data: AssemblyRequestData, peerId: string) 
     })
 }
 
-function handleDeleteObject(sceneObjectKey: RemoteSceneObjectId, peerId: string) {
+function handleDeleteObject(sceneObjectKey: SceneObjectId, peerId: string) {
     if (!World.multiplayerSystem) return
     const clientToObjectMap = World.multiplayerSystem._clientToObjectMap
-    const localKey = World.multiplayerSystem!.convertSceneObjectId(peerId, sceneObjectKey)
 
-    const peerClient = [...clientToObjectMap.entries()].find(([_id, keys]) => keys.includes(localKey))
+    const peerClient = [...clientToObjectMap.entries()].find(([_id, keys]) => keys.includes(sceneObjectKey))
     if (peerClient != null) {
         const keys = clientToObjectMap.get(peerClient[0])
-        const index = keys?.indexOf(World.multiplayerSystem.convertSceneObjectId(peerId, sceneObjectKey)) ?? -1
+        const index = keys?.indexOf(sceneObjectKey) ?? -1
         if (index != -1) {
             keys?.splice(index)
         }
     }
 
-    if (!World.sceneRenderer.sceneObjects.has(localKey)) {
+    if (!World.sceneRenderer.sceneObjects.has(sceneObjectKey)) {
         pendingOperations.push(() => handleDeleteObject(sceneObjectKey, peerId))
     }
 
-    World.sceneRenderer.removeSceneObject(localKey)
+    World.sceneRenderer.removeSceneObject(sceneObjectKey)
 }
 
 function handleObjectConfiguration(data: ObjectPreferences, peerId: string) {
-    const sceneObject = World.sceneRenderer.sceneObjects.get(
-        World.multiplayerSystem!.convertSceneObjectId(peerId, data.sceneObjectKey)
-    )
+    const sceneObject = World.sceneRenderer.sceneObjects.get(data.sceneObjectKey)
     if (sceneObject instanceof MirabufSceneObject) {
         if (sceneObject.isOwnObject) {
             console.warn("received config for own object")
@@ -287,10 +277,8 @@ function handleObjectConfiguration(data: ObjectPreferences, peerId: string) {
     }
 }
 
-function disableObjectPhysics(sceneObjectKey: RemoteSceneObjectId, peerId: string) {
-    const sceneObject = World.sceneRenderer.sceneObjects.get(
-        World.multiplayerSystem!.convertSceneObjectId(peerId, sceneObjectKey)
-    )
+function disableObjectPhysics(sceneObjectKey: SceneObjectId, peerId: string) {
+    const sceneObject = World.sceneRenderer.sceneObjects.get(sceneObjectKey)
     if (sceneObject instanceof MirabufSceneObject) {
         if (sceneObject.isOwnObject) {
             console.warn("received disable for own object")
@@ -302,10 +290,8 @@ function disableObjectPhysics(sceneObjectKey: RemoteSceneObjectId, peerId: strin
     }
 }
 
-function enableObjectPhysics(sceneObjectKey: RemoteSceneObjectId, peerId: string) {
-    const sceneObject = World.sceneRenderer.sceneObjects.get(
-        World.multiplayerSystem!.convertSceneObjectId(peerId, sceneObjectKey)
-    )
+function enableObjectPhysics(sceneObjectKey: SceneObjectId, peerId: string) {
+    const sceneObject = World.sceneRenderer.sceneObjects.get(sceneObjectKey)
     if (sceneObject instanceof MirabufSceneObject) {
         if (sceneObject.isOwnObject) {
             console.warn("received enablephysics for own object")
@@ -318,9 +304,7 @@ function enableObjectPhysics(sceneObjectKey: RemoteSceneObjectId, peerId: string
 }
 
 function handleMatchModePenalty(data: MatchModePenalty, peerId: string) {
-    const obj = World.sceneRenderer.sceneObjects.get(
-        World.multiplayerSystem!.convertSceneObjectId(peerId, data.objectId)
-    )
+    const obj = World.sceneRenderer.sceneObjects.get(data.objectId)
     if (!(obj instanceof MirabufSceneObject)) {
         console.warn("can't handle penalty for object", data.objectId, obj)
         pendingOperations.push(() => handleMatchModePenalty(data, peerId))

--- a/fission/src/systems/multiplayer/MultiplayerSystem.ts
+++ b/fission/src/systems/multiplayer/MultiplayerSystem.ts
@@ -7,9 +7,10 @@ import { mirabuf } from "@/proto/mirabuf"
 import PreferencesSystem from "@/systems/preferences/PreferencesSystem.ts"
 import World from "../World"
 import { peerMessageHandlers } from "./MessageHandlers"
-import type { ClientInfo, LocalSceneObjectId, Message, MessageWithTimestamp, RemoteSceneObjectId } from "./types"
+import type { ClientInfo, Message, MessageWithTimestamp } from "./types"
 import { hashBuffer } from "@/util/Utility"
 import EventSystem from "@/systems/EventSystem.ts"
+import type { SceneObjectId } from "@/systems/scene/SceneRenderer.ts"
 
 export const COLLISION_TIMEOUT = 500
 
@@ -22,9 +23,8 @@ class MultiplayerSystem {
 
     public readonly _clientToInfoMap: Map<string, ClientInfo> = new Map()
 
-    public readonly _clientToObjectMap: Map<string, LocalSceneObjectId[]> = new Map()
+    public readonly _clientToObjectMap: Map<string, SceneObjectId[]> = new Map()
     public readonly _clientToBodyMap: Map<string, Map<number, Jolt.BodyID>> = new Map() // Each Map is: peerBodyId -> clientBodyId
-    public readonly _clientToSceneObjectIdMap: Map<string, Map<RemoteSceneObjectId, LocalSceneObjectId>> = new Map() // Each Map is: peerObjectId -> clientObjectId
 
     readonly info: ClientInfo
     private _onDestroyHooks: (() => void)[] = []
@@ -169,7 +169,7 @@ class MultiplayerSystem {
                 await this.send(conn.peer, {
                     type: "newObject",
                     data: {
-                        sceneObjectKey: obj.id as RemoteSceneObjectId,
+                        sceneObjectKey: obj.id,
                         assemblyHash: await hashBuffer(
                             mirabuf.Assembly.encode(obj.mirabufInstance.parser.assembly).finish().buffer as ArrayBuffer
                         ),
@@ -190,13 +190,12 @@ class MultiplayerSystem {
                 this.handlePeerMessage(
                     {
                         type: "deleteObject",
-                        data: this.convertSceneObjectIdReverse(conn.peer, obj)!,
+                        data: obj!,
                         timestamp: Date.now(),
                     },
                     conn.peer
                 ).catch(console.error) // TODO Get actual sceneObjectKey
             })
-            this._clientToSceneObjectIdMap.delete(conn.peer)
 
             this._connections.delete(conn.peer)
             // TODO: handle host transition
@@ -260,16 +259,15 @@ class MultiplayerSystem {
             .filter(obj => obj instanceof MirabufSceneObject)
     }
 
-    registerOwnSceneObject(objectId: LocalSceneObjectId) {
+    registerOwnSceneObject(objectId: SceneObjectId) {
         const list = this._clientToObjectMap.get(this.clientId)
-        this.setSceneObjectIdMapping(this.clientId, objectId as RemoteSceneObjectId, objectId)
         if (list != null) {
             list.push(objectId)
         } else {
             this._clientToObjectMap.set(this.clientId, [objectId])
         }
     }
-    unregisterOwnSceneObject(objectId: LocalSceneObjectId) {
+    unregisterOwnSceneObject(objectId: SceneObjectId) {
         const list = this._clientToObjectMap.get(this.clientId)
         if (!list) return
         const index = list.indexOf(objectId)
@@ -305,28 +303,10 @@ class MultiplayerSystem {
         this._connections.forEach(conn => conn.close())
         this._connections.clear()
         this.client.destroy()
-        this._clientToSceneObjectIdMap.clear()
         this._onDestroyHooks.forEach(hook => {
             hook()
         })
         World.setMultiplayerSystem(undefined)
-    }
-
-    public convertSceneObjectId(peerId: string, objectId: RemoteSceneObjectId): LocalSceneObjectId {
-        return this._clientToSceneObjectIdMap.get(peerId)?.get(objectId) ?? (-1 as LocalSceneObjectId)
-    }
-
-    public convertSceneObjectIdReverse(peerId: string, objectId: LocalSceneObjectId): RemoteSceneObjectId | undefined {
-        return [...this._clientToSceneObjectIdMap.get(peerId)!.entries()].find(([_, l]) => objectId == l)?.[0]
-    }
-
-    public setSceneObjectIdMapping(peerId: string, remoteId: RemoteSceneObjectId, localId: LocalSceneObjectId) {
-        let peerMap = World.multiplayerSystem?._clientToSceneObjectIdMap.get(peerId)
-        if (peerMap == null) {
-            peerMap = new Map()
-            World.multiplayerSystem?._clientToSceneObjectIdMap.set(peerId, peerMap)
-        }
-        peerMap.set(remoteId, localId)
     }
 }
 

--- a/fission/src/systems/multiplayer/types.ts
+++ b/fission/src/systems/multiplayer/types.ts
@@ -3,6 +3,7 @@ import type MirabufSceneObject from "@/mirabuf/MirabufSceneObject"
 import type { MatchModeConfig } from "@/panels/configuring/MatchModeConfigPanel.tsx"
 import type { Alliance, Station } from "@/systems/preferences/PreferenceTypes.ts"
 import type PhysicsSystem from "../physics/PhysicsSystem"
+import type { SceneObjectId } from "@/systems/scene/SceneRenderer.ts"
 
 export interface MessageType {
     info: ClientInfo
@@ -10,10 +11,10 @@ export interface MessageType {
     collision: UpdateObjectData[] // just a comprehensive list instead
     newObject: InitObjectData
     needAssembly: AssemblyRequestData
-    deleteObject: RemoteSceneObjectId // sceneObjectKey
+    deleteObject: SceneObjectId // sceneObjectKey
     configureObject: ObjectPreferences // sceneObjectKey
-    disableObjectPhysics: RemoteSceneObjectId // sceneObjectKey
-    enableObjectPhysics: RemoteSceneObjectId // sceneObjectKey
+    disableObjectPhysics: SceneObjectId // sceneObjectKey
+    enableObjectPhysics: SceneObjectId // sceneObjectKey
     ping: PingData
     pong: PingData
     matchModeState: MatchModeStateData
@@ -21,7 +22,7 @@ export interface MessageType {
 }
 
 export interface MatchModePenalty {
-    objectId: RemoteSceneObjectId
+    objectId: SceneObjectId
     points: number
     description: string
 }
@@ -40,8 +41,6 @@ export type Message = Omit<MessageWithTimestamp, "timestamp"> & Partial<Pick<Mes
 
 // biome-ignore-start lint/style/useNamingConvention: used for type safety
 export type EncodedAssembly = Uint8Array & { __: "encodedassembly" }
-export type RemoteSceneObjectId = number & { __: "remotesceneobject" | "sceneobjectkey" }
-export type LocalSceneObjectId = number & { __: "localsceneobject" | "sceneobjectkey" }
 // biome-ignore-end lint/style/useNamingConvention: used for type safety
 
 export type ClientInfo = {
@@ -52,7 +51,7 @@ export type ClientInfo = {
 }
 
 export type InitObjectData = {
-    sceneObjectKey: RemoteSceneObjectId
+    sceneObjectKey: SceneObjectId
     assembly?: EncodedAssembly
     assemblyHash: string
     miraType: MiraType
@@ -70,17 +69,17 @@ export type FieldConfiguration = {
     fieldPreferences: string // FieldPreferences
 }
 export type ObjectPreferences = {
-    sceneObjectKey: RemoteSceneObjectId
+    sceneObjectKey: SceneObjectId
     objectConfigurationData: RobotConfiguration | FieldConfiguration
 }
 
 export type AssemblyRequestData = {
-    sceneObjectKey: RemoteSceneObjectId
+    sceneObjectKey: SceneObjectId
     assemblyHash: string
 }
 
 export type UpdateObjectData = {
-    sceneObjectKey: RemoteSceneObjectId
+    sceneObjectKey: SceneObjectId
     gamePiecesControlled: number[] // BodyID
     // {x, y, z, w?}
     bodies: {

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -15,7 +15,7 @@ import {
 import type MirabufParser from "../../mirabuf/MirabufParser"
 import { GAMEPIECE_SUFFIX, GROUNDED_JOINT_ID, type RigidNodeReadOnly } from "@/mirabuf/MirabufParser.ts"
 import { mirabuf } from "@/proto/mirabuf"
-import type { LocalSceneObjectId, Message } from "../multiplayer/types"
+import type { Message } from "../multiplayer/types"
 import PreferencesSystem from "../preferences/PreferencesSystem"
 import World from "../World"
 import WorldSystem from "../WorldSystem"
@@ -42,6 +42,7 @@ import {
     isWheel,
     setAxes,
 } from "./ConstraintSettingsUtilities"
+import type { SceneObjectId } from "@/systems/scene/SceneRenderer.ts"
 
 const DEBUG_COLLIDER_WARNINGS = false
 
@@ -1717,7 +1718,7 @@ class PhysicsSystem extends WorldSystem {
             (ROBOT_LAYERS.includes(body.GetObjectLayer()) &&
                 World.multiplayerSystem
                     ?.getOwnSceneObjectIDs()
-                    .includes(this.bodyToMiraSceneObject(body)?.id as LocalSceneObjectId)) ??
+                    .includes(this.bodyToMiraSceneObject(body)?.id ?? ("" as SceneObjectId))) ??
             false
         )
     }

--- a/fission/src/systems/scene/SceneObject.ts
+++ b/fission/src/systems/scene/SceneObject.ts
@@ -1,12 +1,17 @@
+import type { SceneObjectId } from "@/systems/scene/SceneRenderer.ts"
+
 abstract class SceneObject {
-    private _id: number | null = null
+    private _id: SceneObjectId | null = null
 
     public get id() {
         return this._id!
     }
 
-    public set id(sceneId: number) {
-        if (this._id) return
+    public set id(sceneId: SceneObjectId) {
+        if (this._id) {
+            console.warn("Tried to set an existing ID")
+            return
+        }
         this._id = sceneId
     }
 

--- a/fission/src/systems/scene/SceneRenderer.ts
+++ b/fission/src/systems/scene/SceneRenderer.ts
@@ -8,6 +8,7 @@ import MirabufSceneObject from "@/mirabuf/MirabufSceneObject"
 import fragmentShader from "@/shaders/fragment.glsl"
 import vertexShader from "@/shaders/vertex.glsl"
 import EventSystem from "@/systems/EventSystem.ts"
+import { v4 as uuidv4 } from "uuid"
 import {
     type CameraControls,
     type CameraControlsType,
@@ -27,18 +28,18 @@ import WorldSystem from "../WorldSystem"
 import GizmoSceneObject from "./GizmoSceneObject"
 import type SceneObject from "./SceneObject"
 import ScreenInteractionHandler, { type InteractionEnd } from "./ScreenInteractionHandler"
-import type { LocalSceneObjectId, RemoteSceneObjectId } from "@/systems/multiplayer/types.ts"
 
 const CLEAR_COLOR = 0x121212
 const GROUND_COLOR = 0xfffef0
+
+// biome-ignore lint/style/useNamingConvention: Prevent type bad
+export type SceneObjectId = string & { __: "sceneObjectId" }
 
 const STANDARD_ASPECT = 16.0 / 9.0
 export const STANDARD_CAMERA_FOV_X = 110.0
 export const STANDARD_CAMERA_FOV_Y = STANDARD_CAMERA_FOV_X / STANDARD_ASPECT
 
 const textureLoader = new THREE.TextureLoader()
-
-let nextSceneObjectId = 1
 
 class SceneRenderer extends WorldSystem {
     private _mainCamera: THREE.PerspectiveCamera
@@ -47,10 +48,10 @@ class SceneRenderer extends WorldSystem {
     private _skybox: THREE.Mesh
     private _composer: EffectComposer
 
-    private _sceneObjects: Map<number, SceneObject>
+    private _sceneObjects: Map<SceneObjectId, SceneObject>
 
     // Maps of all the gizmos that are attached to a mirabuf scene object
-    private _gizmosOnMirabuf: Map<number, GizmoSceneObject>
+    private _gizmosOnMirabuf: Map<SceneObjectId, GizmoSceneObject>
 
     private _cameraControls: CameraControls
 
@@ -402,27 +403,19 @@ class SceneRenderer extends WorldSystem {
         this.setupCSMMaterials()
     }
 
-    public registerSceneObject<T extends SceneObject>(obj: T, idOverride?: number): LocalSceneObjectId {
-        const id = idOverride ?? nextSceneObjectId++
-        if (nextSceneObjectId <= id) {
-            nextSceneObjectId = id + 1
-        }
-
-        if (this._sceneObjects.has(id)) {
-            console.error("Trying to add with existing ID!", obj, idOverride)
-            return -1 as LocalSceneObjectId
-        }
+    public registerSceneObject<T extends SceneObject>(obj: T): SceneObjectId {
+        const id = uuidv4() as SceneObjectId
 
         obj.id = id
         this._sceneObjects.set(id, obj)
 
         obj.setup()
 
-        return id as LocalSceneObjectId
+        return id
     }
 
     /** Registers gizmos that are attached to a parent `MirabufSceneObject`  */
-    public registerGizmoSceneObject(obj: GizmoSceneObject): number {
+    public registerGizmoSceneObject(obj: GizmoSceneObject): SceneObjectId {
         if (obj.hasParent()) this._gizmosOnMirabuf.set(obj.parentObjectId!, obj)
         return this.registerSceneObject(obj)
     }
@@ -434,7 +427,7 @@ class SceneRenderer extends WorldSystem {
         this._sceneObjects.clear()
     }
 
-    public removeSceneObject(id: number) {
+    public removeSceneObject(id: SceneObjectId) {
         const obj = this._sceneObjects.get(id)
 
         if (!obj) return
@@ -446,7 +439,7 @@ class SceneRenderer extends WorldSystem {
 
             World?.multiplayerSystem?.broadcast({
                 type: "deleteObject",
-                data: id as RemoteSceneObjectId,
+                data: id,
             })
         } else if (obj instanceof GizmoSceneObject && obj.hasParent()) {
             this._gizmosOnMirabuf.delete(obj.parentObjectId!)

--- a/fission/src/test/scene/SceneRenderer.test.ts
+++ b/fission/src/test/scene/SceneRenderer.test.ts
@@ -4,8 +4,13 @@ import { MiraType } from "@/mirabuf/MirabufLoader"
 import type MirabufSceneObject from "@/mirabuf/MirabufSceneObject"
 import type GizmoSceneObject from "@/systems/scene/GizmoSceneObject"
 import type SceneObject from "@/systems/scene/SceneObject"
-import SceneRenderer, { STANDARD_CAMERA_FOV_X, STANDARD_CAMERA_FOV_Y } from "@/systems/scene/SceneRenderer"
+import SceneRenderer, {
+    type SceneObjectId,
+    STANDARD_CAMERA_FOV_X,
+    STANDARD_CAMERA_FOV_Y,
+} from "@/systems/scene/SceneRenderer"
 import JOLT from "@/util/loading/JoltSyncLoader"
+import type { RecursivePartial } from "@/util/Utility.ts"
 
 interface MockSceneObject {
     dispose: ReturnType<typeof vi.fn>
@@ -336,19 +341,20 @@ describe("SceneRenderer", () => {
 
     describe("Gizmo Management", () => {
         test("should register gizmos with parents", () => {
+            const id = "123-abc-object-id" as SceneObjectId
             const mockGizmo = {
                 dispose: vi.fn(),
                 update: vi.fn(),
                 setup: vi.fn(),
                 hasParent: vi.fn().mockReturnValue(true),
-                parentObjectId: 123,
+                parentObjectId: id,
                 gizmo: { dragging: false },
-            }
+            } satisfies RecursivePartial<GizmoSceneObject>
 
             sceneRenderer.registerGizmoSceneObject(mockGizmo as unknown as GizmoSceneObject)
 
-            expect(sceneRenderer.gizmosOnMirabuf.has(123)).toBe(true)
-            expect(sceneRenderer.gizmosOnMirabuf.get(123)).toBe(mockGizmo)
+            expect(sceneRenderer.gizmosOnMirabuf.has(id)).toBe(true)
+            expect(sceneRenderer.gizmosOnMirabuf.get(id)).toBe(mockGizmo)
         })
 
         test("should not register gizmos without parents", () => {

--- a/fission/src/ui/panels/configuring/CameraSelectionPanel.tsx
+++ b/fission/src/ui/panels/configuring/CameraSelectionPanel.tsx
@@ -18,6 +18,7 @@ import { useUIContext } from "@/ui/helpers/UIProviderHelpers"
 import CommandRegistry from "@/ui/components/CommandRegistry"
 import { globalOpenPanel } from "@/ui/components/GlobalUIControls"
 import { MenuItem } from "@mui/material"
+import type { SceneObjectId } from "@/systems/scene/SceneRenderer.ts"
 
 CommandRegistry.get().registerCommand({
     id: "open-camera-config",
@@ -27,7 +28,7 @@ CommandRegistry.get().registerCommand({
     perform: () => import("./CameraSelectionPanel").then(m => globalOpenPanel(m.default, undefined)),
 })
 
-const UNFOCUSED_ID = -1
+const UNFOCUSED_ID = "unfocused" as SceneObjectId
 const CENTER_POINT_INDEX = -1
 
 function getSceneObjects(): MirabufSceneObject[] {
@@ -90,7 +91,7 @@ const FieldViewSettings: React.FC = () => {
         const selected = getFieldViewControls()?.selectedPoint
         return selected ? getCameraPoints().indexOf(selected) : CENTER_POINT_INDEX
     })
-    const [focusedRobotId, setFocusedRobotId] = useState<number>(
+    const [focusedRobotId, setFocusedRobotId] = useState<SceneObjectId>(
         getFieldViewControls()?.focusedRobot?.id ?? UNFOCUSED_ID
     )
 
@@ -176,7 +177,7 @@ const FieldViewSettings: React.FC = () => {
                     <Select
                         value={focusedRobotId}
                         onChange={e => {
-                            const id = e.target.value as number
+                            const id = e.target.value as SceneObjectId
                             const robot = id === UNFOCUSED_ID ? undefined : robots.find(r => r.id === id)
                             setFocusedRobotId(id)
                             getFieldViewControls()?.focusRobot(robot)
@@ -200,7 +201,7 @@ const FieldViewSettings: React.FC = () => {
 const CameraSelectionPanel: React.FC<PanelImplProps<void, void>> = ({ panel }) => {
     const { configureScreen } = useUIContext()
 
-    const [focusedId, setFocusedId] = useState<number>(() => {
+    const [focusedId, setFocusedId] = useState<SceneObjectId>(() => {
         const controls = World.sceneRenderer?.currentCameraControls
         if (controls instanceof CustomTargetControls) return controls.focusProvider?.id ?? UNFOCUSED_ID
         if (controls instanceof CustomFieldViewControls) {
@@ -264,7 +265,7 @@ const CameraSelectionPanel: React.FC<PanelImplProps<void, void>> = ({ panel }) =
     )
 
     // Selecting a target only updates state. The layout effect switches controls and assigns focus.
-    const onFocusChange = (id: number) => setFocusedId(id)
+    const onFocusChange = (id: SceneObjectId) => setFocusedId(id)
 
     const targetControls = getTargetControls()
 
@@ -274,7 +275,7 @@ const CameraSelectionPanel: React.FC<PanelImplProps<void, void>> = ({ panel }) =
                 <span className="text-xs opacity-70 select-none">Focus Target</span>
                 <Select
                     value={focusedId}
-                    onChange={e => onFocusChange(e.target.value as number)}
+                    onChange={e => onFocusChange(e.target.value as SceneObjectId)}
                     size="small"
                     fullWidth
                 >

--- a/fission/src/ui/panels/configuring/CameraSelectionPanel.tsx
+++ b/fission/src/ui/panels/configuring/CameraSelectionPanel.tsx
@@ -28,7 +28,6 @@ CommandRegistry.get().registerCommand({
     perform: () => import("./CameraSelectionPanel").then(m => globalOpenPanel(m.default, undefined)),
 })
 
-const UNFOCUSED_ID = "unfocused" as SceneObjectId
 const CENTER_POINT_INDEX = -1
 
 function getSceneObjects(): MirabufSceneObject[] {
@@ -91,8 +90,8 @@ const FieldViewSettings: React.FC = () => {
         const selected = getFieldViewControls()?.selectedPoint
         return selected ? getCameraPoints().indexOf(selected) : CENTER_POINT_INDEX
     })
-    const [focusedRobotId, setFocusedRobotId] = useState<SceneObjectId>(
-        getFieldViewControls()?.focusedRobot?.id ?? UNFOCUSED_ID
+    const [focusedRobotId, setFocusedRobotId] = useState<SceneObjectId | null>(
+        getFieldViewControls()?.focusedRobot?.id ?? null
     )
 
     // TODO: this is very bad react, we should not be updating this every re-render
@@ -112,9 +111,9 @@ const FieldViewSettings: React.FC = () => {
                 const freshRobots = World.sceneRenderer.mirabufSceneObjects.getRobots()
                 setRobots(freshRobots)
                 setFocusedRobotId(prev => {
-                    if (prev !== UNFOCUSED_ID && !freshRobots.find(r => r.id === prev)) {
+                    if (prev !== null && !freshRobots.find(r => r.id === prev)) {
                         getFieldViewControls()?.focusRobot(undefined)
-                        return UNFOCUSED_ID
+                        return null
                     }
                     return prev
                 })
@@ -128,7 +127,7 @@ const FieldViewSettings: React.FC = () => {
         () =>
             EventSystem.listen("CameraViewChangedEvent", ({ point, focusedRobotId }) => {
                 setActivePointIndex(point ? getCameraPoints().indexOf(point) : CENTER_POINT_INDEX)
-                setFocusedRobotId(focusedRobotId ?? UNFOCUSED_ID)
+                setFocusedRobotId(focusedRobotId ?? null)
             }),
         []
     )
@@ -142,7 +141,7 @@ const FieldViewSettings: React.FC = () => {
                 if (field) tc.focusProvider = field
             }
             setActivePointIndex(CENTER_POINT_INDEX)
-            setFocusedRobotId(UNFOCUSED_ID)
+            setFocusedRobotId(null)
         } else {
             const point = points[index]
             const field = World.sceneRenderer.mirabufSceneObjects.getField()
@@ -178,14 +177,14 @@ const FieldViewSettings: React.FC = () => {
                         value={focusedRobotId}
                         onChange={e => {
                             const id = e.target.value as SceneObjectId
-                            const robot = id === UNFOCUSED_ID ? undefined : robots.find(r => r.id === id)
+                            const robot = id == null ? undefined : robots.find(r => r.id === id)
                             setFocusedRobotId(id)
                             getFieldViewControls()?.focusRobot(robot)
                         }}
                         size="small"
                         fullWidth
                     >
-                        <MenuItem value={UNFOCUSED_ID}>None</MenuItem>
+                        <MenuItem value={undefined}>None</MenuItem>
                         {robots.map(r => (
                             <MenuItem key={r.id} value={r.id}>
                                 {r.descriptiveName}
@@ -201,13 +200,13 @@ const FieldViewSettings: React.FC = () => {
 const CameraSelectionPanel: React.FC<PanelImplProps<void, void>> = ({ panel }) => {
     const { configureScreen } = useUIContext()
 
-    const [focusedId, setFocusedId] = useState<SceneObjectId>(() => {
+    const [focusedId, setFocusedId] = useState<SceneObjectId | null>(() => {
         const controls = World.sceneRenderer?.currentCameraControls
-        if (controls instanceof CustomTargetControls) return controls.focusProvider?.id ?? UNFOCUSED_ID
+        if (controls instanceof CustomTargetControls) return controls.focusProvider?.id ?? null
         if (controls instanceof CustomFieldViewControls) {
-            return World.sceneRenderer.mirabufSceneObjects.getField()?.id ?? UNFOCUSED_ID
+            return World.sceneRenderer.mirabufSceneObjects.getField()?.id ?? null
         }
-        return UNFOCUSED_ID
+        return null
     })
     const [sceneObjects, setSceneObjects] = useState<MirabufSceneObject[]>(getSceneObjects)
     const [controlsType, setControlsType] = useState<CameraControlsType>(
@@ -248,7 +247,7 @@ const CameraSelectionPanel: React.FC<PanelImplProps<void, void>> = ({ panel }) =
     useEffect(
         () =>
             EventSystem.listen("CameraFocusChangedEvent", ({ focusProvider }) => {
-                setFocusedId(focusProvider?.id ?? UNFOCUSED_ID)
+                setFocusedId(focusProvider?.id ?? null)
             }),
         []
     )
@@ -259,13 +258,13 @@ const CameraSelectionPanel: React.FC<PanelImplProps<void, void>> = ({ panel }) =
             EventSystem.listen("MirabufObjectChangeEvent", () => {
                 const objects = getSceneObjects()
                 setSceneObjects(objects)
-                setFocusedId(prev => (objects.some(o => o.id === prev) ? prev : UNFOCUSED_ID))
+                setFocusedId(prev => (objects.some(o => o.id === prev) ? prev : null))
             }),
         []
     )
 
     // Selecting a target only updates state. The layout effect switches controls and assigns focus.
-    const onFocusChange = (id: SceneObjectId) => setFocusedId(id)
+    const onFocusChange = (id: SceneObjectId | null) => setFocusedId(id)
 
     const targetControls = getTargetControls()
 
@@ -275,11 +274,11 @@ const CameraSelectionPanel: React.FC<PanelImplProps<void, void>> = ({ panel }) =
                 <span className="text-xs opacity-70 select-none">Focus Target</span>
                 <Select
                     value={focusedId}
-                    onChange={e => onFocusChange(e.target.value as SceneObjectId)}
+                    onChange={e => onFocusChange((e.target.value ?? null) as SceneObjectId | null)}
                     size="small"
                     fullWidth
                 >
-                    <MenuItem value={UNFOCUSED_ID}>None</MenuItem>
+                    <MenuItem value={undefined}>None</MenuItem>
                     {sceneObjects.map(t => (
                         <MenuItem key={t.id} value={t.id}>
                             {t.miraType === MiraType.ROBOT ? t.descriptiveName : t.assemblyName}

--- a/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
@@ -38,6 +38,7 @@ import MetadataConfigInterface from "@/panels/configuring/assembly-config/interf
 import { FaArrowsRotate } from "react-icons/fa6"
 import MoveInterface from "@/panels/configuring/assembly-config/interfaces/MoveInterface.tsx"
 import ControlsConfigInterface from "@/panels/configuring/assembly-config/interfaces/ControlsConfigInterface.tsx"
+import type { SceneObjectId } from "@/systems/scene/SceneRenderer.ts"
 
 // Register command: Configure Assets (module-scope side effect)
 CommandRegistry.get().registerCommands([
@@ -168,7 +169,7 @@ const ConfigurePanel: React.FC<PanelImplProps<void, ConfigurePanelCustomProps>> 
     const [selectedAssembly, setSelectedAssembly] = useState<MirabufSceneObject | undefined>(initialSelectedAssembly)
     const [configMode, setConfigMode] = useState<ConfigMode | undefined>(initialConfigMode)
     const [configurationType, setConfigurationType] = useState<ConfigurationType>(initialConfigurationType ?? "ROBOTS")
-    const [pendingDeletes, setPendingDeletes] = useState<number[]>([])
+    const [pendingDeletes, setPendingDeletes] = useState<SceneObjectId[]>([])
 
     const [confirmCallbacks, setConfirmCallbacks] = useState<(() => void | Promise<void>)[]>([])
     const [cancelCallbacks, setCancelCallbacks] = useState<(() => void | Promise<void>)[]>([])

--- a/fission/src/ui/panels/configuring/assembly-config/configure/AssemblySelection.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/configure/AssemblySelection.tsx
@@ -9,13 +9,14 @@ import ImportMirabufPanel from "@/ui/panels/mirabuf/ImportMirabufPanel"
 import type { ConfigurationType } from "../ConfigTypes"
 import type { ConfigurePanelCustomProps } from "../ConfigurePanel"
 import EventSystem from "@/systems/EventSystem.ts"
+import type { SceneObjectId } from "@/systems/scene/SceneRenderer.ts"
 
 interface AssemblySelectionProps {
     configurationType: ConfigurationType
     onAssemblySelected: (assembly?: MirabufSceneObject) => void
     selectedAssembly?: MirabufSceneObject
     onStageDelete: (opt: SelectMenuOption) => void
-    pendingDeletes: number[]
+    pendingDeletes: SceneObjectId[]
 }
 
 export class AssemblySelectionOption extends SelectMenuOption {

--- a/fission/src/util/Utility.ts
+++ b/fission/src/util/Utility.ts
@@ -99,3 +99,11 @@ export function copyVec3(vec: Jolt.Vec3): Jolt.Vec3 {
  * Useful in long, blocking functions to allow the UI to update
  */
 export const yieldToMain = () => new Promise<void>(resolve => setTimeout(resolve, 0))
+
+export type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[]
+        ? RecursivePartial<U>[]
+        : T[P] extends object | undefined
+          ? RecursivePartial<T[P]>
+          : T[P]
+}


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-309

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Currently scene object IDs are auto-incrementing integers, which makes handling translations in multiplayer exceedingly obnoxious. 

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->
This system uses UUIDs instead, meaning no translation is required and scene object IDs match across clients.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

Theoretically, there should be no behavior change. If you find something that's different, that's a bug.

---

Before merging, ensure the following criteria are met:

- [X] All acceptance criteria outlined in the ticket are met.
- [X] Necessary test cases have been added and updated.
- [X] A feature toggle or safe disable path has been added (if applicable).
- [X] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [X] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
