### PR TITLE
chore: use dependabot to update our nix flake

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/flake.nix
+++ b/flake.nix
@@ -2,18 +2,22 @@
 # https://wiki.nixos.org/wiki/Flakes#Setup
 {
   description = "Synthesis' Web-Based Robotics Simulator";
-  
+
   nixConfig = {
     commit-lock-file-summary = "chore: update flake.lock";
   };
 
-  inputs= {
+  inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     systems.url = "github:nix-systems/triplet";
   };
 
   outputs =
-    { self, nixpkgs, systems }:
+    {
+      self,
+      nixpkgs,
+      systems,
+    }:
     let
       inherit (nixpkgs) lib;
 


### PR DESCRIPTION
```
now that we have tests to check that the shell works
properly[1], it is safe to update it without a nix
user to test the PR locally.

[1]: https://github.com/Autodesk/synthesis/pull/1444
```

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
