### PR TITLE
hotfix: biome lint and toasts ui

### DIFF
--- a/fission/src/ui/UIProvider.tsx
+++ b/fission/src/ui/UIProvider.tsx
@@ -3,7 +3,7 @@ import type { SnackbarKey, SnackbarMessage, VariantType } from "notistack"
 import { useSnackbar } from "notistack"
 import type React from "react"
 import type { FunctionComponent, ReactNode } from "react"
-import { useCallback, useReducer, useState } from "react"
+import { Fragment, useCallback, useReducer, useState } from "react"
 import { v4 as uuidv4 } from "uuid"
 import type { ModalImplProps } from "./components/Modal"
 import type { PanelImplProps } from "./components/Panel"
@@ -158,16 +158,18 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
     const addToast = useCallback(
         (variant: VariantType, ...contents: SnackbarMessage[]) => {
             enqueueSnackbar(
-                contents.length <= 1
-                    ? { ...contents }
-                    : {
-                          ...contents.map(child => (
-                              <>
-                                  {child}
-                                  <br />
-                              </>
-                          )),
-                      },
+                contents.length <= 1 ? (
+                    (contents[0] ?? "")
+                ) : (
+                    <span>
+                        {contents.map((content, index) => (
+                            <Fragment key={index}>
+                                {content}
+                                {index < contents.length - 1 && <br />}
+                            </Fragment>
+                        ))}
+                    </span>
+                ),
                 { variant, action: snackbarAction }
             )
         },

--- a/fission/src/ui/panels/configuring/assembly-config/interfaces/cameras/CameraConfigInterface.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/interfaces/cameras/CameraConfigInterface.tsx
@@ -101,7 +101,7 @@ const CameraConfigInterface: React.FC<CameraConfigInterfaceProps> = ({ selectedR
     const gizmoComponent = useMemo(() => {
         if (!camera) {
             gizmoRef.current = undefined
-            return <></>
+            return null
         }
 
         const postGizmoCreation = (gizmo: GizmoSceneObject) => {


### PR DESCRIPTION
## Task

- *Toasts* weren't working on dev and were blank.
- There was a *biome lint error* that was fixed.

<img width="950" height="799" alt="Screenshot 2026-08-06 at 4 32 23 PM" src="https://github.com/user-attachments/assets/4b5bcde1-d02b-46b0-8090-05e33e48399e" />

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
