### PR TITLE
URDF Split Stacked Visual Links `[SYNTH-335]`

### DIFF
--- a/fission/src/mirabuf/PartDeletionBuilder.ts
+++ b/fission/src/mirabuf/PartDeletionBuilder.ts
@@ -3,8 +3,7 @@ import type { mirabuf } from "@/proto/mirabuf"
 
 /**
  * Removes guid's node from the design hierarchy, wherever it lives, re-parenting its children in its place.
- * The hierarchy is derived from the joint/fastener graph (not assembly containment), so a node's descendants
- * are routinely unrelated parts elsewhere in the robot — only the selected guid itself is safe to remove.
+ * The hierarchy is derived from the joint/fastener graph (not assembly containment).
  * Returns the removed GUID.
  */
 function removeFromDesignHierarchy(designHierarchy: mirabuf.IGraphContainer, guid: string): Set<string> {

--- a/fission/src/mirabuf/PartDeletionBuilder.ts
+++ b/fission/src/mirabuf/PartDeletionBuilder.ts
@@ -1,12 +1,12 @@
 import { GROUNDED_JOINT_ID } from "@/mirabuf/MirabufParser"
 import type { mirabuf } from "@/proto/mirabuf"
 
-function collectSubtreeGuids(node: mirabuf.INode, acc: Set<string>): void {
-    if (node.value) acc.add(node.value)
-    node.children?.forEach(child => collectSubtreeGuids(child, acc))
-}
-
-/** Removes guid's node (and its descendants) from the design hierarchy, wherever it lives. Returns the removed GUIDs. */
+/**
+ * Removes guid's node from the design hierarchy, wherever it lives, re-parenting its children in its place.
+ * The hierarchy is derived from the joint/fastener graph (not assembly containment), so a node's descendants
+ * are routinely unrelated parts elsewhere in the robot — only the selected guid itself is safe to remove.
+ * Returns the removed GUID.
+ */
 function removeFromDesignHierarchy(designHierarchy: mirabuf.IGraphContainer, guid: string): Set<string> {
     const removed = new Set<string>()
 
@@ -15,8 +15,8 @@ function removeFromDesignHierarchy(designHierarchy: mirabuf.IGraphContainer, gui
 
         const index = children.findIndex(n => n.value === guid)
         if (index !== -1) {
-            collectSubtreeGuids(children[index], removed)
-            children.splice(index, 1)
+            removed.add(children[index].value!)
+            children.splice(index, 1, ...(children[index].children ?? []))
             return true
         }
 
@@ -27,7 +27,7 @@ function removeFromDesignHierarchy(designHierarchy: mirabuf.IGraphContainer, gui
     return removed
 }
 
-/** Mutates assembly in place: removes each part's subtree and prunes joints/rigid groups referencing it. */
+/** Mutates assembly in place: removes each selected part and prunes joints/rigid groups referencing it. */
 export function applyPartDeletions(assembly: mirabuf.Assembly, partGuids: string[]): void {
     const designHierarchy = assembly.designHierarchy
     if (!designHierarchy) throw new Error("Assembly has no design hierarchy")

--- a/fission/src/systems/scene/ApplyModelConfig.ts
+++ b/fission/src/systems/scene/ApplyModelConfig.ts
@@ -18,13 +18,12 @@ export async function applyModelConfigChanges(): Promise<boolean> {
     wheelMode.clearHover()
     deleteMode.clearHover()
 
-    const sceneObject = World.wheelAssignmentMode.sceneObject
+    const sceneObject = World.wheelAssignmentMode.sceneObject ?? World.partDeletionMode.sceneObject
     if (sceneObject == null) {
         console.warn("Missing part handler", World.wheelAssignmentMode.sceneObject, World.partDeletionMode.sceneObject)
         return false
     }
     const sceneId = sceneObject.id
-    if (!sceneObject) return false
 
     const assembly = sceneObject.mirabufInstance.parser.assembly
 

--- a/fission/src/systems/scene/PartDeletionMode.ts
+++ b/fission/src/systems/scene/PartDeletionMode.ts
@@ -1,7 +1,32 @@
 import type * as THREE from "three"
+import { GROUNDED_JOINT_ID } from "@/mirabuf/MirabufParser"
+import type { mirabuf } from "@/proto/mirabuf"
 import EventSystem from "@/systems/EventSystem.ts"
 import { globalAddToast } from "@/ui/components/GlobalUIControls"
 import PartPickingMode, { type HighlightMap, type PartPick, type PartSelection } from "./PartPickingMode"
+
+/** Finds guid's node in the design hierarchy along with its parent and children (link references). */
+function findHierarchyContext(
+    container: mirabuf.IGraphContainer | null | undefined,
+    guid: string
+): { parentGuid?: string; childGuids: string[] } | undefined {
+    function search(
+        children: mirabuf.INode[] | undefined | null,
+        parentGuid?: string
+    ): { parentGuid?: string; childGuids: string[] } | undefined {
+        if (!children) return undefined
+        for (const node of children) {
+            if (node.value === guid) {
+                return { parentGuid, childGuids: node.children?.map(c => c.value!).filter(Boolean) ?? [] }
+            }
+            const found = search(node.children, node.value ?? parentGuid)
+            if (found) return found
+        }
+        return undefined
+    }
+
+    return search(container?.nodes, undefined)
+}
 
 export interface PartDeletionSelection extends PartSelection {
     name: string
@@ -32,11 +57,48 @@ class PartDeletionMode extends PartPickingMode<PartDeletionSelection> {
             return
         }
 
+        this.logSelection(pick.guid)
+
         this.pending.addPart(pick.guid, {
             guid: pick.guid,
             name: this.getName(pick.guid),
             highlight: { instanceId: pick.instanceId, mesh: pick.object as THREE.BatchedMesh },
         })
+    }
+
+    /** Logs the selected part's name, joints (mates) referencing it, and design-hierarchy links, in real time. */
+    private logSelection(guid: string): void {
+        const assembly = this._object?.mirabufInstance.parser.assembly
+        const partInstances = assembly?.data?.parts?.partInstances
+        const jointInstances = assembly?.data?.joints?.jointInstances
+
+        const mates = Object.entries(jointInstances ?? {})
+            .filter(([key, inst]) => key !== GROUNDED_JOINT_ID && (inst.parentPart === guid || inst.childPart === guid))
+            .map(([key, inst]) => ({
+                key,
+                name: inst.info?.name,
+                parentPart: inst.parentPart,
+                parentPartName: partInstances?.[inst.parentPart!]?.info?.name,
+                childPart: inst.childPart,
+                childPartName: partInstances?.[inst.childPart!]?.info?.name,
+            }))
+
+        const hierarchy = findHierarchyContext(assembly?.designHierarchy, guid)
+
+        const info = {
+            guid,
+            name: this.getName(guid),
+            mates,
+            hierarchy: {
+                parentGuid: hierarchy?.parentGuid,
+                parentName: hierarchy?.parentGuid ? partInstances?.[hierarchy.parentGuid]?.info?.name : undefined,
+                childGuids: hierarchy?.childGuids ?? [],
+                childNames: hierarchy?.childGuids?.map(g => partInstances?.[g]?.info?.name) ?? [],
+            },
+        }
+
+        // Logged as a JSON string (not the raw object) to avoid devtools truncating long arrays/objects in the console.
+        console.log(`[PartDeletionMode] selected part:\n${JSON.stringify(info, null, 2)}`)
     }
 }
 

--- a/fission/src/systems/scene/PartDeletionMode.ts
+++ b/fission/src/systems/scene/PartDeletionMode.ts
@@ -1,32 +1,7 @@
 import type * as THREE from "three"
-import { GROUNDED_JOINT_ID } from "@/mirabuf/MirabufParser"
-import type { mirabuf } from "@/proto/mirabuf"
 import EventSystem from "@/systems/EventSystem.ts"
 import { globalAddToast } from "@/ui/components/GlobalUIControls"
 import PartPickingMode, { type HighlightMap, type PartPick, type PartSelection } from "./PartPickingMode"
-
-/** Finds guid's node in the design hierarchy along with its parent and children (link references). */
-function findHierarchyContext(
-    container: mirabuf.IGraphContainer | null | undefined,
-    guid: string
-): { parentGuid?: string; childGuids: string[] } | undefined {
-    function search(
-        children: mirabuf.INode[] | undefined | null,
-        parentGuid?: string
-    ): { parentGuid?: string; childGuids: string[] } | undefined {
-        if (!children) return undefined
-        for (const node of children) {
-            if (node.value === guid) {
-                return { parentGuid, childGuids: node.children?.map(c => c.value!).filter(Boolean) ?? [] }
-            }
-            const found = search(node.children, node.value ?? parentGuid)
-            if (found) return found
-        }
-        return undefined
-    }
-
-    return search(container?.nodes, undefined)
-}
 
 export interface PartDeletionSelection extends PartSelection {
     name: string
@@ -57,48 +32,11 @@ class PartDeletionMode extends PartPickingMode<PartDeletionSelection> {
             return
         }
 
-        this.logSelection(pick.guid)
-
         this.pending.addPart(pick.guid, {
             guid: pick.guid,
             name: this.getName(pick.guid),
             highlight: { instanceId: pick.instanceId, mesh: pick.object as THREE.BatchedMesh },
         })
-    }
-
-    /** Logs the selected part's name, joints (mates) referencing it, and design-hierarchy links, in real time. */
-    private logSelection(guid: string): void {
-        const assembly = this._object?.mirabufInstance.parser.assembly
-        const partInstances = assembly?.data?.parts?.partInstances
-        const jointInstances = assembly?.data?.joints?.jointInstances
-
-        const mates = Object.entries(jointInstances ?? {})
-            .filter(([key, inst]) => key !== GROUNDED_JOINT_ID && (inst.parentPart === guid || inst.childPart === guid))
-            .map(([key, inst]) => ({
-                key,
-                name: inst.info?.name,
-                parentPart: inst.parentPart,
-                parentPartName: partInstances?.[inst.parentPart!]?.info?.name,
-                childPart: inst.childPart,
-                childPartName: partInstances?.[inst.childPart!]?.info?.name,
-            }))
-
-        const hierarchy = findHierarchyContext(assembly?.designHierarchy, guid)
-
-        const info = {
-            guid,
-            name: this.getName(guid),
-            mates,
-            hierarchy: {
-                parentGuid: hierarchy?.parentGuid,
-                parentName: hierarchy?.parentGuid ? partInstances?.[hierarchy.parentGuid]?.info?.name : undefined,
-                childGuids: hierarchy?.childGuids ?? [],
-                childNames: hierarchy?.childGuids?.map(g => partInstances?.[g]?.info?.name) ?? [],
-            },
-        }
-
-        // Logged as a JSON string (not the raw object) to avoid devtools truncating long arrays/objects in the console.
-        console.log(`[PartDeletionMode] selected part:\n${JSON.stringify(info, null, 2)}`)
     }
 }
 

--- a/fission/src/urdf/URDFConverter.ts
+++ b/fission/src/urdf/URDFConverter.ts
@@ -70,7 +70,6 @@ function rpyToMatrix(roll: number, pitch: number, yaw: number): Mat3 {
     ]
 }
 
-// Inverse of rpyToMatrix (ZYX Euler extraction). https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
 function matrixToRPY(m: Mat3): [number, number, number] {
     const pitch = Math.asin(Math.min(1, Math.max(-1, -m[2][0])))
     const yaw = Math.atan2(m[1][0], m[0][0])
@@ -305,15 +304,8 @@ function fillMissingMaterials(links: URDFLink[]): void {
 
 // URDF only carries one <inertial> per link, so a link with multiple <visual> elements has one
 // real mass/inertia for geometry that mirabuf needs as separate parts. Peel visuals[1:] off into
-// synthetic zero-mass links fixed-jointed (identity origin) back to the original link. The real
-// mass properties stay on the original link; the identity origin reproduces the same world
-// position since visual origin is already expressed in the original link's local frame.
-//
-// shouldTreatVisualOriginsAsRobotSpace only fires on multi-visual links (it needs >= 2 visuals to
-// tell baked-in occurrence transforms apart from ordinary link-local offsets). Once split, every
-// resulting link has exactly one visual, so that detection would never fire again. Bake the
-// robot-space correction into each visual's origin here, before splitting, while the original
-// multi-visual link is still intact for the heuristic to inspect.
+// synthetic zero-mass links fixed-jointed back to the original link.
+// The real mass properties stay on the original link
 function splitMultiVisualLinks(
     links: URDFLink[],
     joints: URDFJoint[],

--- a/fission/src/urdf/URDFConverter.ts
+++ b/fission/src/urdf/URDFConverter.ts
@@ -295,6 +295,48 @@ function fillMissingMaterials(links: URDFLink[]): void {
     }
 }
 
+// URDF only carries one <inertial> per link, so a link with multiple <visual> elements has one
+// real mass/inertia for geometry that mirabuf needs as separate parts. Peel visuals[1:] off into
+// synthetic zero-mass links fixed-jointed (identity origin) back to the original link. The real
+// mass properties stay on the original link; the identity origin reproduces the same world
+// position since visual origin is already expressed in the original link's local frame.
+function splitMultiVisualLinks(links: URDFLink[], joints: URDFJoint[]): { links: URDFLink[]; joints: URDFJoint[] } {
+    const newLinks: URDFLink[] = []
+    const syntheticJoints: URDFJoint[] = []
+
+    for (const link of links) {
+        if (link.visuals.length <= 1) {
+            newLinks.push(link)
+            continue
+        }
+
+        newLinks.push({ ...link, visuals: [link.visuals[0]] })
+
+        for (let i = 1; i < link.visuals.length; i++) {
+            const syntheticName = `${link.name}_visual_${i}`
+            newLinks.push({
+                name: syntheticName,
+                visuals: [link.visuals[i]],
+                mass: 0,
+                comXYZ: [0, 0, 0],
+            })
+            syntheticJoints.push({
+                name: `${syntheticName}_joint`,
+                type: "fixed",
+                parent: link.name,
+                child: syntheticName,
+                originXYZ: [0, 0, 0],
+                originRPY: [0, 0, 0],
+                axisXYZ: [0, 0, 0],
+                limitLower: 0,
+                limitUpper: 0,
+            })
+        }
+    }
+
+    return { links: newLinks, joints: [...joints, ...syntheticJoints] }
+}
+
 function extractJoints(doc: Document): URDFJoint[] {
     const validTypes = new Set(["fixed", "revolute", "continuous", "prismatic", "floating", "planar"])
     return Array.from(doc.querySelectorAll("joint")).map(joint => {
@@ -1009,13 +1051,14 @@ export async function convertURDF(
     if (parseError) throw new Error(`URDF XML parse error: ${parseError.textContent}`)
 
     const robotName = doc.querySelector("robot")?.getAttribute("name") ?? "robot"
-    const links = extractLinks(doc)
-    const joints = extractJoints(doc)
+    const rawLinks = extractLinks(doc)
+    const rawJoints = extractJoints(doc)
     await yieldToMain()
 
-    if (links.length === 0) throw new Error("URDF contains no <link> elements")
+    if (rawLinks.length === 0) throw new Error("URDF contains no <link> elements")
 
-    fillMissingMaterials(links)
+    fillMissingMaterials(rawLinks)
+    const { links, joints } = splitMultiVisualLinks(rawLinks, rawJoints)
     const childSet = new Set(joints.map(j => j.child))
     const rootLink = links.find(l => !childSet.has(l.name))
     if (!rootLink) throw new Error("URDF has no root link - every link is listed as a child joint")

--- a/fission/src/urdf/URDFConverter.ts
+++ b/fission/src/urdf/URDFConverter.ts
@@ -70,6 +70,14 @@ function rpyToMatrix(roll: number, pitch: number, yaw: number): Mat3 {
     ]
 }
 
+// Inverse of rpyToMatrix (ZYX Euler extraction). https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+function matrixToRPY(m: Mat3): [number, number, number] {
+    const pitch = Math.asin(Math.min(1, Math.max(-1, -m[2][0])))
+    const yaw = Math.atan2(m[1][0], m[0][0])
+    const roll = Math.atan2(m[2][1], m[2][2])
+    return [roll, pitch, yaw]
+}
+
 // Rx(-90°): converts URDF Z-up frame to Y-up
 // biome-ignore format: matrix layout
 const RZy: Mat3 = [[1, 0, 0], [0, 0, 1], [0, -1, 0]]
@@ -300,14 +308,42 @@ function fillMissingMaterials(links: URDFLink[]): void {
 // synthetic zero-mass links fixed-jointed (identity origin) back to the original link. The real
 // mass properties stay on the original link; the identity origin reproduces the same world
 // position since visual origin is already expressed in the original link's local frame.
-function splitMultiVisualLinks(links: URDFLink[], joints: URDFJoint[]): { links: URDFLink[]; joints: URDFJoint[] } {
+//
+// shouldTreatVisualOriginsAsRobotSpace only fires on multi-visual links (it needs >= 2 visuals to
+// tell baked-in occurrence transforms apart from ordinary link-local offsets). Once split, every
+// resulting link has exactly one visual, so that detection would never fire again. Bake the
+// robot-space correction into each visual's origin here, before splitting, while the original
+// multi-visual link is still intact for the heuristic to inspect.
+function splitMultiVisualLinks(
+    links: URDFLink[],
+    joints: URDFJoint[],
+    rootName: string,
+    meshFiles: Map<string, Uint8Array>
+): { links: URDFLink[]; joints: URDFJoint[] } {
     const newLinks: URDFLink[] = []
     const syntheticJoints: URDFJoint[] = []
+    const globalTransforms = buildGlobalLinkTransforms(joints, rootName)
+    const meshCache = new Map<string, ParsedMesh | null>()
 
     for (const link of links) {
         if (link.visuals.length <= 1) {
             newLinks.push(link)
             continue
+        }
+
+        const robotSpaceVisuals = shouldTreatVisualOriginsAsRobotSpace(
+            link,
+            globalTransforms.get(link.name),
+            meshFiles,
+            meshCache
+        )
+        if (robotSpaceVisuals) {
+            const linkGlobalTransform = globalTransforms.get(link.name)
+            for (const visual of link.visuals) {
+                const baked = visualTransformInLinkFrame(visual, true, linkGlobalTransform)
+                visual.visualOriginXYZ = baked.translation
+                visual.visualOriginRPY = matrixToRPY(baked.rotation)
+            }
         }
 
         newLinks.push({ ...link, visuals: [link.visuals[0]] })
@@ -1058,10 +1094,12 @@ export async function convertURDF(
     if (rawLinks.length === 0) throw new Error("URDF contains no <link> elements")
 
     fillMissingMaterials(rawLinks)
-    const { links, joints } = splitMultiVisualLinks(rawLinks, rawJoints)
-    const childSet = new Set(joints.map(j => j.child))
-    const rootLink = links.find(l => !childSet.has(l.name))
-    if (!rootLink) throw new Error("URDF has no root link - every link is listed as a child joint")
+    const rawChildSet = new Set(rawJoints.map(j => j.child))
+    const rawRootLink = rawLinks.find(l => !rawChildSet.has(l.name))
+    if (!rawRootLink) throw new Error("URDF has no root link - every link is listed as a child joint")
+
+    const { links, joints } = splitMultiVisualLinks(rawLinks, rawJoints, rawRootLink.name, meshFiles)
+    const rootLink = links.find(l => l.name === rawRootLink.name)!
 
     // rigidGroups must be computed before physicsJoints — filtering depends on group membership.
     // Must be an array (not undefined): bandageRigidNodes calls .forEach on it directly.


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-335

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Robots with *interesting* design hierarchies were causing URDF files to contain many visual tags per link. For mirabuf (and according to the URDF spec) there should be a max of 1.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Gate and split on visual tags of length >1. Each becomes its own component.

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
