### PR TITLE
Use time-based timer for match mode and improve styling `[SYNTH-315]`

### DIFF
--- a/fission/src/systems/match_mode/MatchMode.ts
+++ b/fission/src/systems/match_mode/MatchMode.ts
@@ -130,7 +130,7 @@ class MatchMode {
     }
 
     async start(broadcast = true, useSpawnPositions: boolean) {
-        const startTime = Date.now() + 500
+        const startTime = Date.now() + 300 // Accounts for time it takes for robots to move to start positions and settle, and for multiplayer state to sync
         if (broadcast && World.multiplayerSystem) {
             await World.multiplayerSystem.broadcast({
                 type: "matchModeState",
@@ -147,12 +147,14 @@ class MatchMode {
         if (useSpawnPositions) {
             World.getOwnRobots().forEach(obj => obj.moveToSpawnLocation())
         }
-        this.autonomousModeStart()
+
         World.scoreTracker.resetScores()
         RobotDimensionTracker.matchStart()
 
         const matchEvent = createMatchEventFromConfig(this._matchModeConfig)
         World.analyticsSystem?.event("Match Start", matchEvent)
+
+        this.runForNext(0, false).then(() => this.autonomousModeStart())
     }
 
     matchEnded() {

--- a/fission/src/systems/match_mode/MatchMode.ts
+++ b/fission/src/systems/match_mode/MatchMode.ts
@@ -46,6 +46,7 @@ class MatchMode {
     private _startTime: number = 0
     private _timeUsed: number = 0
     private _intervalId: number | null = null
+    private _cancelHandler: (() => void) | null = null
 
     // Match Mode Config
     private _matchModeConfig: MatchModeConfig = DefaultMatchModeConfigs.fallbackValues()
@@ -72,6 +73,11 @@ class MatchMode {
         return this._matchModeConfig
     }
 
+    /**
+     * Waits for the specified duration in match time to pass, accounting for delays from prior loop cycles. Resolves when the time has elapsed, rejects if cancelled.
+     * @param duration The duration, in seconds, of the phase
+     * @param updateTimeLeft Whether to dispatch scoreboard update events
+     */
     async runForNext(duration: number, updateTimeLeft: boolean = true) {
         if (this._intervalId !== null) {
             console.warn("Timer already running")
@@ -98,7 +104,10 @@ class MatchMode {
         }, 200)
 
         const remainingTime = this._startTime + this._timeUsed - Date.now() + duration * 1000
-        return new Promise<void>(res => setTimeout(res, remainingTime)).finally(() => {
+        return new Promise((res, reject) => {
+            setTimeout(res, remainingTime)
+            this._cancelHandler = () => reject("Cancelled")
+        }).finally(() => {
             this._timeUsed += duration * 1000
             clearInterval(this._intervalId as number)
             this._intervalId = null
@@ -108,18 +117,24 @@ class MatchMode {
     autonomousModeStart() {
         void SoundPlayer.getInstance().play(MatchStart)
         this.setMatchModeType(MatchModeType.AUTONOMOUS)
-        this.runForNext(this._matchModeConfig.autonomousTime).then(() => this.autonomousModeEnd())
+        this.runForNext(this._matchModeConfig.autonomousTime)
+            .then(() => this.autonomousModeEnd())
+            .catch(() => {})
     }
 
     autonomousModeEnd() {
         void SoundPlayer.getInstance().play(MatchEnd)
-        this.runForNext(3, false).then(() => this.teleopModeStart()) // Delay between autonomous and teleop modes
+        this.runForNext(3, false) // Delay between autonomous and teleop modes
+            .then(() => this.teleopModeStart())
+            .catch(() => {})
     }
 
     teleopModeStart() {
         void SoundPlayer.getInstance().play(MatchResume)
         this.setMatchModeType(MatchModeType.TELEOP)
-        this.runForNext(this._matchModeConfig.teleopTime).then(() => this.matchEnded())
+        this.runForNext(this._matchModeConfig.teleopTime)
+            .then(() => this.matchEnded())
+            .catch(() => {})
     }
 
     endgameStart() {
@@ -142,6 +157,8 @@ class MatchMode {
             })
         }
 
+        this.reset()
+
         this._startTime = startTime
 
         if (useSpawnPositions) {
@@ -154,7 +171,9 @@ class MatchMode {
         const matchEvent = createMatchEventFromConfig(this._matchModeConfig)
         World.analyticsSystem?.event("Match Start", matchEvent)
 
-        this.runForNext(0, false).then(() => this.autonomousModeStart())
+        this.runForNext(0, false)
+            .then(() => this.autonomousModeStart())
+            .catch(() => {})
     }
 
     matchEnded() {
@@ -166,13 +185,18 @@ class MatchMode {
         globalOpenModal(MatchResultsModal, undefined)
     }
 
-    sandboxModeStart() {
-        this.setMatchModeType(MatchModeType.SANDBOX)
+    reset() {
         clearInterval(this._intervalId as number)
         this._startTime = 0
         this._timeUsed = 0
+        this._endgame = false
+        this._cancelHandler?.()
         EventSystem.dispatch("TimeChangedEvent", { time: 0 })
         World.scoreTracker.resetScores()
+    }
+    sandboxModeStart() {
+        this.setMatchModeType(MatchModeType.SANDBOX)
+        this.reset()
     }
 
     isMatchEnabled(): boolean {

--- a/fission/src/systems/match_mode/MatchMode.ts
+++ b/fission/src/systems/match_mode/MatchMode.ts
@@ -43,8 +43,8 @@ class MatchMode {
         EventSystem.dispatch("MatchStateChangedEvent", { mode: val })
     }
 
-    private _initialTime: number = 0
-    private _timeLeft: number = 0
+    private _startTime: number = 0
+    private _timeUsed: number = 0
     private _intervalId: number | null = null
 
     // Match Mode Config
@@ -72,53 +72,54 @@ class MatchMode {
         return this._matchModeConfig
     }
 
-    async runTimer(duration: number, updateTimeLeft: boolean = true) {
-        this._initialTime = duration
-        this._timeLeft = duration
+    async runForNext(duration: number, updateTimeLeft: boolean = true) {
+        if (this._intervalId !== null) {
+            console.warn("Timer already running")
+        }
 
         // Dispatch an event to update the time left in the UI
-        if (updateTimeLeft) EventSystem.dispatch("TimeChangedEvent", { time: this._initialTime })
-        return new Promise<void>(res => {
-            this._intervalId = window.setInterval(() => {
-                this._timeLeft--
+        if (updateTimeLeft) EventSystem.dispatch("TimeChangedEvent", { time: duration })
+        this._intervalId = window.setInterval(() => {
+            const timeElapsed = (Date.now() - this._startTime - this._timeUsed) / 1000
+            const timeLeft = duration - timeElapsed
 
-                if (this._timeLeft >= 0 && updateTimeLeft) {
-                    EventSystem.dispatch("TimeChangedEvent", { time: this._timeLeft })
-                }
+            if (timeLeft >= 0 && updateTimeLeft) {
+                EventSystem.dispatch("TimeChangedEvent", { time: timeLeft })
+            }
 
-                // Checks if endgame has started
-                if (
-                    this._matchModeType === MatchModeType.TELEOP &&
-                    this._timeLeft == this._matchModeConfig.endgameTime
-                ) {
-                    this.endgameStart()
-                }
+            // Checks if endgame has started
+            if (
+                this._matchModeType === MatchModeType.TELEOP &&
+                timeLeft <= this._matchModeConfig.endgameTime &&
+                !this._endgame
+            ) {
+                this.endgameStart()
+            }
+        }, 200)
 
-                if (this._timeLeft <= 0) {
-                    console.log("resolving")
-                    res()
-                }
-            }, 1000)
-        }).finally(() => {
+        const remainingTime = this._startTime + this._timeUsed - Date.now() + duration * 1000
+        return new Promise<void>(res => setTimeout(res, remainingTime)).finally(() => {
+            this._timeUsed += duration * 1000
             clearInterval(this._intervalId as number)
+            this._intervalId = null
         })
     }
 
     autonomousModeStart() {
         void SoundPlayer.getInstance().play(MatchStart)
         this.setMatchModeType(MatchModeType.AUTONOMOUS)
-        this.runTimer(this._matchModeConfig.autonomousTime).then(() => this.autonomousModeEnd())
+        this.runForNext(this._matchModeConfig.autonomousTime).then(() => this.autonomousModeEnd())
     }
 
     autonomousModeEnd() {
         void SoundPlayer.getInstance().play(MatchEnd)
-        this.runTimer(3, false).then(() => this.teleopModeStart()) // Delay between autonomous and teleop modes
+        this.runForNext(3, false).then(() => this.teleopModeStart()) // Delay between autonomous and teleop modes
     }
 
     teleopModeStart() {
         void SoundPlayer.getInstance().play(MatchResume)
         this.setMatchModeType(MatchModeType.TELEOP)
-        this.runTimer(this._matchModeConfig.teleopTime).then(() => this.matchEnded())
+        this.runForNext(this._matchModeConfig.teleopTime).then(() => this.matchEnded())
     }
 
     endgameStart() {
@@ -129,13 +130,20 @@ class MatchMode {
     }
 
     async start(broadcast = true, useSpawnPositions: boolean) {
-        if (broadcast) {
-            await World.multiplayerSystem?.broadcast({
+        const startTime = Date.now() + 500
+        if (broadcast && World.multiplayerSystem) {
+            await World.multiplayerSystem.broadcast({
                 type: "matchModeState",
-                data: { event: "start", config: this._matchModeConfig, moveRobots: useSpawnPositions },
+                data: {
+                    event: "start",
+                    config: this._matchModeConfig,
+                    moveRobots: useSpawnPositions,
+                },
             })
-            console.log("sent multiplayer")
         }
+
+        this._startTime = startTime
+
         if (useSpawnPositions) {
             World.getOwnRobots().forEach(obj => obj.moveToSpawnLocation())
         }
@@ -149,7 +157,6 @@ class MatchMode {
 
     matchEnded() {
         void SoundPlayer.getInstance().play(MatchEnd)
-        clearInterval(this._intervalId as number)
         this.setMatchModeType(MatchModeType.MATCH_ENDED)
 
         const matchEvent = createMatchEventFromConfig(this._matchModeConfig)
@@ -160,9 +167,9 @@ class MatchMode {
     sandboxModeStart() {
         this.setMatchModeType(MatchModeType.SANDBOX)
         clearInterval(this._intervalId as number)
-        this._initialTime = 0
-        this._timeLeft = 0
-        EventSystem.dispatch("TimeChangedEvent", { time: this._timeLeft })
+        this._startTime = 0
+        this._timeUsed = 0
+        EventSystem.dispatch("TimeChangedEvent", { time: 0 })
         World.scoreTracker.resetScores()
     }
 

--- a/fission/src/ui/modals/MatchResultsModal.tsx
+++ b/fission/src/ui/modals/MatchResultsModal.tsx
@@ -40,12 +40,12 @@ const getPerRobotScores = (): { redRobotScores: Entry[]; blueRobotScores: Entry[
     return { redRobotScores, blueRobotScores }
 }
 
-const LabelStyled = styled(Typography)<{ winnerColor: string; fontSize: string }>(({ winnerColor, fontSize }) => ({
+const LabelStyled = styled(Typography)<{ color: string; fontSize: string }>(({ color, fontSize }) => ({
     fontWeight: 700,
     fontSize: fontSize,
     margin: "0pt",
     marginTop: "0.5rem",
-    color: winnerColor,
+    color: color,
 }))
 
 const MatchResultsModal: React.FC<ModalImplProps<void, void>> = ({ modal }) => {
@@ -70,7 +70,7 @@ const MatchResultsModal: React.FC<ModalImplProps<void, void>> = ({ modal }) => {
 
     return (
         <Stack direction={"column"}>
-            <LabelStyled winnerColor={color} fontSize="1.5rem">
+            <LabelStyled color={color} fontSize="1.5rem">
                 {message}
             </LabelStyled>
             <Divider sx={{ my: "1rem" }} />
@@ -87,7 +87,7 @@ const MatchResultsModal: React.FC<ModalImplProps<void, void>> = ({ modal }) => {
                 ))}
             </Stack>
             <Divider sx={{ my: "0.5rem" }} />
-            <LabelStyled winnerColor={primaryColor} fontSize="1.25rem" mb={1}>
+            <LabelStyled color={primaryColor} fontSize="1.25rem" mb={1}>
                 Robot Score Contributions
             </LabelStyled>
             <Stack direction={"row"} justifyContent={"space-between"} gap={2}>
@@ -121,7 +121,7 @@ interface RobotContributionProps {
 const RobotContributions: React.FC<RobotContributionProps> = ({ allianceColor, scores, label }) => {
     return (
         <Stack direction={"column"}>
-            <LabelStyled winnerColor={allianceColor} fontSize="1rem">
+            <LabelStyled color={allianceColor} fontSize="1rem">
                 {label}
             </LabelStyled>
             <div className="flex flex-col">

--- a/fission/src/ui/modals/MatchResultsModal.tsx
+++ b/fission/src/ui/modals/MatchResultsModal.tsx
@@ -1,5 +1,6 @@
 import { Divider, Stack, styled, Typography } from "@mui/material"
 import type React from "react"
+import type { ReactNode } from "react"
 import { useEffect } from "react"
 import MatchMode from "@/systems/match_mode/MatchMode"
 import { useThemeContext } from "@/ui/helpers/ThemeProviderHelpers.ts"
@@ -8,6 +9,7 @@ import type { ModalImplProps } from "../components/Modal"
 import { Button } from "../components/StyledComponents"
 import { CloseType, useUIContext } from "../helpers/UIProviderHelpers"
 import World from "@/systems/World.ts"
+import { Box } from "@mui/system"
 
 type Entry = {
     name: string
@@ -67,50 +69,35 @@ const MatchResultsModal: React.FC<ModalImplProps<void, void>> = ({ modal }) => {
     }, [configureScreen, modal])
 
     return (
-        <>
+        <Stack direction={"column"}>
             <LabelStyled winnerColor={color} fontSize="1.5rem">
                 {message}
             </LabelStyled>
             <Divider sx={{ my: "1rem" }} />
-            <Stack>
+            <Stack gap={1}>
                 {entries.map(e => (
                     <Stack key={e.name} direction="row" justifyContent={"space-between"}>
                         <Label size="md">{e.name}</Label>
-                        <Label size="md">{e.value}</Label>
+                        <ScoreBox>
+                            <Label size="md" sx={{ minWidth: "3em", textAlign: "center" }}>
+                                {e.value}
+                            </Label>
+                        </ScoreBox>
                     </Stack>
                 ))}
             </Stack>
             <Divider sx={{ my: "0.5rem" }} />
-            <LabelStyled winnerColor={primaryColor} fontSize="1.25rem">
+            <LabelStyled winnerColor={primaryColor} fontSize="1.25rem" mb={1}>
                 Robot Score Contributions
             </LabelStyled>
-            <Stack direction={"row"} justifyContent={"space-between"} gap={"1rem"}>
-                <Stack direction={"column"}>
-                    <LabelStyled winnerColor={redAllianceColor} fontSize="1rem">
-                        Red Alliance
-                    </LabelStyled>
-                    <div className="flex flex-col">
-                        {redRobotScores.map(e => (
-                            <Stack key={e.name} direction="row" justifyContent={"space-between"}>
-                                <Label size="md">{e.name}</Label>
-                                <Label size="md">{e.value}</Label>
-                            </Stack>
-                        ))}
-                    </div>
-                </Stack>
-                <Stack direction={"column"}>
-                    <LabelStyled winnerColor={blueAllianceColor} fontSize="1rem">
-                        Blue Alliance
-                    </LabelStyled>
-                    <div className="flex flex-col">
-                        {blueRobotScores.map(e => (
-                            <Stack key={e.name} direction="row" justifyContent={"space-between"}>
-                                <Label size="md">{e.name}</Label>
-                                <Label size="md">{e.value}</Label>
-                            </Stack>
-                        ))}
-                    </div>
-                </Stack>
+            <Stack direction={"row"} justifyContent={"space-between"} gap={2}>
+                <RobotContributions allianceColor={redAllianceColor} label={"Red Alliance"} scores={redRobotScores} />
+                <Divider orientation={"vertical"} flexItem />
+                <RobotContributions
+                    allianceColor={blueAllianceColor}
+                    label={"Blue Alliance"}
+                    scores={blueRobotScores}
+                />
             </Stack>
             <Button
                 onClick={() => {
@@ -121,8 +108,40 @@ const MatchResultsModal: React.FC<ModalImplProps<void, void>> = ({ modal }) => {
             >
                 Back to Sandbox Mode
             </Button>
-        </>
+        </Stack>
     )
+}
+
+interface RobotContributionProps {
+    allianceColor: string
+    scores: Entry[]
+    label: string
+}
+
+const RobotContributions: React.FC<RobotContributionProps> = ({ allianceColor, scores, label }) => {
+    return (
+        <Stack direction={"column"}>
+            <LabelStyled winnerColor={allianceColor} fontSize="1rem">
+                {label}
+            </LabelStyled>
+            <div className="flex flex-col">
+                {scores.map(e => (
+                    <Stack key={e.name} direction="row" alignItems="center" justifyContent={"space-between"} gap={2}>
+                        <Label size="md">{e.name}</Label>
+                        <ScoreBox key={e.name}>
+                            <Label size="sm" sx={{ minWidth: "2em", textAlign: "center" }}>
+                                {e.value}
+                            </Label>
+                        </ScoreBox>
+                    </Stack>
+                ))}
+            </div>
+        </Stack>
+    )
+}
+
+const ScoreBox: React.FC<{ children: ReactNode }> = ({ children }) => {
+    return <Box sx={{ bgcolor: "background.paper", padding: 0.5, borderRadius: 2 }}>{children}</Box>
 }
 
 export default MatchResultsModal


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-315

Predicate for multiplayer

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Previously, the match mode timer was decremented manually by 1 second every 1000ish ms (setInterval does not guarantee that it runs exactly at the time interval, just that it doesn't run any more frequently). This meant that matches would be randomly longer than they should be based on how long the event loops took. This is the same issue that occurred with the FMS on Newton at the 2026 World Championship, so I guess by fixing this we are decreasing realism.



## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

I used a start time variable to keep track of elapsed times. It still uses setTimeout to trigger behavior, but this is unavoidable in JS. What this change accomplishes is preventing those delays from compounding, so it might be 30ms behind, but it won't be an additional 30ms behind every second.


Also the styling was kind of wonky on match results with the robot breakdown, and it threw a react error, both of which are now fixed.


## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

Timer works as expected and matches external timing source, even when slowed down browser via dev tools or 2026 field (he he) 

---

Before merging, ensure the following criteria are met:

- [X] All acceptance criteria outlined in the ticket are met.
- [X] Necessary test cases have been added and updated.
- [X] A feature toggle or safe disable path has been added (if applicable).
- [X] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [X] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
