### PR TITLE
chore: always use T[] for arrays

### DIFF
--- a/fission/biome.json
+++ b/fission/biome.json
@@ -72,6 +72,7 @@
         "useAsConstAssertion": "error",
         "useComponentExportOnlyModules": "warn",
         "useImportType": "warn",
+        "useConsistentArrayType": "error",
         "useNamingConvention": {
           "level": "error",
           "options": {

--- a/fission/src/mirabuf/MirabufInstance.ts
+++ b/fission/src/mirabuf/MirabufInstance.ts
@@ -93,8 +93,8 @@ const transformGeometry = (geometry: THREE.BufferGeometry, mesh: mirabuf.IMesh) 
 class MirabufInstance {
     private _mirabufParser: MirabufParser
     private _materials: Map<string, THREE.Material>
-    private _meshes: Map<MirabufPartInstanceGUID, Array<[THREE.BatchedMesh, number]>>
-    private _batches: Array<THREE.BatchedMesh>
+    private _meshes: Map<MirabufPartInstanceGUID, [THREE.BatchedMesh, number][]>
+    private _batches: THREE.BatchedMesh[]
 
     public get parser() {
         return this._mirabufParser
@@ -172,7 +172,7 @@ class MirabufInstance {
             maxIndices: number
         }
 
-        const batchMap = new Map<THREE.Material, Map<string, [mirabuf.IBody, Array<mirabuf.IPartInstance>]>>()
+        const batchMap = new Map<THREE.Material, Map<string, [mirabuf.IBody, mirabuf.IPartInstance[]]>>()
         const countMap = new Map<THREE.Material, BatchCounts>()
 
         // Filter all instances by first material, then body
@@ -192,7 +192,7 @@ class MirabufInstance {
 
                 let materialBodyMap = batchMap.get(material)
                 if (!materialBodyMap) {
-                    materialBodyMap = new Map<string, [mirabuf.IBody, Array<mirabuf.IPartInstance>]>()
+                    materialBodyMap = new Map<string, [mirabuf.IBody, mirabuf.IPartInstance[]]>()
                     batchMap.set(material, materialBodyMap)
                 }
 

--- a/fission/src/mirabuf/MirabufParser.ts
+++ b/fission/src/mirabuf/MirabufParser.ts
@@ -26,7 +26,7 @@ class MirabufParser {
     private _nodeNameCounter: number = 0
 
     private _assembly: mirabuf.Assembly
-    private _errors: Array<ParseError>
+    private _errors: ParseError[]
     private _directedGraph: Graph
     private _rootNode: string
 
@@ -34,7 +34,7 @@ class MirabufParser {
     private _designHierarchyRoot: mirabuf.INode = new mirabuf.Node()
 
     protected _partToNodeMap: Map<string, RigidNode> = new Map()
-    protected _rigidNodes: Array<RigidNode> = []
+    protected _rigidNodes: RigidNode[] = []
     private _globalTransforms: Map<string, THREE.Matrix4>
 
     private _groundedNode: RigidNode | undefined

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -146,10 +146,10 @@ class PhysicsSystem extends WorldSystem {
     private _joltInterface: Jolt.JoltInterface
     private _joltPhysSystem: Jolt.PhysicsSystem
     private _joltBodyInterface: Jolt.BodyInterface
-    private _bodies: Array<Jolt.BodyID>
-    private _constraints: Array<Jolt.Constraint>
+    private _bodies: Jolt.BodyID[]
+    private _constraints: Jolt.Constraint[]
     // Sphere game-piece bodies that get the resting-stiction pass each step (see update()).
-    private _sphereGamePieceBodies: Array<Jolt.BodyID> = []
+    private _sphereGamePieceBodies: Jolt.BodyID[] = []
 
     private _physicsEventQueue: SynthesisEvent<
         "OnContactAddedEvent" | "OnContactPersistedEvent" | "OnContactValidateEvent"


### PR DESCRIPTION
Cherry picked from https://github.com/Autodesk/synthesis/pull/1452 so this can hopefully get merged quicker. I personally prefer `Array<T>` but it doesn't really matter. 

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
