### PR TITLE
Fix Drag Mode Performance With Complex Robots `[SYNTH-356]`

### DIFF
--- a/fission/src/systems/scene/DragModeSystem.ts
+++ b/fission/src/systems/scene/DragModeSystem.ts
@@ -358,8 +358,22 @@ class DragModeSystem extends WorldSystem {
     private stopDragging(): void {
         if (!this._isDragging) return
 
+        let targetSceneObject: MirabufSceneObject | undefined
+        let shouldTransition = true
+
+        if (this._dragTarget) {
+            const association = World.physicsSystem.getBodyAssociation(this._dragTarget.bodyId) as RigidNodeAssociate
+            targetSceneObject = association?.sceneObject
+            if (association?.isGamePiece) {
+                shouldTransition = false
+            }
+        }
+
         if (this._dragTarget?.physicsDisabled) {
-            World.physicsSystem.enablePhysicsForBody(this._dragTarget.bodyId)
+            World.physicsSystem.enablePhysicsForBody(
+                this._dragTarget.bodyId,
+                targetSceneObject?.mechanism.layerReserve?.layer
+            )
         } else if (this._dragTarget) {
             const body = World.physicsSystem.getBody(this._dragTarget.bodyId)
             if (body) {
@@ -384,17 +398,6 @@ class DragModeSystem extends WorldSystem {
 
                 JOLT.destroy(stopBrakingForce)
                 JOLT.destroy(angularStopTorque)
-            }
-        }
-
-        let targetSceneObject: MirabufSceneObject | undefined
-        let shouldTransition = true
-
-        if (this._dragTarget) {
-            const association = World.physicsSystem.getBodyAssociation(this._dragTarget.bodyId) as RigidNodeAssociate
-            targetSceneObject = association?.sceneObject
-            if (association?.isGamePiece) {
-                shouldTransition = false
             }
         }
 
@@ -427,6 +430,9 @@ class DragModeSystem extends WorldSystem {
         if (!this._dragTarget.physicsDisabled && !body.IsActive()) {
             World.physicsSystem.activateBody(this._dragTarget.bodyId)
         }
+
+        const compensateGravity =
+            DragModeSystem.DRAG_FORCE_CONSTANTS.GRAVITY_COMPENSATION && !this._dragTarget.physicsDisabled
 
         const currentPos = body.GetPosition()
         const currentPosition = new THREE.Vector3(currentPos.GetX(), currentPos.GetY(), currentPos.GetZ())
@@ -509,7 +515,7 @@ class DragModeSystem extends WorldSystem {
             const forceNeeded = velocityError.multiplyScalar(forceMultiplier)
 
             // Add gravity compensation to counteract downward pull
-            if (DragModeSystem.DRAG_FORCE_CONSTANTS.GRAVITY_COMPENSATION) {
+            if (compensateGravity) {
                 const gravityCompensation = new THREE.Vector3(
                     0,
                     mass * DragModeSystem.DRAG_FORCE_CONSTANTS.GRAVITY_MAGNITUDE,
@@ -559,7 +565,7 @@ class DragModeSystem extends WorldSystem {
             )
 
             // Add gravity compensation to prevent falling when stationary
-            if (DragModeSystem.DRAG_FORCE_CONSTANTS.GRAVITY_COMPENSATION) {
+            if (compensateGravity) {
                 const gravityCompensationY = mass * DragModeSystem.DRAG_FORCE_CONSTANTS.GRAVITY_MAGNITUDE
                 brakingForce.SetY(brakingForce.GetY() + gravityCompensationY)
             }


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-356

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Recent change mode drag mode performance extremely low for complex robots (such as Kitbot 2026). When drag mode was released the robot would start colliding with itself reducing performance and have wheel jiggling. 


https://github.com/user-attachments/assets/4d757c9e-ce66-4ddc-8c5b-eda80c428c0a

I was getting ~5fps with the 2026 Kitbot vs previously 120+ fps

## Solution

Properly assign the layers when drag mode is released.

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

- [x] Can now drag all default robots with no huge drop in performance
- [x] Drag mode retains all previous functionality & works in multiplayer

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
