### PR TITLE
Mecanum Reset Orientation `[SYNTH-375]`

### DIFF
--- a/fission/src/mirabuf/MirabufSceneObject.ts
+++ b/fission/src/mirabuf/MirabufSceneObject.ts
@@ -7,7 +7,6 @@ import EventSystem from "@/systems/EventSystem.ts"
 import type Mechanism from "@/systems/physics/Mechanism"
 import { LAYER_GHOST, type LayerReserve } from "@/systems/physics/PhysicsSystem"
 import PreferencesSystem from "@/systems/preferences/PreferencesSystem"
-import { DriveType } from "@/systems/simulation/behavior/Behavior.ts"
 import {
     type Alliance,
     defaultFieldPreferences,
@@ -1357,11 +1356,12 @@ class MirabufSceneObject extends SceneObject implements ContextSupplier {
             })
         }
 
-        if ((this.brain as SynthesisBrain | undefined)?.driveType === DriveType.SWERVE) {
+        const synthesisBrain = this.brain as SynthesisBrain | undefined
+        if (synthesisBrain?.isFieldOriented) {
             data.items.push({
                 name: "Reset Orientation",
                 func: () => {
-                    ;(this.brain as SynthesisBrain).resetSwerveOrientation()
+                    synthesisBrain.resetFieldOrientation()
                 },
             })
         }

--- a/fission/src/systems/simulation/synthesis_brain/SynthesisBrain.ts
+++ b/fission/src/systems/simulation/synthesis_brain/SynthesisBrain.ts
@@ -114,10 +114,18 @@ class SynthesisBrain extends Brain {
         if (mecanum) mecanum.robotCentric = robotCentric
     }
 
-    public resetSwerveOrientation(): void {
-        const swerve = this._behaviors.find(b => b instanceof SwerveDriveBehavior) as SwerveDriveBehavior | undefined
-        if (!swerve) return
-        swerve.resetFieldForward()
+    /** Whether this brain currently drives field-oriented. */
+    public get isFieldOriented(): boolean {
+        if (this.driveType === DriveType.SWERVE) return true
+        return this.driveType === DriveType.MECANUM && !this.mecanumRobotCentric
+    }
+
+    /** Re-zeroes field-oriented drive to the direction the robot is facing right now. */
+    public resetFieldOrientation(): void {
+        const drive = this._behaviors.find(
+            b => b instanceof SwerveDriveBehavior || b instanceof MecanumDriveBehavior
+        ) as SwerveDriveBehavior | MecanumDriveBehavior | undefined
+        drive?.resetFieldForward()
     }
 
     public configure(): void {


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-375

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

Mecanum has no button in the rick click context menu to reset orientation, while swerve does.

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Show the reset orientation button if driveType is Swerve or Mecanum and not robot centric.

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

- [x] Non robot centric mecanum drive type has reset orientation button
- [x] Swerve still has reset orientation button

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
