### PR TITLE
refactor(physics): createAnchorPoint() returns Vec3 `SYNTH-341`

### DIFF
--- a/fission/src/systems/physics/ConstraintSettingsUtilities.ts
+++ b/fission/src/systems/physics/ConstraintSettingsUtilities.ts
@@ -6,19 +6,17 @@ import { convertMirabufVector3ToJoltRVec3, convertMirabufVector3ToJoltVec3 } fro
 
 type LimitSpecs = Omit<DOFSpecs, "friction" | "axis">
 
-// Returns a STATIC_ALIAS `RVec3.AddRVec3()`'s scratch buffer.
 export function createAnchorPoint(jointInstance: mirabuf.joint.JointInstance, jointDefinition: mirabuf.joint.Joint) {
-    const jointOrigin = jointDefinition.origin
+    const anchorPoint = jointDefinition.origin
         ? convertMirabufVector3ToJoltRVec3(jointDefinition.origin)
         : new JOLT.RVec3(0, 0, 0)
     // TODO: Offset transformation for robot builder.
     const jointOriginOffset = jointInstance.offset
-        ? convertMirabufVector3ToJoltRVec3(jointInstance.offset)
-        : new JOLT.RVec3(0, 0, 0)
+        ? convertMirabufVector3ToJoltVec3(jointInstance.offset)
+        : new JOLT.Vec3(0, 0, 0)
 
-    const anchorPoint = jointOrigin.AddRVec3(jointOriginOffset)
+    anchorPoint.Add(jointOriginOffset)
 
-    JOLT.destroy(jointOrigin)
     JOLT.destroy(jointOriginOffset)
 
     return anchorPoint

--- a/fission/src/systems/physics/PhysicsSystem.ts
+++ b/fission/src/systems/physics/PhysicsSystem.ts
@@ -609,6 +609,7 @@ class PhysicsSystem extends WorldSystem {
 
         const anchorPoint = createAnchorPoint(jointInstance, jointDefinition)
         hingeConstraintSettings.mPoint1 = hingeConstraintSettings.mPoint2 = anchorPoint
+        JOLT.destroy(anchorPoint)
 
         const rotationalFreedom = jointDefinition.rotational!.rotationalFreedom!
 
@@ -642,6 +643,7 @@ class PhysicsSystem extends WorldSystem {
 
         const anchorPoint = createAnchorPoint(jointInstance, jointDefinition)
         constraintSettings.mPoint1 = constraintSettings.mPoint2 = anchorPoint
+        JOLT.destroy(anchorPoint)
 
         const freedom = jointDefinition.prismatic!.prismaticFreedom!
 
@@ -839,6 +841,7 @@ class PhysicsSystem extends WorldSystem {
 
         JOLT.destroy(axis)
         JOLT.destroy(unitAxis)
+        JOLT.destroy(anchorPoint)
 
         const vehicleConstraint = this.createVehicleConstraint(wheelSettings, bodyMain, maxAcc, urdfWheelBasis)
         const { listener, tester } = this.createVehicleListeners(vehicleConstraint, bodyWheel)
@@ -869,6 +872,7 @@ class PhysicsSystem extends WorldSystem {
         const dofs = jointDefinition.custom?.dofs
         if (!dofs || dofs.length < 3) {
             console.warn("Empty degrees-of-freedom in joint definition for ball constraint")
+            JOLT.destroy(anchorPoint)
 
             return
         }
@@ -922,6 +926,8 @@ class PhysicsSystem extends WorldSystem {
 
             JOLT.destroy(constraintSpecifications.axis)
         })
+
+        JOLT.destroy(anchorPoint)
     }
 
     /**


### PR DESCRIPTION
## Task

This is a refactor made in #1418 which was closed.

SYNTH-341

<!--
Provide a brief description of what the task was here.
-->

## Symptom

Currently in dev, createAnchorPoint() returns a RVec3 which is a __static alias__. There is inherently nothing wrong with this, but it could allow for problematic behaviors down the line such as -> `Jolt.destroy(anchorPoint)`

> `anchorPoint` being a static alias means that if the function Jolt.AddRVec3() is run, the anchorPoint value is overwritten and the `anchorPoint` reference points to the new value.

## Solution

Rather than creating 2 `new Jolt.RVec3` for them only to be destroyed in the function scope:
- create 1 `new Jolt.RVec3` -> gets **destroyed** in function scope.
- create 1 `new Jolt.Vec3` -> passing ownership to function caller.

> Jolt.RVec3 is actually fundamentally the same cpp data type as Jolt.Vec3 (both are the same byte size). Under the hood, JS wraps them differently though. Below is why:
<details>

In CMakeLists.txt in JoltPhysics.js, double precision is turned off:
`option(DOUBLE_PRECISION "Compile the library in double precision mode" OFF)`

In Jolt/Math/Real.h:
```cpp
#ifdef JPH_DOUBLE_PRECISION

...

#else

// Define real to float
using Real = float;
using Real3 = Float3;
using RVec3 = Vec3;
```

Because DOUBLE_PRECISION is off, `RVec3 = Vec3`


</details>


---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
