### PR TITLE
Add KitBot 2025 `[SYNTH-378]`

### DIFF
--- a/fission/public/assetpack.zip
+++ b/fission/public/assetpack.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fae87b207620b5951b2c8e45046679c4d73c7d1c2fb61f5559c42d81c74b4cd1
-size 43330478
+oid sha256:4749de3f998f61636e3d0971b8621e08ce33b038cfa268b16bd89eef2fe90cce
+size 47476801


### PR DESCRIPTION
## Task

<!--
Please include any relevant Jira ticket ID(s) at the end of the PR title, in the form SYNTH-xxxx, where "SYNTH" is the Jira project.
Include the same Jira ticket ID(s) in this section.
-->

SYNTH-378

<!--
Provide a brief description of what the task was here.
-->

## Symptom
<!--
How does the problem manifest itself?
Describe the problem as seen by the user, or by the caller or the code if it's not directly visible to the user.

Note: "Symptom" can include new product use cases, not just bugs.
-->

We have the 2024 and 2026 KitBot, but no 2025 KitBot (2024 was the first year a official KitBot was provided).

## Solution

<!--
How did you fix the problem/symptom?
Explain your approach and reasoning for choosing this solution.
-->

Add 2025 Kitbot

## Verification

<!--
How did you test and verify your changes were correct?
List steps taken, tests/added/updated, and any manual verification done that should be replicated in review.
-->

- [x] Default assetpack now contains the 2025 KitBot which comes preconfigured with default values

---

Before merging, ensure the following criteria are met:

- [x] All acceptance criteria outlined in the ticket are met.
- [x] Necessary test cases have been added and updated.
- [x] A feature toggle or safe disable path has been added (if applicable).
- [x] User-facing polish:
  - Ask: *"Is this ready-looking?"*
- [x] Cross-linking between Jira and GitHub:
  - PR links to the relevant Jira issue.
  - Jira ticket has a comment referencing this PR.
