### PR TITLE
fix: stabilize model config picking lifecycle

### DIFF
--- a/fission/src/systems/scene/ApplyModelConfig.ts
+++ b/fission/src/systems/scene/ApplyModelConfig.ts
@@ -1,4 +1,5 @@
 import { createMirabuf } from "@/mirabuf/MirabufSceneObject"
+import type MirabufSceneObject from "@/mirabuf/MirabufSceneObject"
 import { applyPartDeletions } from "@/mirabuf/PartDeletionBuilder"
 import { applyWheelAssignments } from "@/mirabuf/WheelJointBuilder"
 import World from "../World"
@@ -18,30 +19,44 @@ export async function applyModelConfigChanges(): Promise<boolean> {
     wheelMode.clearHover()
     deleteMode.clearHover()
 
-    const sceneObject = World.wheelAssignmentMode.sceneObject ?? World.partDeletionMode.sceneObject
+    const sceneObject = wheelMode.sceneObject ?? deleteMode.sceneObject
     if (sceneObject == null) {
         console.warn("Missing part handler")
         return false
     }
-    const sceneId = sceneObject.id
 
-    const assembly = sceneObject.mirabufInstance.parser.assembly
+    let rebuilt: MirabufSceneObject | undefined
+    try {
+        const sceneId = sceneObject.id
+        const assembly = sceneObject.mirabufInstance.parser.assembly
 
-    if (assignments) applyWheelAssignments(assembly, assignments)
-    if (deletions) applyPartDeletions(assembly, deletions)
+        if (assignments.length > 0) applyWheelAssignments(assembly, assignments)
+        if (deletions.length > 0) applyPartDeletions(assembly, deletions)
 
-    World.sceneRenderer.removeSceneObject(sceneId)
+        World.sceneRenderer.removeSceneObject(sceneId)
 
-    const rebuilt = await createMirabuf(assembly.info!.GUID!, assembly)
-    if (!rebuilt) {
-        console.warn("Create mirabuf failed")
+        rebuilt = await createMirabuf(assembly.info!.GUID!, assembly)
+        if (!rebuilt) {
+            console.warn("Create mirabuf failed")
+            return false
+        }
+        World.sceneRenderer.registerSceneObject(rebuilt, sceneId)
+
+        wheelMode.isMismatched(assignments, rebuilt)
+        return true
+    } catch (error) {
+        console.error("Applying model config failed", error)
         return false
+    } finally {
+        // Never leave selections pointing at batches that a rebuild disposed.
+        const current = World.sceneRenderer.sceneObjects.get(sceneObject.id)
+        const liveObject = rebuilt ?? (current === sceneObject ? sceneObject : undefined)
+        if (liveObject) {
+            wheelMode.finishApply(liveObject)
+            deleteMode.finishApply(liveObject)
+        } else {
+            wheelMode.cancel()
+            deleteMode.cancel()
+        }
     }
-    World.sceneRenderer.registerSceneObject(rebuilt, sceneId)
-
-    wheelMode.isMismatched(assignments, rebuilt)
-    wheelMode.finishApply()
-    deleteMode.finishApply()
-
-    return true
 }

--- a/fission/src/systems/scene/PartPickingMode.ts
+++ b/fission/src/systems/scene/PartPickingMode.ts
@@ -38,6 +38,19 @@ export function toKey(a?: PartHighlight): HighlightKey | undefined {
 const raycaster = new THREE.Raycaster()
 const ndc = new THREE.Vector2()
 
+/** Converts client-space pointer coordinates to NDC relative to the rendered canvas. */
+export function setPointerNdc(
+    target: THREE.Vector2,
+    mousePos: [number, number],
+    canvasRect: Pick<DOMRect, "left" | "top" | "width" | "height">
+): THREE.Vector2 {
+    target.set(
+        ((mousePos[0] - canvasRect.left) / canvasRect.width) * 2 - 1,
+        -((mousePos[1] - canvasRect.top) / canvasRect.height) * 2 + 1
+    )
+    return target
+}
+
 type HighlightStyler = (isSelected: boolean, highlight: PartHighlight) => void
 
 /** Tracks a set of picked parts and tints their meshes; a hovered pending part keeps `selectedColor`. */
@@ -108,7 +121,7 @@ abstract class PartPickingMode<T extends PartSelection> extends WorldSystem {
     private _latestMousePos: [number, number] | undefined
     private _lastProcessedMousePos: [number, number] | undefined
 
-    // Rebuilt on enable and after finishApply() to avoid rescanning every mesh entry per raycast.
+    // Rebuilt on enable and after finishApply(rebuilt) to avoid rescanning every mesh entry per raycast.
     private _candidateBatches: THREE.BatchedMesh[] = []
     private _pickIndex = new Map<THREE.BatchedMesh, Map<number, string>>()
 
@@ -134,7 +147,18 @@ abstract class PartPickingMode<T extends PartSelection> extends WorldSystem {
     }
 
     public enable(object: MirabufSceneObject) {
-        if (this.enabled) return
+        if (this._object === object) return
+
+        if (this.enabled) {
+            // A rebuild can replace the scene object while React keeps this mode mounted.
+            // Drop selections tied to the old batches before targeting the replacement.
+            this.clearHover()
+            this.pending.clearSilently()
+            this._object = object
+            this.rebuildPickIndex()
+            return
+        }
+
         this._object = object
         this.hookInteractionHandlers()
     }
@@ -219,7 +243,8 @@ abstract class PartPickingMode<T extends PartSelection> extends WorldSystem {
     /** Raycasts the cached candidate batches for the part-instance GUID under the mouse. */
     protected pickPart(mousePos: [number, number]): PartPick | undefined {
         const camera = World.sceneRenderer.mainCamera
-        ndc.set((mousePos[0] / window.innerWidth) * 2 - 1, -(mousePos[1] / window.innerHeight) * 2 + 1)
+        const canvasRect = World.sceneRenderer.renderer.domElement.getBoundingClientRect()
+        setPointerNdc(ndc, mousePos, canvasRect)
         raycaster.setFromCamera(ndc, camera)
 
         const hits = raycaster.intersectObjects<THREE.BatchedMesh>(this._candidateBatches, false)
@@ -326,9 +351,19 @@ abstract class PartPickingMode<T extends PartSelection> extends WorldSystem {
         return [...this.pending.values()]
     }
 
-    public finishApply(): void {
+    /** Clears pending picks after a failed/cancelled configuration without touching old batches. */
+    public cancel(): void {
         this.pending.clearSilently()
-        if (this.enabled) this.rebuildPickIndex()
+        this.disable()
+    }
+
+    /** Clears old picks and retargets the mode to the scene object created by a successful rebuild. */
+    public finishApply(rebuilt: MirabufSceneObject): void {
+        this.pending.clearSilently()
+        if (this.enabled) {
+            this._object = rebuilt
+            this.rebuildPickIndex()
+        }
     }
 
     public get sceneObject() {

--- a/fission/src/test/scene/ApplyModelConfig.test.ts
+++ b/fission/src/test/scene/ApplyModelConfig.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { createMirabuf } from "@/mirabuf/MirabufSceneObject"
+import { applyPartDeletions } from "@/mirabuf/PartDeletionBuilder"
+import { applyWheelAssignments } from "@/mirabuf/WheelJointBuilder"
+import World from "@/systems/World"
+import { applyModelConfigChanges } from "@/systems/scene/ApplyModelConfig"
+
+vi.mock("@/mirabuf/MirabufSceneObject", () => ({
+    createMirabuf: vi.fn(),
+}))
+vi.mock("@/mirabuf/PartDeletionBuilder", () => ({
+    applyPartDeletions: vi.fn(),
+}))
+vi.mock("@/mirabuf/WheelJointBuilder", () => ({
+    applyWheelAssignments: vi.fn(),
+}))
+vi.mock("@/systems/World", () => ({
+    default: {
+        wheelAssignmentMode: {
+            pendingList: [],
+            sceneObject: undefined,
+            clearHover: vi.fn(),
+            finishApply: vi.fn(),
+            cancel: vi.fn(),
+            isMismatched: vi.fn(),
+        },
+        partDeletionMode: {
+            pendingList: [],
+            sceneObject: undefined,
+            clearHover: vi.fn(),
+            finishApply: vi.fn(),
+            cancel: vi.fn(),
+        },
+        sceneRenderer: {
+            sceneObjects: new Map(),
+            removeSceneObject: vi.fn(),
+            registerSceneObject: vi.fn(),
+        },
+    },
+}))
+
+const sceneObject = {
+    id: "scene",
+    mirabufInstance: {
+        parser: { assembly: { info: { GUID: "assembly" } } },
+    },
+}
+
+const wheelAssignment = { wheelPartGuid: "wheel", parentPartGuid: "root" }
+
+type WorldMock = {
+    wheelAssignmentMode: {
+        pendingList: Array<{ assignment: typeof wheelAssignment }>
+        sceneObject: typeof sceneObject | undefined
+        clearHover: ReturnType<typeof vi.fn>
+        finishApply: ReturnType<typeof vi.fn>
+        cancel: ReturnType<typeof vi.fn>
+        isMismatched: ReturnType<typeof vi.fn>
+    }
+    partDeletionMode: {
+        pendingList: Array<{ guid: string }>
+        sceneObject: typeof sceneObject | undefined
+        clearHover: ReturnType<typeof vi.fn>
+        finishApply: ReturnType<typeof vi.fn>
+        cancel: ReturnType<typeof vi.fn>
+    }
+    sceneRenderer: {
+        sceneObjects: Map<string, typeof sceneObject>
+        removeSceneObject: ReturnType<typeof vi.fn>
+        registerSceneObject: ReturnType<typeof vi.fn>
+    }
+}
+
+describe("applyModelConfigChanges", () => {
+    const world = World as unknown as WorldMock
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        world.wheelAssignmentMode.pendingList = [{ assignment: wheelAssignment }]
+        world.wheelAssignmentMode.sceneObject = sceneObject
+        world.partDeletionMode.pendingList = []
+        world.partDeletionMode.sceneObject = undefined
+        world.sceneRenderer.sceneObjects = new Map([[sceneObject.id, sceneObject]])
+        vi.mocked(applyWheelAssignments).mockImplementation(() => {})
+        vi.mocked(applyPartDeletions).mockImplementation(() => {})
+        vi.mocked(createMirabuf).mockResolvedValue(sceneObject as never)
+    })
+
+    test("returns a failure and clears lifecycle state when applying throws", async () => {
+        vi.mocked(applyWheelAssignments).mockImplementation(() => {
+            throw new Error("invalid assembly")
+        })
+
+        await expect(applyModelConfigChanges()).resolves.toBe(false)
+
+        expect(world.wheelAssignmentMode.finishApply).toHaveBeenCalledWith(sceneObject)
+        expect(world.partDeletionMode.finishApply).toHaveBeenCalledWith(sceneObject)
+        expect(createMirabuf).not.toHaveBeenCalled()
+    })
+
+    test("cancels modes if rebuilding removes the old scene without a replacement", async () => {
+        world.sceneRenderer.removeSceneObject.mockImplementation((id: string) => {
+            world.sceneRenderer.sceneObjects.delete(id)
+        })
+        vi.mocked(createMirabuf).mockResolvedValue(undefined)
+
+        await expect(applyModelConfigChanges()).resolves.toBe(false)
+
+        expect(world.wheelAssignmentMode.cancel).toHaveBeenCalledOnce()
+        expect(world.partDeletionMode.cancel).toHaveBeenCalledOnce()
+        expect(world.wheelAssignmentMode.finishApply).not.toHaveBeenCalled()
+    })
+})

--- a/fission/src/test/scene/PartPickingMode.test.ts
+++ b/fission/src/test/scene/PartPickingMode.test.ts
@@ -1,0 +1,132 @@
+import * as THREE from "three"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import type MirabufSceneObject from "@/mirabuf/MirabufSceneObject"
+import World from "@/systems/World"
+import PartPickingMode, { type PartSelection, setPointerNdc } from "@/systems/scene/PartPickingMode"
+
+vi.mock("@/systems/World", () => ({
+    default: {
+        sceneRenderer: {
+            mainCamera: undefined,
+            renderer: {
+                domElement: {
+                    addEventListener: vi.fn(),
+                    removeEventListener: vi.fn(),
+                    getBoundingClientRect: vi.fn(),
+                },
+            },
+            scene: {
+                add: vi.fn(),
+                remove: vi.fn(),
+            },
+        },
+    },
+}))
+
+class TestPickingMode extends PartPickingMode<PartSelection> {
+    public constructor() {
+        super(new THREE.Color(), vi.fn(), vi.fn())
+    }
+
+    protected handlePick(): void {}
+
+    public pick(mousePos: [number, number]) {
+        return this.pickPart(mousePos)
+    }
+}
+
+function createBatch(): THREE.BatchedMesh {
+    const geometry = new THREE.BoxGeometry(1, 1, 1)
+    const batch = new THREE.BatchedMesh(1, geometry.attributes.position.count, geometry.index!.count)
+    const geometryId = batch.addGeometry(geometry)
+    const instanceId = batch.addInstance(geometryId)
+    batch.setMatrixAt(instanceId, new THREE.Matrix4())
+    return batch
+}
+
+function createSceneObject(mesh: THREE.BatchedMesh, guid: string): MirabufSceneObject {
+    return {
+        mirabufInstance: {
+            batches: [mesh],
+            meshes: new Map([[guid, [[mesh, 0]]]]),
+        },
+    } as unknown as MirabufSceneObject
+}
+
+describe("PartPickingMode", () => {
+    beforeEach(() => {
+        const sceneRenderer = World.sceneRenderer as unknown as {
+            mainCamera: THREE.PerspectiveCamera
+            renderer: { domElement: HTMLCanvasElement }
+            screenInteractionHandler: {
+                interactionStart: ((interaction: unknown) => void) | undefined
+                interactionEnd: ((interaction: unknown) => void) | undefined
+            }
+            scene: THREE.Scene
+        }
+        const canvas = document.createElement("canvas")
+        Object.defineProperty(canvas, "getBoundingClientRect", {
+            value: () => ({ left: 100, top: 50, width: 400, height: 300 }),
+        })
+        sceneRenderer.mainCamera = new THREE.PerspectiveCamera(90, 4 / 3, 0.1, 100)
+        sceneRenderer.mainCamera.position.set(0, 0, 5)
+        sceneRenderer.mainCamera.lookAt(0, 0, 0)
+        sceneRenderer.mainCamera.updateMatrixWorld()
+        sceneRenderer.renderer.domElement = canvas
+        sceneRenderer.screenInteractionHandler = {
+            interactionStart: undefined,
+            interactionEnd: undefined,
+        }
+        sceneRenderer.scene = new THREE.Scene()
+    })
+
+    test("maps client coordinates relative to the canvas into NDC", () => {
+        const ndc = setPointerNdc(new THREE.Vector2(), [300, 200], {
+            left: 100,
+            top: 50,
+            width: 400,
+            height: 300,
+        })
+
+        expect(ndc.x).toBeCloseTo(0)
+        expect(ndc.y).toBeCloseTo(0)
+
+        setPointerNdc(ndc, [100, 50], { left: 100, top: 50, width: 400, height: 300 })
+        expect(ndc.x).toBe(-1)
+        expect(ndc.y).toBe(1)
+    })
+
+    test("retargets the pick index to replacement batches after apply", () => {
+        const oldBatch = createBatch()
+        const replacementBatch = createBatch()
+        const oldObject = createSceneObject(oldBatch, "old-part")
+        const replacementObject = createSceneObject(replacementBatch, "replacement-part")
+        World.sceneRenderer.scene.add(replacementBatch)
+        World.sceneRenderer.scene.updateMatrixWorld(true)
+
+        const mode = new TestPickingMode()
+        mode.enable(oldObject)
+        mode.finishApply(replacementObject)
+
+        expect(mode.sceneObject).toBe(replacementObject)
+        expect(mode.pick([300, 200])?.guid).toBe("replacement-part")
+
+        mode.destroy()
+        oldBatch.dispose()
+        replacementBatch.dispose()
+    })
+
+    test("clears selections when configuration is cancelled", () => {
+        const batch = createBatch()
+        const sceneObject = createSceneObject(batch, "part")
+        const mode = new TestPickingMode()
+        mode.enable(sceneObject)
+        mode.pending.addPart("part", { guid: "part", highlight: { mesh: batch, instanceId: 0 } })
+
+        mode.cancel()
+
+        expect(mode.pendingCount).toBe(0)
+        expect(mode.enabled).toBe(false)
+        batch.dispose()
+    })
+})

--- a/fission/src/ui/components/StyledComponents.tsx
+++ b/fission/src/ui/components/StyledComponents.tsx
@@ -168,8 +168,11 @@ export const ProgressButton: React.FC<
 
     const onClickReal = useCallback(async () => {
         setInProgress(true)
-        await onClick()
-        setInProgress(false)
+        try {
+            await onClick()
+        } finally {
+            setInProgress(false)
+        }
     }, [onClick])
     return (
         <Button onClick={onClickReal} {...props} disabled={disabled || inProgress}>

--- a/fission/src/ui/components/UserModelConfig/ModelConfigPanel.tsx
+++ b/fission/src/ui/components/UserModelConfig/ModelConfigPanel.tsx
@@ -94,11 +94,13 @@ const ModelConfigPanel: React.FC<PanelImplProps<void, { sceneObject: MirabufScen
             },
             {
                 onCancel: () => {
+                    World.wheelAssignmentMode.cancel()
+                    World.partDeletionMode.cancel()
                     World.sceneRenderer.removeSceneObject(sceneObject.id)
                 },
             }
         )
-    }, [configureScreen, panel, screen])
+    }, [configureScreen, panel, screen, sceneObject.id])
 
     const closeCallback = useCallback(async () => {
         closePanel(panel!.id, CloseType.ACCEPT)


### PR DESCRIPTION
Fix model-config raycast coordinates and stale selection cleanup; add regression tests.