### PR TITLE
Allow gamepiece bodies to sleep `[SYNTH-314]`

### DIFF
--- a/fission/src/mirabuf/MirabufLoader.ts
+++ b/fission/src/mirabuf/MirabufLoader.ts
@@ -513,7 +513,7 @@ export async function spawnCachedMira(
                 }
 
                 progressHandle.done()
-
+                World.physicsSystem.deactivateGamepieces()
                 if (mirabufSceneObject.miraType == MiraType.ROBOT) {
                     globalOpenPanel(InitialConfigPanel, undefined)
                 }

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -1087,7 +1087,13 @@ class PhysicsSystem extends WorldSystem {
                 const body = this._joltBodyInterface.CreateBody(bodySettings)
                 this._joltBodyInterface.AddBody(body.GetID(), JOLT.EActivation_Activate)
 
-                // allowing gamepieces to sleep
+                // Game pieces are allowed to sleep, but are inactive by default
+                // they are placed at their initial position by their `MirabufSceneObject`
+                // which activates them.
+                this._joltBodyInterface.AddBody(
+                    body.GetID(),
+                    rn.isGamePiece ? JOLT.EActivation_DontActivate : JOLT.EActivation_Activate
+                )
                 if (!rn.isGamePiece) body.SetAllowSleeping(false)
                 rnToBodies.set(rn.id, body.GetID())
 

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -284,6 +284,17 @@ class PhysicsSystem extends WorldSystem {
         this.getBody(bodyId)!.SetIsSensor(false)
     }
 
+    /**
+     * Wakes a sleeping body.
+     *
+     * @param bodyId
+     */
+    public activateBody(bodyId: Jolt.BodyID) {
+        if (!this.isBodyAdded(bodyId)) return
+
+        this._joltBodyInterface.ActivateBody(bodyId)
+    }
+
     public isBodyAdded(bodyId: Jolt.BodyID) {
         return this._joltBodyInterface.IsAdded(bodyId)
     }

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -906,6 +906,8 @@ class PhysicsSystem extends WorldSystem {
             return parser.assembly.dynamic && assemblyMass > MAX_ROBOT_MASS ? MAX_ROBOT_MASS / assemblyMass : 1
         })()
 
+        const gamepieceBodies: Jolt.BodyID[] = []
+
         const minBounds = new JOLT.Vec3(1000000.0, 1000000.0, 1000000.0)
         const maxBounds = new JOLT.Vec3(-1000000.0, -1000000.0, -1000000.0)
 
@@ -1130,6 +1132,10 @@ class PhysicsSystem extends WorldSystem {
                 this._bodies.push(body.GetID())
                 body.SetRestitution(0.4)
 
+                if (rn.isGamePiece) {
+                    gamepieceBodies.push(body.GetID())
+                }
+
                 if (appliedSphereCollider) {
                     body.GetMotionProperties().SetAngularDamping(SPHERE_GP_ANGULAR_DAMPING)
                     body.GetMotionProperties().SetLinearDamping(SPHERE_GP_LINEAR_DAMPING)
@@ -1144,7 +1150,9 @@ class PhysicsSystem extends WorldSystem {
             // Cleanup
             JOLT.destroy(compoundShapeSettings)
         })
-
+        setTimeout(() => {
+            gamepieceBodies.forEach(body => this._joltBodyInterface.DeactivateBody(body))
+        })
         return rnToBodies
     }
 

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -150,6 +150,7 @@ class PhysicsSystem extends WorldSystem {
     private _constraints: Jolt.Constraint[]
     // Sphere game-piece bodies that get the resting-stiction pass each step (see update()).
     private _sphereGamePieceBodies: Jolt.BodyID[] = []
+    private _gamepiecesToFreeze: Jolt.BodyID[] = []
 
     private _physicsEventQueue: SynthesisEvent<
         "OnContactAddedEvent" | "OnContactPersistedEvent" | "OnContactValidateEvent"
@@ -298,6 +299,13 @@ class PhysicsSystem extends WorldSystem {
 
     public isBodyAdded(bodyId: Jolt.BodyID) {
         return this._joltBodyInterface.IsAdded(bodyId)
+    }
+
+    public deactivateGamepieces() {
+        this._gamepiecesToFreeze.forEach(body => {
+            this._joltBodyInterface.DeactivateBody(body)
+        })
+        this._gamepiecesToFreeze = []
     }
 
     /**
@@ -906,8 +914,6 @@ class PhysicsSystem extends WorldSystem {
             return parser.assembly.dynamic && assemblyMass > MAX_ROBOT_MASS ? MAX_ROBOT_MASS / assemblyMass : 1
         })()
 
-        const gamepieceBodies: Jolt.BodyID[] = []
-
         const minBounds = new JOLT.Vec3(1000000.0, 1000000.0, 1000000.0)
         const maxBounds = new JOLT.Vec3(-1000000.0, -1000000.0, -1000000.0)
 
@@ -1133,7 +1139,7 @@ class PhysicsSystem extends WorldSystem {
                 body.SetRestitution(0.4)
 
                 if (rn.isGamePiece) {
-                    gamepieceBodies.push(body.GetID())
+                    this._gamepiecesToFreeze.push(body.GetID())
                 }
 
                 if (appliedSphereCollider) {
@@ -1149,9 +1155,6 @@ class PhysicsSystem extends WorldSystem {
 
             // Cleanup
             JOLT.destroy(compoundShapeSettings)
-        })
-        setTimeout(() => {
-            gamepieceBodies.forEach(body => this._joltBodyInterface.DeactivateBody(body))
         })
         return rnToBodies
     }

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -193,6 +193,7 @@ class PhysicsSystem extends WorldSystem {
         this._joltPhysSystem.GetPhysicsSettings().mDeterministicSimulation = false
         this._joltPhysSystem.GetPhysicsSettings().mSpeculativeContactDistance = 0.06
         this._joltPhysSystem.GetPhysicsSettings().mPenetrationSlop = 0.005
+        this._joltPhysSystem.GetPhysicsSettings().mTimeBeforeSleep = 0.2
 
         const ground = this.createBox(
             new THREE.Vector3(7.5, 0.1, 7.5),
@@ -1096,7 +1097,6 @@ class PhysicsSystem extends WorldSystem {
                 }
 
                 const body = this._joltBodyInterface.CreateBody(bodySettings)
-                this._joltBodyInterface.AddBody(body.GetID(), JOLT.EActivation_Activate)
 
                 // Game pieces are allowed to sleep, but are inactive by default
                 // they are placed at their initial position by their `MirabufSceneObject`

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -1086,7 +1086,9 @@ class PhysicsSystem extends WorldSystem {
 
                 const body = this._joltBodyInterface.CreateBody(bodySettings)
                 this._joltBodyInterface.AddBody(body.GetID(), JOLT.EActivation_Activate)
-                body.SetAllowSleeping(false)
+
+                // allowing gamepieces to sleep
+                if (!rn.isGamePiece) body.SetAllowSleeping(false)
                 rnToBodies.set(rn.id, body.GetID())
 
                 // Set Friction Here
@@ -1406,7 +1408,8 @@ class PhysicsSystem extends WorldSystem {
         const zero = new JOLT.Vec3(0, 0, 0)
         this._sphereGamePieceBodies.forEach(bodyId => {
             const body = this.getBody(bodyId)
-            if (!body) return
+            // Sleeping bodies are already at rest and shouldn't be touched
+            if (!body || !body.IsActive()) return
 
             const atRest =
                 body.GetLinearVelocity().Length() < SPHERE_GP_STICTION_LINEAR_SPEED &&

--- a/fission/src/systems/scene/DragModeSystem.ts
+++ b/fission/src/systems/scene/DragModeSystem.ts
@@ -377,6 +377,11 @@ class DragModeSystem extends WorldSystem {
             return
         }
 
+        // keeping the dragged body awake so drag forces take effect even if body is sleeping
+        if (!this._dragTarget.physicsDisabled && !body.IsActive()) {
+            World.physicsSystem.activateBody(this._dragTarget.bodyId)
+        }
+
         const currentPos = body.GetPosition()
         const currentPosition = new THREE.Vector3(currentPos.GetX(), currentPos.GetY(), currentPos.GetZ())
         const currentRotation = body.GetRotation()

--- a/fission/src/test/physics/PhysicsSystem.test.ts
+++ b/fission/src/test/physics/PhysicsSystem.test.ts
@@ -1,6 +1,7 @@
 import type Jolt from "@synthesis.adsk/jolt-physics"
 import * as THREE from "three"
 import { afterEach, assert, beforeEach, describe, expect, test } from "vitest"
+import { GAMEPIECE_SUFFIX } from "@/mirabuf/MirabufParser"
 import { BodyAssociate } from "@/systems/physics/BodyAssociate"
 import JOLT from "@/util/loading/JoltSyncLoader"
 import PhysicsSystem, { LayerReserve } from "../../systems/physics/PhysicsSystem"
@@ -678,6 +679,9 @@ describe("Update Loop", () => {
 function makeMockParser(physicalData: { volume: number; area: number }, isGamePiece: boolean): MirabufParser {
     const tetraVerts = [0, 0, 0, 100, 0, 0, 0, 100, 0, 0, 0, 100]
 
+    // PhysicsSystem picks the collision layer off the node id suffix, not isGamePiece
+    const nodeId = isGamePiece ? `node-0${GAMEPIECE_SUFFIX}` : "node-0"
+
     return {
         assembly: {
             dynamic: false,
@@ -709,9 +713,9 @@ function makeMockParser(physicalData: { volume: number; area: number }, isGamePi
         },
         rigidNodes: new Map([
             [
-                "node-0",
+                nodeId,
                 {
-                    id: "node-0",
+                    id: nodeId,
                     parts: new Set(["part-0"]),
                     isDynamic: true,
                     isGamePiece,
@@ -762,5 +766,48 @@ describe("Sphere Game Piece Body Registration", () => {
         system.createBodiesFromParser(makeMockParser(SPHERE_DATA, true))
         system.createBodiesFromParser(makeMockParser(SPHERE_DATA, true))
         expect(system.sphereGamePieceBodies.length).toBe(2)
+    })
+})
+
+describe("Game Piece Sleeping", () => {
+    let system: PhysicsSystem
+
+    const SPHERE_DATA = { volume: 1767.15, area: 706.86 } // 2026 game piece approximate values
+
+    function spawnFromParser(isGamePiece: boolean): Jolt.Body {
+        const bodyIds = system.createBodiesFromParser(makeMockParser(SPHERE_DATA, isGamePiece))
+        const bodyId = [...bodyIds.values()][0]
+        return system.getBody(bodyId)!
+    }
+
+    beforeEach(() => {
+        system = new PhysicsSystem()
+    })
+
+    afterEach(() => {
+        system.destroy()
+    })
+
+    test("Game piece is allowed to sleep", () => {
+        expect(spawnFromParser(true).GetAllowSleeping()).toBe(true)
+    })
+
+    test("Non game piece is not allowed to sleep", () => {
+        expect(spawnFromParser(false).GetAllowSleeping()).toBe(false)
+    })
+
+    test("Game piece resting on the floor falls asleep", () => {
+        const floor = system.createBox(new THREE.Vector3(5, 0.5, 5), undefined, new THREE.Vector3(0, -1, 0), undefined)
+        system.addBodyToSystem(floor.GetID(), false)
+
+        const body = spawnFromParser(true)
+        expect(body.IsActive()).toBe(true)
+
+        // 4 seconds of fixed timestep: enough to drop, settle, and exceed Jolt's 0.5s sleep timer
+        for (let i = 0; i < 240; i++) {
+            system.update(1 / 60)
+        }
+
+        expect(body.IsActive()).toBe(false)
     })
 })

--- a/fission/src/test/physics/PhysicsSystem.test.ts
+++ b/fission/src/test/physics/PhysicsSystem.test.ts
@@ -788,6 +788,15 @@ describe("Game Piece Sleeping", () => {
         system.destroy()
     })
 
+    /** Steps the system until `body` sleeps, returning the step it slept on, or -1 if it never did. */
+    function stepUntilAsleep(body: Jolt.Body, maxSteps: number): number {
+        for (let i = 0; i < maxSteps; i++) {
+            system.update(1 / 60)
+            if (!body.IsActive()) return i
+        }
+        return -1
+    }
+
     test("Game piece is allowed to sleep", () => {
         expect(spawnFromParser(true).GetAllowSleeping()).toBe(true)
     })
@@ -796,18 +805,30 @@ describe("Game Piece Sleeping", () => {
         expect(spawnFromParser(false).GetAllowSleeping()).toBe(false)
     })
 
-    test("Game piece resting on the floor falls asleep", () => {
-        const floor = system.createBox(new THREE.Vector3(5, 0.5, 5), undefined, new THREE.Vector3(0, -1, 0), undefined)
-        system.addBodyToSystem(floor.GetID(), false)
+    test("Game piece spawns inactive", () => {
+        expect(spawnFromParser(true).IsActive()).toBe(false)
+    })
 
+    test("Non game piece spawns active", () => {
+        expect(spawnFromParser(false).IsActive()).toBe(true)
+    })
+
+    test("Game piece falls asleep once it settles", () => {
         const body = spawnFromParser(true)
+
+        // Game pieces originally spawn inactive at origin and MirabufSceneobject is what moves
+        // them to their rightful place.
+        system.setBodyPosition(body.GetID(), new JOLT.RVec3(0, 1, 0))
         expect(body.IsActive()).toBe(true)
 
-        // 4 seconds of fixed timestep: enough to drop, settle, and exceed Jolt's 0.5s sleep timer
-        for (let i = 0; i < 240; i++) {
-            system.update(1 / 60)
-        }
+        // settling is pretty slow (sphere takes 300 steps to sleep; 5 seconds)
+        expect(stepUntilAsleep(body, 900)).toBeGreaterThanOrEqual(0)
+    })
 
-        expect(body.IsActive()).toBe(false)
+    test("Non game piece never sleeps even at rest", () => {
+        const body = spawnFromParser(false)
+        system.setBodyPosition(body.GetID(), new JOLT.RVec3(0, 1, 0))
+
+        expect(stepUntilAsleep(body, 900)).toBe(-1)
     })
 })

--- a/fission/src/test/scene/DragModeSystem.test.ts
+++ b/fission/src/test/scene/DragModeSystem.test.ts
@@ -124,7 +124,7 @@ describe("DragModeSystem Integration Tests", () => {
     })
 
     describe("Physics Integration", () => {
-        function setupDraggableCube() {
+        function setupDraggableCube(spawnActive: boolean = true) {
             // Create a physics cube which will then be a draggable game piece
             const vertices = new Float32Array([
                 -0.5, -0.5, -0.5, 0.5, -0.5, -0.5, 0.5, 0.5, -0.5, -0.5, 0.5, -0.5, -0.5, -0.5, 0.5, 0.5, -0.5, 0.5,
@@ -137,7 +137,7 @@ describe("DragModeSystem Integration Tests", () => {
             const shape = shapeResult.Get()
             const body = physicsSystem.createBody(shape, 1.0, new THREE.Vector3(0, 0, 0), new THREE.Quaternion())
             const bodyId = body.GetID()
-            physicsSystem.addBodyToSystem(bodyId, true)
+            physicsSystem.addBodyToSystem(bodyId, spawnActive)
 
             // Create a mock MirabufSceneObject that properly passes `instanceof` checks
             const mockSceneObject = Object.create(MirabufSceneObject.prototype)
@@ -218,6 +218,44 @@ describe("DragModeSystem Integration Tests", () => {
             }
 
             screenHandler.interactionEnd?.(endInteraction)
+
+            cleanup()
+        })
+
+        test("should wake and drag a sleeping game piece", () => {
+            const { physicsBody, cleanup } = setupDraggableCube(false)
+            expect(physicsBody.IsActive()).toBe(false)
+
+            const initialPos = physicsBody.GetPosition()
+            const initialPosition = { x: initialPos.GetX(), y: initialPos.GetY(), z: initialPos.GetZ() }
+
+            const screenHandler = World.sceneRenderer.screenInteractionHandler
+            screenHandler?.interactionStart?.({
+                interactionType: PRIMARY_MOUSE_INTERACTION as InteractionType,
+                position: [400, 300] as [number, number],
+            })
+            screenHandler?.interactionMove?.({
+                interactionType: PRIMARY_MOUSE_INTERACTION as InteractionType,
+                movement: [100, 0] as [number, number],
+            })
+
+            for (let i = 0; i < 10; i++) {
+                dragModeSystem.update(0.016)
+                physicsSystem.update(0.016)
+            }
+
+            expect(physicsBody.IsActive()).toBe(true)
+            const afterDragPos = physicsBody.GetPosition()
+            const moved =
+                Math.abs(afterDragPos.GetX() - initialPosition.x) > 0.2 ||
+                Math.abs(afterDragPos.GetY() - initialPosition.y) > 0.2 ||
+                Math.abs(afterDragPos.GetZ() - initialPosition.z) > 0.2
+            expect(moved).toBe(true)
+
+            screenHandler.interactionEnd?.({
+                interactionType: PRIMARY_MOUSE_INTERACTION as InteractionType,
+                position: [400, 300] as [number, number],
+            })
 
             cleanup()
         })


### PR DESCRIPTION
This is extracted from Dhruv's #1421, which is now a draft, and includes the sleeping gamepieces but not the physics timestep changes
<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-314

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

See #1421

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Rebased and dropped the time-step commits, which were the controversial changes that caused other issues.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [X] Necessary test cases have been added and updated.
- [X] A feature toggle or safe disable path has been added (if applicable).
- [X] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [X] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
