### PR TITLE
fix: configure panel options not visible in dev

### DIFF
--- a/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
+++ b/fission/src/ui/panels/configuring/assembly-config/ConfigurePanel.tsx
@@ -341,8 +341,7 @@ const ConfigurePanel: React.FC<PanelImplProps<void, ConfigurePanelCustomProps>> 
                             pendingDeletes={pendingDeletes}
                         />
 
-                        {configMode === undefined &&
-                            selectedAssembly !== undefined &&
+                        {selectedAssembly !== undefined &&
                             (!selectedAssembly.isOwnObject ? (
                                 <Label size={"sm"}>Cannot configure someone else's object</Label>
                             ) : (
@@ -360,13 +359,13 @@ const ConfigurePanel: React.FC<PanelImplProps<void, ConfigurePanelCustomProps>> 
                                     {ConfigSubPanel != null && (
                                         <ConfigSubPanel
                                             panel={panel!}
-                                            selectedAssembly={selectedAssembly!}
+                                            selectedAssembly={selectedAssembly}
                                             setDisableAccept={setDisableAccept}
                                             hasMadeChanges={hasMadeChanges}
                                             registerCleanupFunction={registerCleanupFunctions}
                                         />
                                     )}
-                                    {
+                                    {configMode === undefined && (
                                         <>
                                             <Spacer height={16} />
                                             <AssemblyExportButton selectedAssembly={selectedAssembly} />
@@ -388,7 +387,7 @@ const ConfigurePanel: React.FC<PanelImplProps<void, ConfigurePanelCustomProps>> 
                                                 <FaArrowsRotate />
                                             </Button>
                                         </>
-                                    }
+                                    )}
                                 </>
                             ))}
                     </>


### PR DESCRIPTION
## Task

On dev, the configure panel options are empty. This PR fixes that bug.


## Symptom

originated from #1453 

## Solution

There was a duplicate ConfigSubPanel before and one of them was deleted and we had skipped over some functionality / testing. This PR just adds back the proper checks.

## Verification

Try dev and try this PR and see if you can configure robots.

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
