### PR TITLE
fix: hardcoded path for synthesis logo

### DIFF
--- a/fission/src/ui/components/overlays/PortraitOverlay.tsx
+++ b/fission/src/ui/components/overlays/PortraitOverlay.tsx
@@ -39,7 +39,7 @@ const PortraitOverlay: React.FC = () => {
             <Stack alignItems="center" gap={3} sx={{ px: 4, textAlign: "center" }}>
                 <Box
                     component="img"
-                    src="/synthesis-logo.svg"
+                    src={`${import.meta.env.BASE_URL}synthesis-logo.svg`}
                     alt="Synthesis"
                     sx={{ width: 80, height: 80, objectFit: "contain" }}
                 />


### PR DESCRIPTION
## Task

On production, the synthesis logo wouldn't show up when you made your screen vertical. This PR fixes the hardcoded path that led to that bug.

SYNTH-371

---

Before merging, ensure the following criteria are met:

- [ ] All acceptance criteria outlined in the ticket are met.
- [ ] Necessary test cases have been added and updated.
- [ ] A feature toggle or safe disable path has been added (if applicable).
- [ ] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [ ] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
