### PR TITLE
Fix Drag Mode During Gizmo Move `[SYNTH-322]`

### DIFF
--- a/fission/src/systems/scene/DragModeSystem.ts
+++ b/fission/src/systems/scene/DragModeSystem.ts
@@ -224,6 +224,8 @@ class DragModeSystem extends WorldSystem {
     }
 
     private findDragTarget(mousePos: [number, number]): { bodyId: Jolt.BodyID; hitPoint: THREE.Vector3 } | undefined {
+        if (World.physicsSystem.isPaused) return undefined
+
         const result = rayCastForRigidBody(mousePos)
         if (!result || !this.isDraggable(result.association)) return undefined
         return { bodyId: result.bodyId, hitPoint: result.hitPoint }
@@ -370,6 +372,7 @@ class DragModeSystem extends WorldSystem {
 
     private updateDragForce(): void {
         if (!this._dragTarget) return
+        if (World.physicsSystem.isPaused) return
 
         const body = World.physicsSystem.getBody(this._dragTarget.bodyId)
         if (!body) {


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-322

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Moving an object using the gizmo move tool while drag mode was enabled would result in a unexpected force being applied after you confirmed the new robot position.


https://github.com/user-attachments/assets/656669a9-abc1-4b61-9345-77b3dc776a91


## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Don't run drag mode if the World physics system is paused.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

- [x] Drag mode still works as before
- [x] Moving a robot while drag mode is active doesn't cause a bounce at the end

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
